### PR TITLE
Platform/Rpi4: Enable HTTP Boot

### DIFF
--- a/Platform/RaspberryPi/RPi4/RPi4.dsc
+++ b/Platform/RaspberryPi/RPi4/RPi4.dsc
@@ -28,8 +28,9 @@
   #
   # Network definition
   #
-  DEFINE NETWORK_TLS_ENABLE       = FALSE
-  DEFINE NETWORK_HTTP_BOOT_ENABLE = FALSE
+  DEFINE NETWORK_TLS_ENABLE             = FALSE
+  DEFINE NETWORK_HTTP_BOOT_ENABLE       = TRUE
+  DEFINE NETWORK_ALLOW_HTTP_CONNECTIONS = TRUE
 
   #
   # Defines for default states.  These can be changed on the command line.
@@ -339,6 +340,11 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdFixedMediaImageVerificationPolicy|0x04
   gEfiSecurityPkgTokenSpaceGuid.PcdRemovableMediaImageVerificationPolicy|0x04
 !endif
+
+  #
+  # NETSEC Info
+  #
+  gEfiNetworkPkgTokenSpaceGuid.PcdAllowHttpConnections|TRUE
 
 [LibraryClasses.common]
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf


### PR DESCRIPTION
This adds the HTTP boot network drivers. TLS is disabled, and unsecured HTTP connection
is allowed (TLS/HTTPs to be enabled later)

Signed-off-by: Samer El-Haj-Mahmoud <samer@elhajmahmoud.com>