### PR TITLE
Reset DWC2 on all raspberry pi boards

### DIFF
--- a/Platform/RaspberryPi/Drivers/DwUsbHostDxe/DriverBinding.c
+++ b/Platform/RaspberryPi/Drivers/DwUsbHostDxe/DriverBinding.c
@@ -140,7 +140,7 @@ DriverStart (
    * UsbBusDxe as of b4e96b82b4e2e47e95014b51787ba5b43abac784 expects
    * the HCD to do this. There is no agent invoking DwHcReset anymore.
    */
-  DwHcReset (&DwHc->DwUsbOtgHc, 0);
+  DwHcReset (&DwHc->DwUsbOtgHc, EFI_USB_HC_RESET_HOST_CONTROLLER);
   DwHcSetState (&DwHc->DwUsbOtgHc, EfiUsbHcStateOperational);
 
   Status = gBS->InstallMultipleProtocolInterfaces (


### PR DESCRIPTION
Setting the attributes to 0 causes `DwHcReset` to never execute any code.
Setting the attributes to `EFI_USB_HC_RESET_HOST_CONTROLLER` will result in a full USB controller reset.

This will not change anything for boards that initialize the USB controller in the firmware (RPI3/4). But some boards (CM4 and potentially PI400) do not initialize the port early and leave it unconfigured / powered of.

Tested on my CM4 with the official IO board.