### PR TITLE
Platform/ARM: TimerLib based RngLib for CryptoPkg

### DIFF
--- a/Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2011-2019, ARM Limited. All rights reserved.
+#  Copyright (c) 2011-2020, Arm Limited. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -138,6 +138,7 @@
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
   IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
   OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLib.inf
+  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
   VarCheckLib|MdeModulePkg/Library/VarCheckLib/VarCheckLib.inf
 
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf


### PR DESCRIPTION
The commit at "b5701a4c7a0f CryptoPkg: OpensslLib: Use RngLib to
generate entropy in rand_pool" updated CryptoPkg\OpenSSL to no
longer depend on TimerLib and instead use RngLib. This is done so
that platforms can choose the desired entropy source. However, this
change breaks the builds for platforms under Platform/ARM.

To fix this, update ArmVExpress.dsc.inc to use a TimerLib based
implementation of RngLib.

Note: The TimerLib based implementation of RngLib replicates past
behavior when used with OpenSSL. However, this should not be used
in production as a real source of entropy.

Signed-off-by: Sami Mujawar <sami.mujawar@arm.com>