### PR TITLE
Platform/ARM/VExpressPkg: Remove non-ASCII characters

### DIFF
--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/AslTables/SsdtPci.asl
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/AslTables/SsdtPci.asl
@@ -51,7 +51,7 @@
 
 /*
   See Reference [1] 6.1.1
-  "High word–Device #, Low word–Function #. (for example, device 3,
+  "High word Device #, Low word Function #. (for example, device 3,
   function 2 is 0x00030002). To refer to all the functions on a device #,
   use a function number of FFFF)."
 */


### PR DESCRIPTION
The patch at "4be8625ab1b008057ae9a500aa8978be2a02d6e2
Platform/ARM/VExpressPkg: Add support for FVP RevC model"
introduced a new file SsdtPci.asl. The file SsdtPci.asl
had a few non-ASCII characters in the code comments.
These resulted in the Trim utility generating a warning
that caused the firmware build to fail on a Linux
development PC.

Therefore, remove the non-ASCII characters as it results
in builds failures on a Linux development PC.

Note: This issue was not observed on a Windows development
PC.

Signed-off-by: Sami Mujawar <sami.mujawar@arm.com>
Reviewed-by: Thomas Abraham <thomas.abraham@arm.com>