### PR TITLE
SMBIOS Feature Package

### DIFF
--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/Include/PostMemory.fdf
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/Include/PostMemory.fdf
@@ -1,0 +1,10 @@
+## @file
+#  FDF file for post-memory SMBIOS modules.
+#
+# Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+  INF SystemInformation/SmbiosFeaturePkg/SmbiosBasicDxe/SmbiosBasicDxe.inf

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/Include/PreMemory.fdf
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/Include/PreMemory.fdf
@@ -1,0 +1,8 @@
+## @file
+#  FDF file for pre-memory SMBIOS modules.
+#
+# Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/Include/SmbiosFeature.dsc
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/Include/SmbiosFeature.dsc
@@ -1,0 +1,115 @@
+## @file
+# This is a build description file for the SMBIOS advanced feature.
+# This file should be included into another package DSC file to build this feature.
+#
+# The DEC files are used by the utilities that parse DSC and
+# INF files to generate AutoGen.c and AutoGen.h files
+# for the build infrastructure.
+#
+# Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+################################################################################
+#
+# Defines Section - statements that will be processed to create a Makefile.
+#
+################################################################################
+[Defines]
+!ifndef $(PEI_ARCH)
+  !error "PEI_ARCH must be specified to build this feature!"
+!endif
+!ifndef $(DXE_ARCH)
+  !error "DXE_ARCH must be specified to build this feature!"
+!endif
+
+################################################################################
+#
+# Library Class section - list of all Library Classes needed by this feature.
+#
+################################################################################
+[LibraryClasses]
+  #######################################
+  # Edk2 Packages
+  #######################################
+  BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
+  BaseMemoryLib|MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
+  DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+  DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
+  PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
+  UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
+  UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
+  UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
+  UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
+
+[LibraryClasses.common.DXE_DRIVER]
+  #######################################
+  # Edk2 Packages
+  #######################################
+  HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
+  MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+  PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+
+################################################################################
+#
+# Component section - list of all components that need built for this feature.
+#
+# Note: The EDK II DSC file is not used to specify how compiled binary images get placed
+#       into firmware volume images. This section is just a list of modules to compile from
+#       source into UEFI-compliant binaries.
+#       It is the FDF file that contains information on combining binary files into firmware
+#       volume images, whose concept is beyond UEFI and is described in PI specification.
+#       There may also be modules listed in this section that are not required in the FDF file,
+#       When a module listed here is excluded from FDF file, then UEFI-compliant binary will be
+#       generated for it, but the binary will not be put into any firmware volume.
+#
+################################################################################
+#
+# Feature PEI Components
+#
+
+# @todo: Change below line to [Components.$(PEI_ARCH)] after https://bugzilla.tianocore.org/show_bug.cgi?id=2308
+#        is completed.
+[Components.IA32]
+  #####################################
+  # SMBIOS Feature Package
+  #####################################
+
+  # Add library instances here that are not included in package components and should be tested
+  # in the package build.
+
+  # Add components here that should be included in the package build.
+
+#
+# Feature DXE Components
+#
+
+# @todo: Change below line to [Components.$(DXE_ARCH)] after https://bugzilla.tianocore.org/show_bug.cgi?id=2308
+#        is completed.
+[Components.X64]
+  #####################################
+  # SMBIOS Feature Package
+  #####################################
+
+  # Add library instances here that are not included in package components and should be tested
+  # in the package build.
+
+  # Add components here that should be included in the package build.
+  SystemInformation/SmbiosFeaturePkg/SmbiosBasicDxe/SmbiosBasicDxe.inf
+
+###################################################################################################
+#
+# BuildOptions Section - Define the module specific tool chain flags that should be used as
+#                        the default flags for a module. These flags are appended to any
+#                        standard flags that are defined by the build process. They can be
+#                        applied for any modules or only those modules with the specific
+#                        module style (EDK or EDKII) specified in [Components] section.
+#
+#                        For advanced features, it is recommended to enable [BuildOptions] in
+#                        the applicable INF file so it does not affect the whole board package
+#                        build when this DSC file is active.
+#
+###################################################################################################
+[BuildOptions]

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/Readme.md
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/Readme.md
@@ -1,0 +1,104 @@
+# Overview
+* **Feature Name:** System Management BIOS (SMBIOS)
+* **PI Phase(s) Supported:** DXE
+* **SMM Required?** No
+
+More Information:
+* [SMBIOS Reference Specification](https://www.dmtf.org/standards/smbios)
+
+## Purpose
+System Management BIOS (SMBIOS) is an industry standard for delivering management information via system firmware.
+SMBIOS provides a standard format to present management information across various environments including OS-present,
+OS-absent, and pre-OS environments. SMBIOS was originally designed for Intel&reg; processor architecture systems, SMBIOS
+now includes support for IA-32 (x86), x64 (x86-64, Intel64, AMD64, EM64T), Intel&reg; Itanium&reg; architecture, 32-bit
+ARM (Aarch32) and 64-bit ARM (Aarch64).
+
+The SMBIOS feature includes generic firmware functionality to implement the SMBIOS reference specification. Since the
+information required by these modules is very platform/board-specific by nature this feature requires a high-level of
+customization (mostly in the form of PCD values) by the feature consumer.
+
+# High-Level Theory of Operation
+*_TODO_*
+A description of how the device works at a high-level.
+
+The description should not be constrained to implementation details but provide a simple mental model of how the
+feature is supposed to work.
+
+## Firmware Volumes
+*_TODO_*
+A bulleted list of the firmware volumes that feature module(s) are placed in.
+
+## Modules
+*_TODO_*
+A bulleted list of the modules that make up the feature.
+
+## <Module Name>
+*_TODO_*
+Each module in the feature should have a section that describes the module in a level of detail that is useful
+to better understand the module source code.
+
+## <Library Name>
+*_TODO_*
+Each library in the feature should have a section that describes the library in a level of detail that is useful
+to better understand the library source code.
+
+## Key Functions
+*_TODO_*
+A bulleted list of key functions for interacting with the feature.
+
+Not all features need to be listed. Only functions exposed through external interfaces that are important for feature
+users to be aware of.
+
+## Configuration
+*_TODO_*
+Information that is useful for configuring the feature.
+
+Not all configuration options need to be listed. This section is used to provide more background on configuration
+options than possible elsewhere.
+
+## Data Flows
+*_TODO_*
+Architecturally defined data structures and flows for the feature.
+
+## Control Flows
+*_TODO_*
+Key control flows for the feature.
+
+## Build Flows
+*_TODO_*
+Any special build flows should be described in this section.
+
+This is particularly useful for features that use custom build tools or require non-standard tool configuration. If the
+standard flow in the feature package template is used, this section may be empty.
+
+## Test Point Results
+*_TODO_*
+The test(s) that can verify porting is complete for the feature.
+
+Each feature must describe at least one test point to verify the feature is successful. If the test point is not
+implemented, this should be stated.
+
+## Functional Exit Criteria
+*_TODO_*
+The testable functionality for the feature.
+
+This section should provide an ordered list of criteria that a board integrator can reference to ensure the feature is
+functional on their board.
+
+## Feature Enabling Checklist
+*_TODO_*
+An ordered list of required activities to achieve desired functionality for the feature.
+
+## Performance Impact
+A general expectation for the impact on overall boot performance due to using this feature.
+
+This section is expected to provide guidance on:
+* How to estimate performance impact due to the feature
+* How to measure performance impact of the feature
+* How to manage performance impact of the feature
+
+## Common Optimizations
+*_TODO_*
+Common size or performance tuning options for this feature.
+
+This section is recommended but not required. If not used, the contents should be left empty.

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/SmbiosBasic.h
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/SmbiosBasic.h
@@ -1,0 +1,45 @@
+/** @file
+  Smbios basic header file.
+
+Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _SMBIOS_BASIC_DRIVER_H
+#define _SMBIOS_BASIC_DRIVER_H
+
+#include <PiDxe.h>
+#include <Protocol/Smbios.h>
+#include <IndustryStandard/SmBios.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DevicePathLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
+#include <Library/UefiLib.h>
+
+/**
+  Add an SMBIOS record.
+
+  @param  Smbios                The EFI_SMBIOS_PROTOCOL instance.
+  @param  SmbiosHandle          A unique handle will be assigned to the SMBIOS record.
+  @param  Record                The data for the fixed portion of the SMBIOS record. The format of the record is
+                                determined by EFI_SMBIOS_TABLE_HEADER.Type. The size of the formatted area is defined
+                                by EFI_SMBIOS_TABLE_HEADER.Length and either followed by a double-null (0x0000) or
+                                a set of null terminated strings and a null.
+
+  @retval EFI_SUCCESS           Record was added.
+  @retval EFI_OUT_OF_RESOURCES  Record was not added due to lack of system resources.
+
+**/
+EFI_STATUS
+AddSmbiosRecord (
+  IN EFI_SMBIOS_PROTOCOL        *Smbios,
+  OUT EFI_SMBIOS_HANDLE         *SmbiosHandle,
+  IN EFI_SMBIOS_TABLE_HEADER    *Record
+  );
+
+#endif

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/SmbiosBasicDxe.inf
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/SmbiosBasicDxe.inf
@@ -1,0 +1,259 @@
+### @file
+# Component description file for the SMBIOS basic module.
+#
+# Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+###
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SmbiosBasic
+  FILE_GUID                      = 03ADF4A1-A27A-45E3-B211-3177C6C2E7ED
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = SmbiosBasicEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF EBC
+#
+
+[Sources]
+  SmbiosBasic.h
+  SmbiosBasicEntryPoint.c
+  Type0BiosVendorFunction.c
+  Type1SystemManufacturerFunction.c
+  Type2BaseBoardManufacturerFunction.c
+  Type3ChassisManufacturerFunction.c
+  Type4ProcessorInformationFunction.c
+  Type5MemoryControllerFunction.c
+  Type6MemoryModuleInformationFunction.c
+  Type7CacheInformationFunction.c
+  Type8PortConnectorInformationFunction.c
+  Type9SystemSlotsFunction.c
+  Type10OnBoardDevicesInformationFunction.c
+  Type11OEMStringsFunction.c
+  Type12SystemConfigurationOptionsFunction.c
+  Type13BiosLanguageInformationFunction.c
+  Type14GroupAssociationFunction.c
+  Type15SystemEventLogFunction.c
+  Type16PhysicalMemoryArrayFunction.c
+  Type17MemoryDeviceFunction.c
+  Type1832bitMemoryErrorInformationFunction.c
+  Type19MemoryArrayMappedAddressFunction.c
+  Type20MemoryDeviceMappedAddressFunction.c
+  Type21PointingDeviceFunction.c
+  Type22PortableBatteryFunction.c
+  Type23SystemResetFunction.c
+  Type24HardwareSecurityFunction.c
+  Type25SystemPowerControlsFunction.c
+  Type26VoltageProbeFunction.c
+  Type27CoolingDeviceFunction.c
+  Type28TemperatureProbeFunction.c
+  Type29ElectricalCurrentProbeFunction.c
+  Type30OutOfBandRemoteAccess.c
+  Type31BISEntryPointFunction.c
+  Type32BootInformationFunction.c
+  Type3364BitMemoryErrorInformationFunction.c
+  Type34ManagementDeviceFunction.c
+  Type35ManagementDeviceComponentFunction.c
+  Type36ManagementDeviceThresholdDataFunction.c
+  Type37MemoryChannelInformation.c
+  Type38IpmiDeviceInformationFunction.c
+  Type39SystemPowerSupplyFunction.c
+  Type40AdditionalInformationFunction.c
+  Type41OnboardDevicesExtendedInformationFunction.c
+  Type42ManagementControllerHostInterfaceFunction.c
+  Type43TMPDeviceFunction.c
+  Type44ProcessorAdditionalInformationFunction.c
+  Type126InactiveFunction.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+# SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  DevicePathLib
+  HobLib
+  MemoryAllocationLib
+  PcdLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  UefiLib
+
+[Protocols]
+  gEfiSmbiosProtocolGuid                       # PROTOCOL ALWAYS_CONSUMED
+  gEfiVariableArchProtocolGuid
+
+[Pcd]
+  # Type 0:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0StringBiosReleaseDate
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0StringBiosVersion
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0StringVendor
+  # Type 1:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1StringFamily
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1StringManufacturer
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1StringProductName
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1StringSerialNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1StringSKUNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1StringVersion
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1SystemInformation
+  # Type 2:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2BaseBoardInformation
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2StringAssetTag
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2StringLocationInChassis
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2StringManufacturer
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2StringProductName
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2StringSerialNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2StringVersion
+  # Type 3:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3StringAssetTag
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3StringManufacturer
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3StringSerialNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3StringSKUNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3StringVersion
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3SystemEnclosureChassis
+  # Type 4:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4StringSocket
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4StringManufacturer
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4StringVersion
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4StringSerialNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4StringAssetTag
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4StringPartNumber
+  # Type 5:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController
+  # Type 6:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6StringSocketDesignation
+  # Type 7:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7StringSocketDesignation
+  # Type 8:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType8PortConnectorInformation
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType8StringInternalReferenceDesignator
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType8StringExternalReferenceDesignator
+  # Type 9:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9StringSlotDesignation
+  # Type 10:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType10OnBoardDevicesInformation
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType10StringDescriptionString
+  # Type 11:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType11OEMStrings
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType11StringCount
+  # Type 12:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType12SystemConfigurationOptions
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType12StringCount
+  # Type 13:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13StringCurrentLanguages
+  # Type 14:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType14GroupAssociations
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType14StringGroupName
+  # Type 15
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog 
+  # Type 16:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType16PhysicalMemoryArray
+  # Type 17:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringDeviceLocator
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringBankLocator
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringManufacturer
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringSerialNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringAssetTag
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringPartNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringFirmwareVersion
+  # Type 18:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1832bitMemoryErrorInformation
+  # Type 19:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType19MemoryArrayMappedAddress
+  # Type 20:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType20MemoryDeviceMappedAddress
+  # Type 21:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType21PointingDevice
+  # Type 22:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22PortableBattery
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringLocation
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringManufacturer
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringManufactureDate
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringSerialNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringDeviceName
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringSBDSVersionNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringSBDSDeviceChemistryStr
+  # Type 23:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType23SystemReset
+  # Type 24:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType24HardwareSecurity
+  # Type 25:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType25SystemPowerControls
+  # Type 26:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26VoltageProbe
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26StringDescription
+  # Type 27:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType27CoolingDevice
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType27StringDescription
+  # Type 28:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28TemperatureProbe
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28StringDescription
+  # Type 29:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29ElectricalCurrentProbe
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29StringDescription
+  # Type 30
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType30OutOfBoundRemoteAccess
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType30StringManufacturerName
+  # Type 31:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType31BISEntryPoint
+  # Type 32:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType32SystemBootInformation
+  # Type 33:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType33_64BitMemoryErrorInformation
+  # Type 34:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType34ManagementDevice
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType34StringDescription
+  # Type 35:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType35ManagementDeviceComponent
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType35StringDescription
+  # Type 36:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType36ManagementDeviceThresholdData
+  # Type 37:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType37MemoryChannelInformation
+  # Type 38:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType38PimiDeviceInformation
+  # Type 39:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39StringLocation
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39StringDeviceName
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39Manufacturer
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SerialNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39AssetTagNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39ModelPartNumber
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39RevisionLevel
+  # Type 40:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType40AdditionalInformation
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType40StringEntryString
+  # Type 41:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType41OnboardDevicesExtendedInformation
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType41StringReferenceDesignation
+  # Type 42:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType42ManagementControllerHostInterface
+  #type 43
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43TMPDevice
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43StringDescription
+  # Type 44:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType44ProcessorAdditionalInformation
+  # Type 126:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType126Inactive
+
+[Depex]
+  gEfiSmbiosProtocolGuid AND
+  gEfiVariableArchProtocolGuid

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/SmbiosBasicEntryPoint.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/SmbiosBasicEntryPoint.c
@@ -1,0 +1,412 @@
+/** @file
+  Smbios basic entry point.
+
+Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+EFI_STATUS
+EFIAPI
+BiosVendorFunction( // Type 0
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+SystemManufacturerFunction( // Type 1
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+BaseBoardManufacturerFunction( // Type 2
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+ChassisManufacturerFunction( // Type 3
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+ProcessorInformationFunction( // Type 4
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+MemoryControllerFunction( // Type 5
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+MemoryModuleInformationFunction( // Type 6
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+CacheInformationFunction( // Type 7
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+PortConnectorInformationFunction( // Type 8
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+SystemSlotsFunction( // Type 9
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+OnBoardDevicesInformationFunction( // Type 10
+	IN  EFI_SMBIOS_PROTOCOL* Smbios
+);
+
+EFI_STATUS
+EFIAPI
+OEMStringsFunction( // Type 11
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+  EFIAPI
+  SystemConfigurationOptionsFunction( // Type 12
+     IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+BiosLanguageFunction( // Type 13
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+GroupAssociationsFunction( // Type 14
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+SystemEventLogFunction( // Type 15
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+PhysicalMemoryArrayFunction( // Type 16
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+MemoryDeviceFunction( // Type 17
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+g32bitMemoryErrorInformationFunction( // Type 18
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+MemoryArrayMappedAddressFunction( // Type 19
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+MemoryDeviceMappedAddressFunction( // Type 20
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+PointingDeviceFunction( // Type 21
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+PortableBatterynFunction( // Type 22
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+SystemResetFunction( // Type 23
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+HardwareSecurityFunction( // Type 24
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+SystemPowerControlsFunction( // Type 25
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+VoltageProbeFunction( // Type 26
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+CoolingDeviceFunction( // Type 27
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+TemperatureProbeFunction( // Type 28
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+ElectricalCurrentProbeFunction( // Type 29
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+OutOfBoundRemoteAccessFunction(
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+BISEntryPointFunction( // Type 31
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+BootInfoStatusFunction( // Type 32
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  );
+
+EFI_STATUS
+EFIAPI
+BitMemoryErrorInformationFunction( // Type 33
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+ManagementDeviceFunction( // Type 34
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+ManagementDeviceComponentFunction( // Type 35
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+ManagementDeviceThresholdDataFunction( // Type 36
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+MemoryChannelInformationFunction( // Type 37
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+PimiDeviceInformationFunction( // Type 38
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+SystemPowerSupplyFunction( // Type 39
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+AdditionalInformationFunction( // Type 40
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+OnboardDevicesExtendedInformationFunction( // Type 41
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+ManagementControllerHostInterfaceFunction( // Type 42
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+TMPDeviceFunction( // Type 43
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+ProcessorAdditionalInformationFunction( // Type 44
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+EFI_STATUS
+EFIAPI
+InactiveFunction( // Type 126
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+);
+
+typedef
+EFI_STATUS
+(EFIAPI EFI_BASIC_SMBIOS_DATA_FUNCTION) (
+  IN  EFI_SMBIOS_PROTOCOL  *Smbios
+  );
+
+typedef struct {
+  EFI_BASIC_SMBIOS_DATA_FUNCTION *Function;
+} EFI_BASIC_SMBIOS_DATA;
+
+EFI_BASIC_SMBIOS_DATA mSmbiosBasicDataFuncTable[] = {
+  {&BiosVendorFunction},
+  {&SystemManufacturerFunction},
+  {&BaseBoardManufacturerFunction},
+  {&ChassisManufacturerFunction},
+  {&ProcessorInformationFunction},
+  {&MemoryControllerFunction},
+  {&MemoryModuleInformationFunction},
+  {&CacheInformationFunction},
+  {&PortConnectorInformationFunction},
+  {&SystemSlotsFunction},
+  {&OnBoardDevicesInformationFunction},
+  {&OEMStringsFunction},
+  {&SystemConfigurationOptionsFunction},
+  {&BiosLanguageFunction},
+  {&GroupAssociationsFunction},
+  {&SystemEventLogFunction},
+  {&PhysicalMemoryArrayFunction},
+  {&MemoryDeviceFunction},
+  {&g32bitMemoryErrorInformationFunction},
+  {&MemoryArrayMappedAddressFunction},
+  {&MemoryDeviceMappedAddressFunction},
+  {&PointingDeviceFunction},
+  {&PortableBatterynFunction},
+  {&SystemResetFunction},
+  {&HardwareSecurityFunction},
+  {&SystemPowerControlsFunction},
+  {&VoltageProbeFunction},
+  {&CoolingDeviceFunction},
+  {&TemperatureProbeFunction},
+  {&ElectricalCurrentProbeFunction},
+  {&OutOfBoundRemoteAccessFunction},
+  {&BISEntryPointFunction},
+  {&BootInfoStatusFunction},
+  {&BitMemoryErrorInformationFunction},
+  {&ManagementDeviceFunction},
+  {&ManagementDeviceComponentFunction},
+  {&ManagementDeviceThresholdDataFunction},
+  {&MemoryChannelInformationFunction},
+  {&PimiDeviceInformationFunction},
+  {&SystemPowerSupplyFunction},
+  {&AdditionalInformationFunction},
+  {&OnboardDevicesExtendedInformationFunction},
+  {&ManagementControllerHostInterfaceFunction},
+  {&TMPDeviceFunction},
+  {&ProcessorAdditionalInformationFunction},
+  {&InactiveFunction},
+};
+
+/**
+  Standard EFI driver point.  This driver parses the mSmbiosMiscDataTable
+  structure and reports any generated data using SMBIOS protocol.
+
+  @param  ImageHandle     Handle for the image of this driver
+  @param  SystemTable     Pointer to the EFI System Table
+
+  @retval  EFI_SUCCESS    The data was successfully stored.
+
+**/
+EFI_STATUS
+EFIAPI
+SmbiosBasicEntryPoint(
+  IN EFI_HANDLE         ImageHandle,
+  IN EFI_SYSTEM_TABLE   *SystemTable
+  )
+{
+  UINTN                Index;
+  EFI_STATUS           EfiStatus;
+  EFI_SMBIOS_PROTOCOL  *Smbios;
+
+  EfiStatus = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID**)&Smbios);
+  if (EFI_ERROR(EfiStatus)) {
+    DEBUG((DEBUG_ERROR, "Could not locate SMBIOS protocol.  %r\n", EfiStatus));
+    return EfiStatus;
+  }
+
+  for (Index = 0; Index < sizeof(mSmbiosBasicDataFuncTable)/sizeof(mSmbiosBasicDataFuncTable[0]); ++Index) {
+    EfiStatus = (*mSmbiosBasicDataFuncTable[Index].Function) (Smbios);
+    if (EFI_ERROR(EfiStatus)) {
+      DEBUG((DEBUG_ERROR, "Basic smbios store error.  Index=%d, ReturnStatus=%r\n", Index, EfiStatus));
+      return EfiStatus;
+    }
+  }
+
+  return EfiStatus;
+}
+
+/**
+  Add an SMBIOS record.
+
+  @param  Smbios                The EFI_SMBIOS_PROTOCOL instance.
+  @param  SmbiosHandle          A unique handle will be assigned to the SMBIOS record.
+  @param  Record                The data for the fixed portion of the SMBIOS record. The format of the record is
+                                determined by EFI_SMBIOS_TABLE_HEADER.Type. The size of the formatted area is defined
+                                by EFI_SMBIOS_TABLE_HEADER.Length and either followed by a double-null (0x0000) or
+                                a set of null terminated strings and a null.
+
+  @retval EFI_SUCCESS           Record was added.
+  @retval EFI_OUT_OF_RESOURCES  Record was not added due to lack of system resources.
+
+**/
+EFI_STATUS
+AddSmbiosRecord (
+  IN EFI_SMBIOS_PROTOCOL        *Smbios,
+  OUT EFI_SMBIOS_HANDLE         *SmbiosHandle,
+  IN EFI_SMBIOS_TABLE_HEADER    *Record
+  )
+{
+  *SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+  return Smbios->Add (
+                   Smbios,
+                   NULL,
+                   SmbiosHandle,
+                   Record
+                   );
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type0BiosVendorFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type0BiosVendorFunction.c
@@ -1,0 +1,81 @@
+/** @file
+  Smbios type 0.
+
+Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  BiosVendor (Type 0).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+BiosVendorFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS            Status;
+  CHAR8                 *VendorStr;
+  UINTN                 VendorStrLen;
+  CHAR8                 *VersionStr;
+  UINTN                 VerStrLen;
+  CHAR8                 *DateStr;
+  UINTN                 DateStrLen;
+  SMBIOS_TABLE_TYPE0    *SmbiosRecord;
+  SMBIOS_TABLE_TYPE0    *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE     SmbiosHandle;
+  UINTN                 StringOffset;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType0BiosInformation);
+
+  VendorStr = PcdGetPtr (PcdSmbiosType0StringVendor);
+  VendorStrLen = AsciiStrLen (VendorStr);
+  ASSERT (VendorStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  VersionStr = PcdGetPtr (PcdSmbiosType0StringBiosVersion);
+  VerStrLen = AsciiStrLen (VersionStr);
+  ASSERT (VerStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  DateStr = PcdGetPtr (PcdSmbiosType0StringBiosReleaseDate);
+  DateStrLen = AsciiStrLen (DateStr);
+  ASSERT (DateStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Two zeros following the last string.
+  //
+  SmbiosRecord = AllocateZeroPool (sizeof (SMBIOS_TABLE_TYPE0) + VendorStrLen + 1 + VerStrLen + 1 + DateStrLen + 1 + 1);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, sizeof(SMBIOS_TABLE_TYPE0));
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_BIOS_INFORMATION;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE0);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  StringOffset = SmbiosRecord->Hdr.Length;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, VendorStr, VendorStrLen);
+  StringOffset += VendorStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, VersionStr, VerStrLen);
+  StringOffset += VerStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, DateStr, DateStrLen);
+
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type11OEMStringsFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type11OEMStringsFunction.c
@@ -1,0 +1,77 @@
+/** @file
+  Smbios type 11.
+
+  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  free-form strings defined by OEM (Type 11).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+OEMStringsFunction(
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+)
+{
+    CHAR8                       *StringCountStr;
+    UINTN                       StringCountStrLen;    
+    EFI_STATUS                  Status;
+    SMBIOS_TABLE_TYPE11         *PcdSmbiosRecord;
+    SMBIOS_TABLE_TYPE11         *SmbiosRecord;
+    EFI_SMBIOS_HANDLE           SmbiosHandle;
+    UINTN                       StringOffset;
+    UINTN                       TableSize;
+
+    PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType11OEMStrings);
+
+    //
+    // Get board string count string
+    //
+    StringCountStr = PcdGetPtr (PcdSmbiosType11StringCount);
+    StringCountStrLen = AsciiStrLen (StringCountStr);
+    ASSERT (StringCountStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+    //
+    // Create table size based on string lengths
+    //
+    TableSize = sizeof (SMBIOS_TABLE_TYPE11) + StringCountStrLen + 1 + 1;
+    SmbiosRecord = AllocateZeroPool (TableSize);
+    if (SmbiosRecord == NULL) {
+      ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    CopyMem (SmbiosRecord, PcdSmbiosRecord, sizeof(SMBIOS_TABLE_TYPE11));
+
+    //
+    // Fill in type 11 fields
+    //
+    SmbiosRecord->Hdr.Type = SMBIOS_TYPE_OEM_STRINGS;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE11);
+    SmbiosRecord->Hdr.Handle = 0;
+
+    //
+    // Add strings to bottom of data block
+    //
+    StringOffset = SmbiosRecord->Hdr.Length;
+    CopyMem ((UINT8 *)SmbiosRecord + StringOffset, StringCountStr, StringCountStrLen);
+    StringOffset += StringCountStrLen + 1;
+
+    //
+    // Full smbios record, call smbios protocol to add this record.
+    //
+    Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+    
+    FreePool (SmbiosRecord);
+    return Status; 
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type126InactiveFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type126InactiveFunction.c
@@ -1,0 +1,58 @@
+/** @file
+  Smbios type 126.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of
+  Inactive (Type 126).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+InactiveFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  SMBIOS_TABLE_TYPE126                *SmbiosRecord;
+  SMBIOS_TABLE_TYPE126                *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+  UINTN                               TableSize;   
+  
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType126Inactive);
+
+    //
+    // Create table size based on string lengths
+    //
+    TableSize = sizeof (SMBIOS_TABLE_TYPE126) + 1 + 1;
+    SmbiosRecord = AllocateZeroPool (TableSize);
+    if (SmbiosRecord == NULL) {
+        ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+        return EFI_OUT_OF_RESOURCES;
+    }  
+
+    //
+    // Fill in type 126 fields
+    //
+    SmbiosRecord->Hdr.Type = SMBIOS_TYPE_INACTIVE;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE126);
+    SmbiosRecord->Hdr.Handle = 0;
+
+    //
+    // Full smbios record, call smbios protocol to add this record.
+    //
+    Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+    
+    FreePool (SmbiosRecord);
+    return Status;
+}        

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type13BiosLanguageInformationFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type13BiosLanguageInformationFunction.c
@@ -1,0 +1,72 @@
+/** @file
+  Smbios type 13.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  BiosLanguageFunction (Type 13).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+BiosLanguageFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  CHAR8                               *CurrentLanguagesStr;
+  UINTN                               CurrentLanguagesStrLen;
+  SMBIOS_TABLE_TYPE9                  *SmbiosRecord;
+  SMBIOS_TABLE_TYPE9                  *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+  UINTN                               SourceSize;
+  UINTN                               TotalSize;
+  UINTN                               StringOffset;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType13BiosLanguageInformation);
+
+  //
+  // Get Current Languages String.
+  //
+  CurrentLanguagesStr = PcdGetPtr (PcdSmbiosType13StringCurrentLanguages);
+  CurrentLanguagesStrLen = AsciiStrLen (CurrentLanguagesStr);
+  ASSERT (CurrentLanguagesStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Allocate space for the record
+  //
+  SourceSize = PcdGetSize (PcdSmbiosType13BiosLanguageInformation);
+  TotalSize = SourceSize + CurrentLanguagesStrLen + 1 + 1;
+  SmbiosRecord = AllocateZeroPool(TotalSize);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Copy the data to the table
+  //
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, SourceSize);
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_BIOS_LANGUAGE_INFORMATION;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE13);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  StringOffset = SmbiosRecord->Hdr.Length;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, CurrentLanguagesStr, CurrentLanguagesStrLen);
+  
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type15SystemEventLogFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type15SystemEventLogFunction.c
@@ -1,0 +1,58 @@
+/** @file
+  Smbios type 15.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  System Event Log (Type 15).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+SystemEventLogFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+    EFI_STATUS                      Status;
+    SMBIOS_TABLE_TYPE15             *SmbiosRecord;
+    SMBIOS_TABLE_TYPE15             *PcdSmbiosRecord;
+    EFI_SMBIOS_HANDLE               SmbiosHandle;
+    UINTN                           TableSize;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType15SystemEventLog);
+
+  //
+  // Create table size based on string lengths
+  //
+  TableSize = sizeof (SMBIOS_TABLE_TYPE15) + 1 + 1;
+  SmbiosRecord = AllocateZeroPool (TableSize);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Fill in type 15 fields
+  //
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_SYSTEM_EVENT_LOG;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE15);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  //
+  // Full smbios record, call smbios protocol to add this record.
+  //
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+    
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type17MemoryDeviceFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type17MemoryDeviceFunction.c
@@ -1,0 +1,134 @@
+/** @file
+  Smbios type 17.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  MemoryDeviceFunction (Type 17).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+MemoryDeviceFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  CHAR8                               *DeviceLocatorStr;
+  UINTN                               DeviceLocatorStrLen;
+  CHAR8                               *BankLocatorStr;
+  UINTN                               BankLocatorStrLen;
+  CHAR8                               *ManufacturerStr;
+  UINTN                               ManufacturerStrLen;
+  CHAR8                               *SerialNumberStr;
+  UINTN                               SerialNumberStrLen;
+  CHAR8                               *AssetTagStr;
+  UINTN                               AssetTagStrLen;
+  CHAR8                               *PartNumberStr;
+  UINTN                               PartNumberStrLen;
+  CHAR8                               *FirmwareVersionStr;
+  UINTN                               FirmwareVersionStrLen;
+  SMBIOS_TABLE_TYPE17                 *SmbiosRecord;
+  SMBIOS_TABLE_TYPE17                 *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+  UINTN                               SourceSize;
+  UINTN                               TotalSize;
+  UINTN                               StringOffset;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType17MemoryDevice);
+
+  //
+  // Get Device Locator String.
+  //
+  DeviceLocatorStr = PcdGetPtr (PcdSmbiosType17StringDeviceLocator);
+  DeviceLocatorStrLen = AsciiStrLen (DeviceLocatorStr);
+  ASSERT (DeviceLocatorStrLen <= SMBIOS_STRING_MAX_LENGTH);
+  //
+  // Get Bank Locator String.
+  //
+  BankLocatorStr = PcdGetPtr (PcdSmbiosType17StringBankLocator);
+  BankLocatorStrLen = AsciiStrLen (BankLocatorStr);
+  ASSERT (BankLocatorStrLen <= SMBIOS_STRING_MAX_LENGTH);
+  //
+  // Get Manufacturer String.
+  //
+  ManufacturerStr = PcdGetPtr (PcdSmbiosType17StringManufacturer);
+  ManufacturerStrLen = AsciiStrLen (ManufacturerStr);
+  ASSERT (ManufacturerStrLen <= SMBIOS_STRING_MAX_LENGTH);
+  //
+  // Get Serial Number String.
+  //
+  SerialNumberStr = PcdGetPtr (PcdSmbiosType17StringSerialNumber);
+  SerialNumberStrLen = AsciiStrLen (SerialNumberStr);
+  ASSERT (SerialNumberStrLen <= SMBIOS_STRING_MAX_LENGTH);
+  //
+  // Get Asset Tag String.
+  //
+  AssetTagStr = PcdGetPtr (PcdSmbiosType17StringAssetTag);
+  AssetTagStrLen = AsciiStrLen (AssetTagStr);
+  ASSERT (AssetTagStrLen <= SMBIOS_STRING_MAX_LENGTH);
+  //
+  // Get Part Number String.
+  //
+  PartNumberStr = PcdGetPtr (PcdSmbiosType17StringPartNumber);
+  PartNumberStrLen = AsciiStrLen (PartNumberStr);
+  ASSERT (PartNumberStrLen <= SMBIOS_STRING_MAX_LENGTH);
+  //
+  // Get Firmware Version String.
+  //
+  FirmwareVersionStr = PcdGetPtr (PcdSmbiosType17StringFirmwareVersion);
+  FirmwareVersionStrLen = AsciiStrLen (FirmwareVersionStr);
+  ASSERT (FirmwareVersionStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Allocate space for the record
+  //
+  SourceSize = PcdGetSize (PcdSmbiosType17MemoryDevice);
+  TotalSize = SourceSize + DeviceLocatorStrLen + 1 + BankLocatorStrLen + 1 + ManufacturerStrLen + 1 + SerialNumberStrLen + 1;
+  TotalSize += AssetTagStrLen + 1 + PartNumberStrLen + 1 + FirmwareVersionStrLen + 1 + 1;
+  SmbiosRecord = AllocateZeroPool(TotalSize);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Copy the data to the table
+  //
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, SourceSize);
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_MEMORY_DEVICE;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE17);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  StringOffset = SmbiosRecord->Hdr.Length;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, DeviceLocatorStr, DeviceLocatorStrLen);
+  StringOffset += DeviceLocatorStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, BankLocatorStr, BankLocatorStrLen);
+  StringOffset += BankLocatorStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, ManufacturerStr, ManufacturerStrLen);
+  StringOffset += ManufacturerStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, SerialNumberStr, SerialNumberStrLen);
+  StringOffset += SerialNumberStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, AssetTagStr, AssetTagStrLen);
+  StringOffset += AssetTagStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, PartNumberStr, PartNumberStrLen);
+  StringOffset += PartNumberStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, FirmwareVersionStr, FirmwareVersionStrLen);
+  StringOffset += FirmwareVersionStrLen + 1;
+  
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type19MemoryArrayMappedAddressFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type19MemoryArrayMappedAddressFunction.c
@@ -1,0 +1,58 @@
+/** @file
+  Smbios type 19.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  Memory Array Mapped Address (Type 19).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+MemoryArrayMappedAddressFunction(
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+)
+{
+    EFI_STATUS                  Status;
+    SMBIOS_TABLE_TYPE19         *PcdSmbiosRecord;
+    SMBIOS_TABLE_TYPE19         *SmbiosRecord;
+    EFI_SMBIOS_HANDLE           SmbiosHandle;
+    UINTN                       TableSize;
+
+    PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType19MemoryArrayMappedAddress);
+
+    //
+    // Create table size based on string lengths
+    //
+    TableSize = sizeof (SMBIOS_TABLE_TYPE19) + 1 + 1;
+    SmbiosRecord = AllocateZeroPool (TableSize);
+    if (SmbiosRecord == NULL) {
+        ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+        return EFI_OUT_OF_RESOURCES;
+    }
+
+    //
+    // Fill in type 19 fields
+    //
+    SmbiosRecord->Hdr.Type = SMBIOS_TYPE_MEMORY_ARRAY_MAPPED_ADDRESS;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE19);
+    SmbiosRecord->Hdr.Handle = 0;
+
+    //
+    // Full smbios record, call smbios protocol to add this record.
+    //
+    Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+    
+    FreePool (SmbiosRecord);
+    return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type1SystemManufacturerFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type1SystemManufacturerFunction.c
@@ -1,0 +1,114 @@
+/** @file
+  Smbios type 1.
+
+Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  SystemManufacturer (Type 1).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+SystemManufacturerFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                      Status;
+  CHAR8                           *ManufacturerStr;
+  CHAR8                           *ProductNameStr;
+  CHAR8                           *VersionStr;
+  CHAR8                           *SerialNumberStr;
+  CHAR8                           *SKUNumberStr;
+  CHAR8                           *FamilyStr;
+  UINTN                           ManufacturerStrLen;
+  UINTN                           ProductNameStrLen;
+  UINTN                           VersionStrLen;
+  UINTN                           SerialNumberStrLen;
+  UINTN                           SKUNumberStrLen;
+  UINTN                           FamilyStrLen;
+  UINTN                           TableSize;
+  SMBIOS_TABLE_TYPE1              *PcdSmbiosRecord;
+  SMBIOS_TABLE_TYPE1              *SmbiosRecord;
+  EFI_SMBIOS_HANDLE               SmbiosHandle;
+  UINTN                           StringOffset;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType1SystemInformation);
+
+  ManufacturerStr = PcdGetPtr (PcdSmbiosType1StringManufacturer);
+  ManufacturerStrLen = AsciiStrLen (ManufacturerStr);
+  ASSERT (ManufacturerStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  ProductNameStr = PcdGetPtr (PcdSmbiosType1StringProductName);
+  ProductNameStrLen = AsciiStrLen (ProductNameStr);
+  ASSERT (ProductNameStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  VersionStr = PcdGetPtr (PcdSmbiosType1StringVersion);
+  VersionStrLen = AsciiStrLen (VersionStr);
+  ASSERT (VersionStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  SerialNumberStr = PcdGetPtr (PcdSmbiosType1StringSerialNumber);
+  SerialNumberStrLen = AsciiStrLen (SerialNumberStr);
+  ASSERT (SerialNumberStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  SKUNumberStr = PcdGetPtr (PcdSmbiosType1StringSKUNumber);
+  SKUNumberStrLen = AsciiStrLen (SKUNumberStr);
+  ASSERT (SKUNumberStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  FamilyStr = PcdGetPtr (PcdSmbiosType1StringFamily);
+  FamilyStrLen = AsciiStrLen (FamilyStr);
+  ASSERT (FamilyStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Create table size based on string lengths
+  //
+  TableSize = sizeof (SMBIOS_TABLE_TYPE1) + ManufacturerStrLen + 1 + ProductNameStrLen + 1 + VersionStrLen + 1 + SerialNumberStrLen + 1 + SKUNumberStrLen + 1 + FamilyStrLen + 1 + 1;
+  SmbiosRecord = AllocateZeroPool (TableSize);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, sizeof(SMBIOS_TABLE_TYPE1));
+
+  //
+  // Fill in Type 1 fields
+  //
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_SYSTEM_INFORMATION;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE1);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  //
+  // Add strings to bottom of data block
+  //
+  StringOffset = SmbiosRecord->Hdr.Length;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, ManufacturerStr, ManufacturerStrLen);
+  StringOffset += ManufacturerStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, ProductNameStr, ProductNameStrLen);
+  StringOffset += ProductNameStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, VersionStr, VersionStrLen);
+  StringOffset += VersionStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, SerialNumberStr, SerialNumberStrLen);
+  StringOffset += SerialNumberStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, SKUNumberStr, SKUNumberStrLen);
+  StringOffset += SKUNumberStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, FamilyStr, FamilyStrLen);
+
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool(SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type21PointingDeviceFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type21PointingDeviceFunction.c
@@ -1,0 +1,52 @@
+/** @file
+  Smbios type 21.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  PointingDevice (Type 21).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+PointingDeviceFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  SMBIOS_TABLE_TYPE21                  *SmbiosRecord;
+  SMBIOS_TABLE_TYPE21                  *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType21PointingDevice);
+
+  SmbiosRecord = AllocateZeroPool(sizeof (SMBIOS_TABLE_TYPE21) + 1 + 1);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, sizeof(SMBIOS_TABLE_TYPE21));
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_BUILT_IN_POINTING_DEVICE;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE21);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type23SystemResetFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type23SystemResetFunction.c
@@ -1,0 +1,58 @@
+/** @file
+  Smbios type 23.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  System Reset (Type 23).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+SystemResetFunction(
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+)
+{
+    EFI_STATUS                  Status;
+    SMBIOS_TABLE_TYPE23         *PcdSmbiosRecord;
+    SMBIOS_TABLE_TYPE23         *SmbiosRecord;
+    EFI_SMBIOS_HANDLE           SmbiosHandle;
+    UINTN                       TableSize;
+
+    PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType23SystemReset);
+
+    //
+    // Create table size based on string lengths
+    //
+    TableSize = sizeof (SMBIOS_TABLE_TYPE23) + 1 + 1;
+    SmbiosRecord = AllocateZeroPool (TableSize);
+    if (SmbiosRecord == NULL) {
+        ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+        return EFI_OUT_OF_RESOURCES;
+    }
+
+    //
+    // Fill in type 23 fields
+    //
+    SmbiosRecord->Hdr.Type = SMBIOS_TYPE_SYSTEM_RESET;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE23);
+    SmbiosRecord->Hdr.Handle = 0;
+
+    //
+    // Full smbios record, call smbios protocol to add this record.
+    //
+    Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+    
+    FreePool (SmbiosRecord);
+    return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type25SystemPowerControlsFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type25SystemPowerControlsFunction.c
@@ -1,0 +1,52 @@
+/** @file
+  Smbios type 25.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  SystemPowerControls (Type 25).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+SystemPowerControlsFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  SMBIOS_TABLE_TYPE25                 *SmbiosRecord;
+  SMBIOS_TABLE_TYPE25                 *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType25SystemPowerControls);
+
+  SmbiosRecord = AllocateZeroPool(sizeof (SMBIOS_TABLE_TYPE25) + 1 + 1);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, sizeof(SMBIOS_TABLE_TYPE25));
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_SYSTEM_POWER_CONTROLS;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE25);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type27CoolingDeviceFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type27CoolingDeviceFunction.c
@@ -1,0 +1,77 @@
+/** @file
+  Smbios type 27.
+
+  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  Cooling Device (Type 27).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+CoolingDeviceFunction(
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+)
+{
+    EFI_STATUS                  Status;
+    CHAR8                       *DescriptionStr;
+    UINTN                       DescriptionStrLen;
+    SMBIOS_TABLE_TYPE27         *PcdSmbiosRecord;
+    SMBIOS_TABLE_TYPE27         *SmbiosRecord;
+    EFI_SMBIOS_HANDLE           SmbiosHandle;
+    UINTN                       StringOffset;
+    UINTN                       TableSize;
+
+    PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType27CoolingDevice);
+
+    //
+    // Get board cooling device description string
+    //
+    DescriptionStr = PcdGetPtr (PcdSmbiosType27StringDescription);
+    DescriptionStrLen = AsciiStrLen (DescriptionStr);
+    ASSERT (DescriptionStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+    //
+    // Create table size based on string lengths
+    //
+    TableSize = sizeof (SMBIOS_TABLE_TYPE27) + DescriptionStrLen + 1 + 1;
+    SmbiosRecord = AllocateZeroPool (TableSize);
+    if (SmbiosRecord == NULL) {
+        ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+        return EFI_OUT_OF_RESOURCES;
+    }
+
+    CopyMem (SmbiosRecord, PcdSmbiosRecord, sizeof(SMBIOS_TABLE_TYPE27));
+
+    //
+    // Fill in type 27 fields
+    //
+    SmbiosRecord->Hdr.Type = SMBIOS_TYPE_COOLING_DEVICE;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE27);
+    SmbiosRecord->Hdr.Handle = 0;
+
+    //
+    // Add strings to bottom of data block
+    //
+    StringOffset = SmbiosRecord->Hdr.Length;
+    CopyMem ((UINT8 *)SmbiosRecord + StringOffset, DescriptionStr, DescriptionStrLen);
+    StringOffset += DescriptionStrLen + 1;
+
+    //
+    // Full smbios record, call smbios protocol to add this record.
+    //
+    Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+    
+    FreePool (SmbiosRecord);
+    return Status;
+}    

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type29ElectricalCurrentProbeFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type29ElectricalCurrentProbeFunction.c
@@ -1,0 +1,72 @@
+/** @file
+  Smbios type 29.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  ElectricalCurrentProbe (Type 29).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+ElectricalCurrentProbeFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  CHAR8                               *DescriptionStr;
+  UINTN                               DescriptionStrLen;
+  SMBIOS_TABLE_TYPE29                 *SmbiosRecord;
+  SMBIOS_TABLE_TYPE29                 *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+  UINTN                               SourceSize;
+  UINTN                               TotalSize;
+  UINTN                               StringOffset;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType29ElectricalCurrentProbe);
+
+  //
+  // Get Description String.
+  //
+  DescriptionStr = PcdGetPtr (PcdSmbiosType29StringDescription);
+  DescriptionStrLen = AsciiStrLen (DescriptionStr);
+  ASSERT (DescriptionStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Allocate space for the record
+  //
+  SourceSize = PcdGetSize (PcdSmbiosType29ElectricalCurrentProbe);
+  TotalSize = SourceSize + DescriptionStrLen + 1 + 1;
+  SmbiosRecord = AllocateZeroPool(TotalSize);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Copy the data to the table
+  //
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, SourceSize);
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_ELECTRICAL_CURRENT_PROBE;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE29);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  StringOffset = SmbiosRecord->Hdr.Length;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, DescriptionStr, DescriptionStrLen);
+  
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type2BaseBoardManufacturerFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type2BaseBoardManufacturerFunction.c
@@ -1,0 +1,131 @@
+/** @file
+  Smbios type 2.
+
+Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  BaseBoardManufacturer (Type 2).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+BaseBoardManufacturerFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  CHAR8                               *ManufacturerStr;
+  CHAR8                               *ProductStr;
+  CHAR8                               *VersionStr;
+  CHAR8                               *SerialNumberStr;
+  CHAR8                               *AssertTagStr;
+  CHAR8                               *ChassisStr;
+  UINTN                               ManuStrLen;
+  UINTN                               ProductStrLen;
+  UINTN                               VerStrLen;
+  UINTN                               AssertTagStrLen;
+  UINTN                               SerialNumStrLen;
+  UINTN                               ChassisStrLen;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+  SMBIOS_TABLE_TYPE2                  *PcdSmbiosRecord;
+  SMBIOS_TABLE_TYPE2                  *SmbiosRecord;
+  UINTN                               SourceSize;
+  UINTN                               TotalSize;
+  UINTN                               StringOffset;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType2BaseBoardInformation);
+
+  //
+  // Get BoardManufacturer String.
+  //
+  ManufacturerStr = PcdGetPtr (PcdSmbiosType2StringManufacturer);
+  ManuStrLen = AsciiStrLen (ManufacturerStr);
+  ASSERT (ManuStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Get Board ProductName String.
+  //
+  ProductStr = PcdGetPtr (PcdSmbiosType2StringProductName);
+  ProductStrLen = AsciiStrLen (ProductStr);
+  ASSERT (ProductStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Get Board Version String.
+  //
+  VersionStr = PcdGetPtr (PcdSmbiosType2StringVersion);
+  VerStrLen = AsciiStrLen (VersionStr);
+  ASSERT (VerStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Get Board Serial Number String.
+  //
+  SerialNumberStr = PcdGetPtr (PcdSmbiosType2StringSerialNumber);
+  SerialNumStrLen = AsciiStrLen (SerialNumberStr);
+  ASSERT (SerialNumStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Get Board Asset Tag String.
+  //
+  AssertTagStr = PcdGetPtr (PcdSmbiosType2StringAssetTag);
+  AssertTagStrLen = AsciiStrLen (AssertTagStr);
+  ASSERT (AssertTagStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Get Board Chassis Location Tag String.
+  //
+  ChassisStr = PcdGetPtr (PcdSmbiosType2StringLocationInChassis);
+  ChassisStrLen = AsciiStrLen (ChassisStr);
+  ASSERT (ChassisStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Two zeros following the last string.
+  //
+  SourceSize = PcdGetSize (PcdSmbiosType2BaseBoardInformation);
+  TotalSize = SourceSize + ManuStrLen + 1 + ProductStrLen + 1 + VerStrLen + 1 + SerialNumStrLen + 1 + AssertTagStrLen + 1 + ChassisStrLen + 1 + 1;
+  SmbiosRecord = AllocateZeroPool(TotalSize);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, SourceSize);
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_BASEBOARD_INFORMATION;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE2);
+  if (PcdSmbiosRecord->NumberOfContainedObjectHandles >= 2) {
+    SmbiosRecord->Hdr.Length += (PcdSmbiosRecord->NumberOfContainedObjectHandles - 1) * sizeof(PcdSmbiosRecord->ContainedObjectHandles);
+  }
+  ASSERT(SourceSize >= SmbiosRecord->Hdr.Length);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  StringOffset = SmbiosRecord->Hdr.Length;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, ManufacturerStr, ManuStrLen);
+  StringOffset += ManuStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, ProductStr, ProductStrLen);
+  StringOffset += ProductStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, VersionStr, VerStrLen);
+  StringOffset += VerStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, SerialNumberStr, SerialNumStrLen);
+  StringOffset += SerialNumStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, AssertTagStr, AssertTagStrLen);
+  StringOffset += AssertTagStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, ChassisStr, ChassisStrLen);
+
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool(SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type31BISEntryPointFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type31BISEntryPointFunction.c
@@ -1,0 +1,59 @@
+/** @file
+  Smbios type 31.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  Boot Integrity Services (BIS) Entry Point (Type 31).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+
+EFI_STATUS
+EFIAPI
+BISEntryPointFunction(
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+)
+{
+    EFI_STATUS                  Status;
+    SMBIOS_TABLE_TYPE31         *PcdSmbiosRecord;
+    SMBIOS_TABLE_TYPE31         *SmbiosRecord;
+    EFI_SMBIOS_HANDLE           SmbiosHandle;
+    UINTN                       TableSize;  
+
+    PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType31BISEntryPoint);
+
+    //
+    // Create table size based on string lengths
+    //
+    TableSize = sizeof (SMBIOS_TABLE_TYPE31) + 1 + 1;
+    SmbiosRecord = AllocateZeroPool (TableSize);
+    if (SmbiosRecord == NULL) {
+        ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+        return EFI_OUT_OF_RESOURCES;
+    }
+
+    //
+    // Fill in type 31 fields
+    //
+    SmbiosRecord->Hdr.Type = 31;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE31);
+    SmbiosRecord->Hdr.Handle = 0;
+
+    //
+    // Full smbios record, call smbios protocol to add this record.
+    //
+    Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+    
+    FreePool (SmbiosRecord);
+    return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type32BootInformationFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type32BootInformationFunction.c
@@ -1,0 +1,56 @@
+/** @file
+  Smbios type 32.
+
+Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+
+/**
+  This function makes boot time changes to the contents of the
+  BootInformation (Type 32).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+BootInfoStatusFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                         Status;
+  EFI_SMBIOS_HANDLE                  SmbiosHandle;
+  SMBIOS_TABLE_TYPE32                *PcdSmbiosRecord;
+  SMBIOS_TABLE_TYPE32                *SmbiosRecord;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType32SystemBootInformation);
+
+  //
+  // Two zeros following the last string.
+  //
+  SmbiosRecord = AllocateZeroPool(sizeof (SMBIOS_TABLE_TYPE32) + 1 + 1);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, sizeof(SMBIOS_TABLE_TYPE32));
+
+  SmbiosRecord->Hdr.Type = EFI_SMBIOS_TYPE_SYSTEM_BOOT_INFORMATION;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE32);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool(SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type34ManagementDeviceFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type34ManagementDeviceFunction.c
@@ -1,0 +1,72 @@
+/** @file
+  Smbios type 34.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  ManagementDevice (Type 34).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+ManagementDeviceFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  CHAR8                               *DescriptionStr;
+  UINTN                               DescriptionStrLen;
+  SMBIOS_TABLE_TYPE34                 *SmbiosRecord;
+  SMBIOS_TABLE_TYPE34                 *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+  UINTN                               SourceSize;
+  UINTN                               TotalSize;
+  UINTN                               StringOffset;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType34ManagementDevice);
+
+  //
+  // Get Description String.
+  //
+  DescriptionStr = PcdGetPtr (PcdSmbiosType34StringDescription);
+  DescriptionStrLen = AsciiStrLen (DescriptionStr);
+  ASSERT (DescriptionStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Allocate space for the record
+  //
+  SourceSize = PcdGetSize (PcdSmbiosType34ManagementDevice);
+  TotalSize = SourceSize + DescriptionStrLen + 1 + 1;
+  SmbiosRecord = AllocateZeroPool(TotalSize);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Copy the data to the table
+  //
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, SourceSize);
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_MANAGEMENT_DEVICE;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE34);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  StringOffset = SmbiosRecord->Hdr.Length;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, DescriptionStr, DescriptionStrLen);
+  
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type36ManagementDeviceThresholdDataFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type36ManagementDeviceThresholdDataFunction.c
@@ -1,0 +1,58 @@
+  /** @file
+  Smbios type 36.
+
+  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  Management Device Threshold Data (Type 36).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+ManagementDeviceThresholdDataFunction(
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+)
+{
+    EFI_STATUS                  Status;
+    SMBIOS_TABLE_TYPE36         *PcdSmbiosRecord;
+    SMBIOS_TABLE_TYPE36         *SmbiosRecord;
+    EFI_SMBIOS_HANDLE           SmbiosHandle;
+    UINTN                       TableSize; 
+
+    PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType36ManagementDeviceThresholdData);    
+    
+    //
+    // Create table size based on string lengths
+    //
+    TableSize = sizeof (SMBIOS_TABLE_TYPE36) + 1 + 1;
+    SmbiosRecord = AllocateZeroPool (TableSize);
+    if (SmbiosRecord == NULL) {
+        ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+        return EFI_OUT_OF_RESOURCES;
+    }
+
+    //
+    // Fill in type 36 fields
+    //
+    SmbiosRecord->Hdr.Type = SMBIOS_TYPE_MANAGEMENT_DEVICE_THRESHOLD_DATA;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE36);
+    SmbiosRecord->Hdr.Handle = 0;    
+
+    //
+    // Full smbios record, call smbios protocol to add this record.
+    //
+    Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+    
+    FreePool (SmbiosRecord);
+    return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type38IpmiDeviceInformationFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type38IpmiDeviceInformationFunction.c
@@ -1,0 +1,52 @@
+/** @file
+  Smbios type 38.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  PimiDeviceInformation (Type 38).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+PimiDeviceInformationFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  SMBIOS_TABLE_TYPE38                 *SmbiosRecord;
+  SMBIOS_TABLE_TYPE38                 *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType38PimiDeviceInformation);
+
+  SmbiosRecord = AllocateZeroPool(sizeof (SMBIOS_TABLE_TYPE38) + 1 + 1);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, sizeof(SMBIOS_TABLE_TYPE38));
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_IPMI_DEVICE_INFORMATION;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE38);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type3ChassisManufacturerFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type3ChassisManufacturerFunction.c
@@ -1,0 +1,125 @@
+/** @file
+  Smbios type 3.
+
+Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  ChassisManufacturer (Type 3).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+ChassisManufacturerFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  UINTN                           ManuStrLen;
+  UINTN                           VerStrLen;
+  UINTN                           AssertTagStrLen;
+  UINTN                           SerialNumStrLen;
+  UINTN                           SKUNumberStrLen;
+  EFI_STATUS                      Status;
+  CHAR8                           *ManufacturerStr;
+  CHAR8                           *VersionStr;
+  CHAR8                           *SerialNumberStr;
+  CHAR8                           *AssertTagStr;
+  CHAR8                           *SKUNumberStr;
+  SMBIOS_TABLE_STRING             *SKUNumberPtr;
+  EFI_SMBIOS_HANDLE               SmbiosHandle;
+  SMBIOS_TABLE_TYPE3              *SmbiosRecord;
+  SMBIOS_TABLE_TYPE3              *PcdSmbiosRecord;
+  UINTN                           SourceSize;
+  UINTN                           TotalSize;
+  UINTN                           StringOffset;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType3SystemEnclosureChassis);
+
+  //
+  // Get ChassisManufacturer String.
+  //
+  ManufacturerStr = PcdGetPtr (PcdSmbiosType3StringManufacturer);
+  ManuStrLen = AsciiStrLen (ManufacturerStr);
+  ASSERT (ManuStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Get ChassisVersion String.
+  //
+  VersionStr = PcdGetPtr (PcdSmbiosType3StringVersion);
+  VerStrLen = AsciiStrLen (VersionStr);
+  ASSERT (VerStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Get ChassisSerialNumber String.
+  //
+  SerialNumberStr = PcdGetPtr (PcdSmbiosType3StringSerialNumber);
+  SerialNumStrLen = AsciiStrLen (SerialNumberStr);
+  ASSERT (SerialNumStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Get ChassisAssetTag String.
+  //
+  AssertTagStr = PcdGetPtr (PcdSmbiosType3StringAssetTag);
+  AssertTagStrLen = AsciiStrLen (AssertTagStr);
+  ASSERT (AssertTagStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Get ChassisSKUNumber String.
+  //
+  SKUNumberStr = PcdGetPtr (PcdSmbiosType3StringSKUNumber);
+  SKUNumberStrLen = AsciiStrLen (SKUNumberStr);
+  ASSERT (SKUNumberStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Two zeros following the last string.
+  //
+  SourceSize = PcdGetSize(PcdSmbiosType3SystemEnclosureChassis);
+  TotalSize = SourceSize + sizeof(SMBIOS_TABLE_STRING) + ManuStrLen + 1 + VerStrLen + 1 + SerialNumStrLen + 1 + AssertTagStrLen + 1 + SKUNumberStrLen + 1 + 1;
+  SmbiosRecord = AllocateZeroPool(TotalSize);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, SourceSize);
+
+  SmbiosRecord->Hdr.Type = EFI_SMBIOS_TYPE_SYSTEM_ENCLOSURE;
+  SmbiosRecord->Hdr.Length = OFFSET_OF (SMBIOS_TABLE_TYPE3, ContainedElements) + sizeof(SMBIOS_TABLE_STRING);
+  if (PcdSmbiosRecord->ContainedElementCount >= 1) {
+    SmbiosRecord->Hdr.Length += PcdSmbiosRecord->ContainedElementCount * PcdSmbiosRecord->ContainedElementRecordLength;
+  }
+  SmbiosRecord->Hdr.Handle = 0;
+
+  if ((PcdSmbiosRecord->ContainedElementCount == 0) || (SourceSize < (UINTN)SmbiosRecord + SmbiosRecord->Hdr.Length)) {
+    SKUNumberPtr = (SMBIOS_TABLE_STRING *)((UINTN)SmbiosRecord + SmbiosRecord->Hdr.Length - sizeof(SMBIOS_TABLE_STRING));
+    *SKUNumberPtr = 5;
+  }
+
+  StringOffset = SmbiosRecord->Hdr.Length;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, ManufacturerStr, ManuStrLen);
+  StringOffset += ManuStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, VersionStr, VerStrLen);
+  StringOffset += VerStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, SerialNumberStr, SerialNumStrLen);
+  StringOffset += SerialNumStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, AssertTagStr, AssertTagStrLen);
+  StringOffset += AssertTagStrLen + 1;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, SKUNumberStr, SKUNumberStrLen);
+
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool(SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type40AdditionalInformationFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type40AdditionalInformationFunction.c
@@ -1,0 +1,69 @@
+/** @file
+  Smbios type 40.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  Additional Information (Type 40).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+AdditionalInformationFunction(
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+)
+{
+  EFI_STATUS                  Status;  
+  CHAR8                       *EntryStr;
+  UINTN                       EntryStrLen; 
+  SMBIOS_TABLE_TYPE40         *PcdSmbiosRecord;
+  SMBIOS_TABLE_TYPE40         *SmbiosRecord;
+  EFI_SMBIOS_HANDLE           SmbiosHandle;
+  UINTN                       SourceSize;
+  UINTN                       TotalSize;
+  UINTN                       StringOffset;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType40AdditionalInformation);
+  
+  //
+  // Get Slot Designation String.
+  //
+  EntryStr = PcdGetPtr (PcdSmbiosType40StringEntryString);
+  EntryStrLen = AsciiStrLen (EntryStr);
+  ASSERT (EntryStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Allocate space for the record
+  //
+  SourceSize = PcdGetSize (PcdSmbiosType40AdditionalInformation);
+  TotalSize = SourceSize + EntryStrLen + 1 + 1;
+  SmbiosRecord = AllocateZeroPool(TotalSize);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, SourceSize);
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_ADDITIONAL_INFORMATION;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE40);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  StringOffset = SmbiosRecord->Hdr.Length;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, EntryStr, EntryStrLen);
+
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool (SmbiosRecord);
+  return Status;
+} 

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type42ManagementControllerHostInterfaceFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type42ManagementControllerHostInterfaceFunction.c
@@ -1,0 +1,52 @@
+/** @file
+  Smbios type 42.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  ManagementControllerHostInterface (Type 42).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+ManagementControllerHostInterfaceFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  SMBIOS_TABLE_TYPE42                 *SmbiosRecord;
+  SMBIOS_TABLE_TYPE42                 *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType42ManagementControllerHostInterface);
+
+  SmbiosRecord = AllocateZeroPool(sizeof (SMBIOS_TABLE_TYPE42) + 1 + 1);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, sizeof(SMBIOS_TABLE_TYPE42));
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_MANAGEMENT_CONTROLLER_HOST_INTERFACE;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE42);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type44ProcessorAdditionalInformationFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type44ProcessorAdditionalInformationFunction.c
@@ -1,0 +1,58 @@
+/** @file
+  Smbios type 44.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  Processor Additional Information (Type 44).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+ProcessorAdditionalInformationFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  SMBIOS_TABLE_TYPE44                 *SmbiosRecord;
+  SMBIOS_TABLE_TYPE44                 *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+  UINTN                               TableSize;   
+  
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType44ProcessorAdditionalInformation);
+
+    //
+    // Create table size based on string lengths
+    //
+    TableSize = sizeof (SMBIOS_TABLE_TYPE44) + 1 + 1;
+    SmbiosRecord = AllocateZeroPool (TableSize);
+    if (SmbiosRecord == NULL) {
+        ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+        return EFI_OUT_OF_RESOURCES;
+    }
+
+    //
+    // Fill in type 44 fields
+    //
+    SmbiosRecord->Hdr.Type = SMBIOS_TYPE_PROCESSOR_ADDITIONAL_INFORMATION;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE44);
+    SmbiosRecord->Hdr.Handle = 0;
+
+    //
+    // Full smbios record, call smbios protocol to add this record.
+    //
+    Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+    
+    FreePool (SmbiosRecord);
+    return Status;
+}    

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type4ProcessorInformationFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type4ProcessorInformationFunction.c
@@ -1,0 +1,133 @@
+/** @file
+  Smbios type 4.
+
+  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  Processor Information (Type 4).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+ProcessorInformationFunction(
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+)
+{
+    EFI_STATUS                  Status;
+    CHAR8                       *SocketStr;
+    CHAR8                       *ProcessorManufacturerStr;
+    CHAR8                       *ProcessorVersionStr;
+    CHAR8                       *SerialNumberStr;
+    CHAR8                       *AssetTagStr;
+    CHAR8                       *PartNumberStr;
+    UINTN                       SocketStrLen;
+    UINTN                       ProcessorManufacturerStrLen;
+    UINTN                       ProcessorVersionStrLen;
+    UINTN                       SerialNumberStrLen;
+    UINTN                       AssetTagStrLen;
+    UINTN                       PartNumberStrLen;         
+    SMBIOS_TABLE_TYPE4          *PcdSmbiosRecord;
+    SMBIOS_TABLE_TYPE4          *SmbiosRecord;
+    EFI_SMBIOS_HANDLE           SmbiosHandle;
+    UINTN                       StringOffset;
+    UINTN                       TableSize;
+
+
+    PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType4ProcessorInformation);
+
+    //
+    // Get board socket string
+    //
+    SocketStr = PcdGetPtr (PcdSmbiosType4StringSocket);
+    SocketStrLen = AsciiStrLen (SocketStr);
+    ASSERT (SocketStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+    //
+    // Get board processor manufacturer string
+    //
+    ProcessorManufacturerStr = PcdGetPtr (PcdSmbiosType4StringManufacturer);
+    ProcessorManufacturerStrLen = AsciiStrLen (ProcessorManufacturerStr);
+    ASSERT (ProcessorManufacturerStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+    //
+    // Get board processor version string
+    //
+    ProcessorVersionStr = PcdGetPtr (PcdSmbiosType4StringVersion);
+    ProcessorVersionStrLen = AsciiStrLen (ProcessorVersionStr);
+    ASSERT (ProcessorVersionStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+    //
+    // Get board processor serial number string
+    //
+    SerialNumberStr = PcdGetPtr (PcdSmbiosType4StringSerialNumber);
+    SerialNumberStrLen = AsciiStrLen (SerialNumberStr);
+    ASSERT (SerialNumberStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+    //
+    // Get board processor asset tag string
+    //
+    AssetTagStr = PcdGetPtr (PcdSmbiosType4StringAssetTag);
+    AssetTagStrLen = AsciiStrLen (AssetTagStr);
+    ASSERT (AssetTagStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+    //
+    // Get board part number string
+    //
+    PartNumberStr = PcdGetPtr (PcdSmbiosType4StringPartNumber);
+    PartNumberStrLen = AsciiStrLen (PartNumberStr);
+    ASSERT (PartNumberStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+    //
+    // Create table size based on string lengths
+    //
+    TableSize = sizeof (SMBIOS_TABLE_TYPE4) + SocketStrLen + 1 + ProcessorManufacturerStrLen + 1 + ProcessorVersionStrLen + 1 +  SerialNumberStrLen + 1 + AssetTagStrLen + 1 + PartNumberStrLen + 1 + 1;
+    SmbiosRecord = AllocateZeroPool (TableSize);
+    if (SmbiosRecord == NULL) {
+      ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    CopyMem (SmbiosRecord, PcdSmbiosRecord, sizeof(SMBIOS_TABLE_TYPE4));
+
+    //
+    // Fill in type 4 fields
+    //
+    SmbiosRecord->Hdr.Type = SMBIOS_TYPE_PROCESSOR_INFORMATION;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE4);
+    SmbiosRecord->Hdr.Handle = 0;
+
+    //
+    // Add strings to bottom of data block
+    //
+    StringOffset = SmbiosRecord->Hdr.Length;
+    CopyMem ((UINT8 *)SmbiosRecord + StringOffset, SocketStr, SocketStrLen);
+    StringOffset += SocketStrLen + 1;
+    CopyMem ((UINT8 *)SmbiosRecord + StringOffset, ProcessorManufacturerStr, ProcessorManufacturerStrLen);
+    StringOffset += ProcessorManufacturerStrLen + 1;
+    CopyMem ((UINT8 *)SmbiosRecord + StringOffset, ProcessorVersionStr, ProcessorVersionStrLen);
+    StringOffset += ProcessorVersionStrLen + 1;
+    CopyMem ((UINT8 *)SmbiosRecord + StringOffset, SerialNumberStr, SerialNumberStrLen);
+    StringOffset += SerialNumberStrLen + 1;
+    CopyMem ((UINT8 *)SmbiosRecord + StringOffset, AssetTagStr, AssetTagStrLen);
+    StringOffset += AssetTagStrLen + 1;
+    CopyMem ((UINT8 *)SmbiosRecord + StringOffset, PartNumberStr, PartNumberStrLen);
+    StringOffset += PartNumberStrLen + 1;
+
+    //
+    // Full smbios record, call smbios protocol to add this record.
+    //
+    Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+    
+    FreePool (SmbiosRecord);
+    return Status; 
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type5MemoryControllerFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type5MemoryControllerFunction.c
@@ -1,0 +1,52 @@
+/** @file
+  Smbios type 5.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  MemoryController (Type 5).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+MemoryControllerFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  SMBIOS_TABLE_TYPE5                  *SmbiosRecord;
+  SMBIOS_TABLE_TYPE5                  *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType5MemoryController);
+
+  SmbiosRecord = AllocateZeroPool(sizeof (SMBIOS_TABLE_TYPE5) + 1 + 1);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, sizeof(SMBIOS_TABLE_TYPE5));
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_MEMORY_CONTROLLER_INFORMATION;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE5);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type7CacheInformationFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type7CacheInformationFunction.c
@@ -1,0 +1,76 @@
+/** @file
+  Smbios type 7.
+
+  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  CPU Cache (Type 7).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+CacheInformationFunction(
+    IN  EFI_SMBIOS_PROTOCOL   *Smbios
+)
+{
+    EFI_STATUS                  Status;
+    CHAR8                       *SocketDesignationStr;       
+    UINTN                       SocketDesignationStrLen;             
+    UINTN                       StringOffset;
+    UINTN                       TableSize;
+    SMBIOS_TABLE_TYPE7          *SmbiosRecord;
+    SMBIOS_TABLE_TYPE7          *PcdSmbiosRecord;  
+    EFI_SMBIOS_HANDLE           SmbiosHandle; 
+
+    PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType7CacheInformation);
+
+    //
+    // Get board socket designation string
+    //
+    SocketDesignationStr = PcdGetPtr (PcdSmbiosType7StringSocketDesignation);
+    SocketDesignationStrLen = AsciiStrLen (SocketDesignationStr);
+    ASSERT (SocketDesignationStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+    //
+    // Create table size based on string lengths
+    //
+    TableSize = sizeof (SMBIOS_TABLE_TYPE7) + SocketDesignationStrLen + 1 + 1;
+    SmbiosRecord = AllocateZeroPool (TableSize);
+    if (SmbiosRecord == NULL) {
+      ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    CopyMem (SmbiosRecord, PcdSmbiosRecord, sizeof(SMBIOS_TABLE_TYPE7));
+
+    //
+    // Fill in type 7 fields
+    //
+    SmbiosRecord->Hdr.Type = SMBIOS_TYPE_CACHE_INFORMATION;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE7);
+    SmbiosRecord->Hdr.Handle = 0;
+
+    //
+    // Add strings to bottom of data block
+    //
+    StringOffset = SmbiosRecord->Hdr.Length;
+    CopyMem ((UINT8 *)SmbiosRecord + StringOffset, SocketDesignationStr, SocketDesignationStrLen);
+
+    //
+    // Full smbios record, call smbios protocol to add this record.
+    //
+    Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+    
+    FreePool (SmbiosRecord);
+    return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type9SystemSlotsFunction.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosBasicDxe/Type9SystemSlotsFunction.c
@@ -1,0 +1,72 @@
+/** @file
+  Smbios type 9.
+
+Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosBasic.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  SlotFunction (Type 9).
+
+  @retval EFI_SUCCESS                All parameters were valid.
+  @retval EFI_UNSUPPORTED            Unexpected RecordType value.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+
+**/
+EFI_STATUS
+EFIAPI
+SystemSlotsFunction(
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios
+  )
+{
+  EFI_STATUS                          Status;
+  CHAR8                               *SlotDesignationStr;
+  UINTN                               SlotDesignationStrLen;
+  SMBIOS_TABLE_TYPE9                  *SmbiosRecord;
+  SMBIOS_TABLE_TYPE9                  *PcdSmbiosRecord;
+  EFI_SMBIOS_HANDLE                   SmbiosHandle;
+  UINTN                               SourceSize;
+  UINTN                               TotalSize;
+  UINTN                               StringOffset;
+
+  PcdSmbiosRecord = PcdGetPtr (PcdSmbiosType9SystemSlots);
+
+  //
+  // Get Slot Designation String.
+  //
+  SlotDesignationStr = PcdGetPtr (PcdSmbiosType9StringSlotDesignation);
+  SlotDesignationStrLen = AsciiStrLen (SlotDesignationStr);
+  ASSERT (SlotDesignationStrLen <= SMBIOS_STRING_MAX_LENGTH);
+
+  //
+  // Allocate space for the record
+  //
+  SourceSize = PcdGetSize (PcdSmbiosType9SystemSlots);
+  TotalSize = SourceSize + SlotDesignationStrLen + 1 + 1;
+  SmbiosRecord = AllocateZeroPool(TotalSize);
+  if (SmbiosRecord == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Copy the data to the table
+  //
+  CopyMem (SmbiosRecord, PcdSmbiosRecord, SourceSize);
+
+  SmbiosRecord->Hdr.Type = SMBIOS_TYPE_SYSTEM_SLOTS;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE9);
+  SmbiosRecord->Hdr.Handle = 0;
+
+  StringOffset = SmbiosRecord->Hdr.Length;
+  CopyMem ((UINT8 *)SmbiosRecord + StringOffset, SlotDesignationStr, SlotDesignationStrLen);
+  
+  Status = AddSmbiosRecord (Smbios, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *) SmbiosRecord);
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
@@ -1,0 +1,1190 @@
+## @file
+# This package provides advanced feature functionality for System Management BIOS (SMBIOS).
+# This package should only depend on EDK II Core packages, IntelSiliconPkg, and MinPlatformPkg.
+#
+# The DEC files are used by the utilities that parse DSC and
+# INF files to generate AutoGen.c and AutoGen.h files
+# for the build infrastructure.
+#
+# Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  DEC_SPECIFICATION = 0x00010017
+  PACKAGE_NAME      = SmbiosFeaturePkg
+  PACKAGE_GUID      = 8CCEE569-02AD-4844-8725-F4C7966E320A
+  PACKAGE_VERSION   = 0.1
+
+[Includes]
+  Include
+
+[LibraryClasses]
+
+[Guids]
+  gSmbiosFeaturePkgTokenSpaceGuid  =  {0xc1530658, 0xe234, 0x4c13, {0xb6, 0x82, 0xd3, 0x87, 0x84, 0xf1, 0xd7, 0x16}}
+
+[PcdsFeatureFlag]
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosFeatureEnable|FALSE|BOOLEAN|0xA0000001
+
+[PcdsDynamic, PcdsDynamicEx]
+  #
+  # SMBIOS Type 0 BIOS Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation|{0x0}|SMBIOS_TABLE_TYPE0|0xD0000001 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.Vendor|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosVersion|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosSegment|0xF000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosReleaseDate|0x3
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosSize|0xFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.PciIsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.PlugAndPlayIsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.BiosIsUpgradable|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.BiosShadowingAllowed|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.BootFromCdIsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.SelectableBootIsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.EDDSpecificationIsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.Floppy525_12IsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.Floppy35_720IsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.Floppy35_288IsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.PrintScreenIsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.Keyboard8042IsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.SerialIsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.PrinterIsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BiosCharacteristics.CgaMonoIsSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BIOSCharacteristicsExtensionBytes[0]|0x33
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.BIOSCharacteristicsExtensionBytes[1]|0x0F
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.SystemBiosMajorRelease|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.SystemBiosMinorRelease|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.EmbeddedControllerFirmwareMajorRelease|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.EmbeddedControllerFirmwareMinorRelease|0x0
+  #
+  # SMBIOS Type 0 BIOS Information Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0StringBiosReleaseDate|"01/01/2019"|VOID*|0xD1000001
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0StringBiosVersion|"1.0"|VOID*|0xD1000002
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType0StringVendor|"BIOS Vendor"|VOID*|0xD1000003
+
+  #
+  # SMBIOS Type 1 System Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1SystemInformation|{0x0}|SMBIOS_TABLE_TYPE1|0xD0000002 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1SystemInformation.Manufacturer|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1SystemInformation.ProductName|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1SystemInformation.Version|0x3
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1SystemInformation.SerialNumber|0x4
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1SystemInformation.Uuid|{GUID("88888888-8887-8888-8888-878888888888")}
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1SystemInformation.WakeUpType|SystemWakeupTypePowerSwitch
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1SystemInformation.SKUNumber|0x5
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1SystemInformation.Family|0x6
+  #
+  # SMBIOS Type 1 System Information Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1StringFamily|"System Family"|VOID*|0xD1000004
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1StringManufacturer|"System Manufacturer"|VOID*|0xD1000005
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1StringProductName|"System Product Name"|VOID*|0xD1000006
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1StringSerialNumber|"UNKNOWN"|VOID*|0xD1000007
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1StringSKUNumber|"System SKU Number"|VOID*|0xD1000008
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1StringVersion|"System Version"|VOID*|0xD1000009
+
+  #
+  # SMBIOS Type 2 Base Board Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2BaseBoardInformation|{0x0}|SMBIOS_TABLE_TYPE2|0xD0000003 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2BaseBoardInformation.Manufacturer|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2BaseBoardInformation.ProductName|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2BaseBoardInformation.Version|0x3
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2BaseBoardInformation.SerialNumber|0x4
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2BaseBoardInformation.AssetTag|0x5
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2BaseBoardInformation.FeatureFlag.Motherboard|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2BaseBoardInformation.FeatureFlag.Replaceable|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2BaseBoardInformation.LocationInChassis|0x6
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2BaseBoardInformation.BoardType|BaseBoardTypeMotherBoard
+  #
+  # SMBIOS Type 2 Base Board Information Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2StringAssetTag|"Base Board Asset Tag"|VOID*|0xD100000A
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2StringLocationInChassis|"Part Component"|VOID*|0xD100000B
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2StringManufacturer|"Base Board Manufacturer"|VOID*|0xD100000C
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2StringProductName|"Base Board Product Name"|VOID*|0xD100000D
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2StringSerialNumber|"UNKNOWN"|VOID*|0xD100000E
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType2StringVersion|"Base Board Version"|VOID*|0xD100000F
+
+  #
+  # SMBIOS Type 3 System Enclosure Chassis
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3SystemEnclosureChassis|{0x0}|SMBIOS_TABLE_TYPE3|0xD0000004 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3SystemEnclosureChassis.Manufacturer|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3SystemEnclosureChassis.Type|MiscChassisTypeRackMountChassis
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3SystemEnclosureChassis.Version|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3SystemEnclosureChassis.SerialNumber|0x3
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3SystemEnclosureChassis.AssetTag|0x4
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3SystemEnclosureChassis.BootupState|ChassisStateSafe
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3SystemEnclosureChassis.PowerSupplyState|ChassisStateSafe
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3SystemEnclosureChassis.ThermalState|ChassisStateSafe
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3SystemEnclosureChassis.SecurityStatus|ChassisSecurityStatusNone
+  #
+  # SMBIOS Type 3 System Enclosure Chassis Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3StringAssetTag|"Chassis Asset Tag"|VOID*|0xD1000010
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3StringManufacturer|"Chassis Manufacturer"|VOID*|0xD1000011
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3StringSerialNumber|"UNKNOWN"|VOID*|0xD1000012
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3StringSKUNumber|"Chassis SKU Number"|VOID*|0xD1000013
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType3StringVersion|"Chassis Version"|VOID*|0xD1000014
+
+  #
+  # SMBIOS Type 4 Processor Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation|{0x0}|SMBIOS_TABLE_TYPE4|0xD0000005 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.Socket|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorType|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorFamily|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorManufacturer|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.Signature.ProcessorSteppingId|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.Signature.ProcessorModel|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.Signature.ProcessorFamily|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.Signature.ProcessorType|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.Signature.ProcessorReserved1|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.Signature.ProcessorXModel|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.Signature.ProcessorXFamily|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.Signature.ProcessorReserved2|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorFpu|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorVme|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorDe|0       
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorPse|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorTsc|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorMsr|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorPae|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorMce|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorCx8|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorApic|0     
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorReserved1|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorSep|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorMtrr|0     
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorPge|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorMca|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorCmov|0     
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorPat|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorPse36|0    
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorPsn|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorClfsh|0    
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorReserved2|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorDs|0       
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorAcpi|0     
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorMmx|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorFxsr|0     
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorSse|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorSse2|0     
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorSs|0       
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorReserved3|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorId.FeatureFlags.ProcessorTm|0       
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorVersion|0x3
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.Voltage.ProcessorVoltageCapability5V|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.Voltage.ProcessorVoltageCapability3_3V|0    
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.Voltage.ProcessorVoltageCapability2_9V|0    
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.Voltage.ProcessorVoltageCapabilityReserved|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.Voltage.ProcessorVoltageIndicateLegacy|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ExternalClock|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.MaxSpeed|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.CurrentSpeed|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.Status|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.ProcessorUpgrade|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.L1CacheHandle|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.L2CacheHandle|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.L3CacheHandle|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.SerialNumber|0x4
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.AssetTag|0x5
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4ProcessorInformation.PartNumber|0x6
+  #
+  # SMBIOS Type 4 Processor Information Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4StringSocket|"Processor Socket"|VOID*|0xD1000015
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4StringManufacturer|"Processor Manufacturer"|VOID*|0xD1000016
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4StringVersion|"Processor Version"|VOID*|0xD1000017
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4StringSerialNumber|"Serial Number"|VOID*|0xD1000018
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4StringAssetTag|"Asset Tag"|VOID*|0xD1000019
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType4StringPartNumber|"Part Number"|VOID*|0xD100001A
+
+  #
+  # SMBIOS Type 5 Memory Controller
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController|{0x0}|SMBIOS_TABLE_TYPE5|0xD0000006 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.ErrDetectMethod|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.ErrCorrectCapability.Other|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.ErrCorrectCapability.Unknown|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.ErrCorrectCapability.None|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.ErrCorrectCapability.SingleBitErrorCorrect|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.ErrCorrectCapability.DoubleBitErrorCorrect|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.ErrCorrectCapability.ErrorScrubbing|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.SupportInterleave|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.CurrentInterleave|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.MaxMemoryModuleSize|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.SupportSpeed.Other|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.SupportSpeed.Unknown|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.SupportSpeed.SeventyNs|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.SupportSpeed.SixtyNs|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.SupportSpeed.FiftyNs|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.SupportMemoryType|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.MemoryModuleVoltage|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.AssociatedMemorySlotNum|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType5MemoryController.MemoryModuleConfigHandles[0]|0x1
+
+  #
+  # SMBIOS Type 6 Memory Module Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation|{0x0}|SMBIOS_TABLE_TYPE6|0xD0000007 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.BankConnections|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentSpeed|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.ErrorStatus|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentMemoryType.Other|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentMemoryType.Unknown|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentMemoryType.Standard|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentMemoryType.FastPageMode|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentMemoryType.Edo|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentMemoryType.Parity|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentMemoryType.Ecc|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentMemoryType.Simm|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentMemoryType.Dimm|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentMemoryType.BurstEdo|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentMemoryType.Sdram|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.CurrentMemoryType.Reserved|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.InstalledSize.InstalledOrEnabledSize|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.InstalledSize.SingleOrDoubleBank|0  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.EnabledSize.InstalledOrEnabledSize|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6MemoryModuleInformation.EnabledSize.SingleOrDoubleBank|0
+  #
+  # SMBIOS Type 6 Memory Module Information Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType6StringSocketDesignation|"Socket Designation"|VOID*|0xD100001B
+
+  #
+  # SMBIOS Type 7 Cache Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation|{0x0}|SMBIOS_TABLE_TYPE7|0xD0000008 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.CacheConfiguration|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.MaximumCacheSize|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.InstalledSize|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.SupportedSRAMType.Other|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.SupportedSRAMType.Unknown|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.SupportedSRAMType.NonBurst|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.SupportedSRAMType.Burst|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.SupportedSRAMType.PipelineBurst|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.SupportedSRAMType.Synchronous|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.SupportedSRAMType.Asynchronous|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.SupportedSRAMType.Reserved|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.CurrentSRAMType.Other|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.CurrentSRAMType.Unknown|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.CurrentSRAMType.NonBurst|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.CurrentSRAMType.Burst|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.CurrentSRAMType.PipelineBurst|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.CurrentSRAMType.Synchronous|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.CurrentSRAMType.Asynchronous|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.CurrentSRAMType.Reserved|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.CacheSpeed|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.ErrorCorrectionType|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.SystemCacheType|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.Associativity|0x0      
+  # Add for smbios 3.1.0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.MaximumCacheSize2|0xFFFF     
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7CacheInformation.InstalledSize2|0xFFFF   
+  #
+  # SMBIOS Type 7 Cache Information Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType7StringSocketDesignation|"Socket Designation"|VOID*|0xD100001C
+
+
+
+  #
+  # SMBIOS Type 8 Port Connector Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType8PortConnectorInformation|{0x0}|SMBIOS_TABLE_TYPE8|0xD0000009 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType8PortConnectorInformation.InternalReferenceDesignator|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType8PortConnectorInformation.InternalConnectorType|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType8PortConnectorInformation.ExternalReferenceDesignator|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType8PortConnectorInformation.ExternalConnectorType|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType8PortConnectorInformation.PortType|0x1
+  #
+  # SMBIOS Type 8 Port Connector Information Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType8StringInternalReferenceDesignator|"Port Internal Reference Designator"|VOID*|0xD100001D
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType8StringExternalReferenceDesignator|"Port External Reference Designator"|VOID*|0xD100001E
+
+  #
+  # SMBIOS Type 9 System Slots
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots|{0x0}|SMBIOS_TABLE_TYPE9|0xD000000A {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotDesignation|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotType|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotDataBusWidth|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.CurrentUsage|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotLength|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotID|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotCharacteristics1.CharacteristicsUnknown|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotCharacteristics1.Provides50Volts|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotCharacteristics1.Provides33Volts|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotCharacteristics1.SharedSlot|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotCharacteristics1.PcCard16Supported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotCharacteristics1.CardBusSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotCharacteristics1.ZoomVideoSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotCharacteristics1.ModemRingResumeSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotCharacteristics2.PmeSignalSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotCharacteristics2.HotPlugDevicesSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotCharacteristics2.SmbusSignalSupported|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SlotCharacteristics2.BifurcationSupported|1
+  # Add for SMBIOS 2.6:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.SegmentGroupNum|0xFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.BusNum|0xFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.DevFuncNum|0xFF
+  # Add for SMBIOS 3.2:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.DataBusWidth|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.PeerGroupingCount|0x1
+  # MUSC_SLOT_PEER_GROUP:
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.PeerGroups[0].SegmentGroupNum|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.PeerGroups[0].BusNum|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.PeerGroups[0].DevFuncNum|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9SystemSlots.PeerGroups[0].DataBusWidth|0x1
+  #
+  # SMBIOS Type 9 System Slots Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType9StringSlotDesignation|"Desgnation of the slot"|VOID*|0xD100001F
+
+
+
+  #
+  # SMBIOS Type 10 On Board Devices Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType10OnBoardDevicesInformation|{0x0}|SMBIOS_TABLE_TYPE10|0xD000000B {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType10OnBoardDevicesInformation.Device[0].DeviceType|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType10OnBoardDevicesInformation.Device[0].DescriptionString|0x1
+  #
+  # SMBIOS Type 10 On Board Devices Information String
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType10StringDescriptionString|"Description String Content"|VOID*|0xD1000020
+
+
+
+  #
+  # SMBIOS Type 11 OEM Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType11OEMStrings|{0x0}|SMBIOS_TABLE_TYPE11|0xD000000C {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  #
+  # SMBIOS Type 11 OEM Strings Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType11StringCount|"String Count"|VOID*|0xD1000021
+
+
+
+
+  #
+  # SMBIOS Type 12 System Configuration Options
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType12SystemConfigurationOptions|{0x0}|SMBIOS_TABLE_TYPE12|0xD000000D {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  #
+  # SMBIOS Type 12 System Configuration Options Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType12StringCount|"String Count"|VOID*|0xD1000022
+
+  #
+  # SMBIOS Type 13 BIOS Language Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation|{0x0}|SMBIOS_TABLE_TYPE13|0xD000000E {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.InstallableLanguages|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Flags|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[0]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[1]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[2]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[3]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[4]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[5]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[6]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[7]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[8]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[9]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[10]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[11]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[12]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[13]|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13BiosLanguageInformation.Reserved[14]|0x0
+  #
+  # SMBIOS Type 13 BIOS Information Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType13StringCurrentLanguages|"en|US|iso8859-1"|VOID*|0xD1000023
+
+  #
+  # SMBIOS Type 14 Group Associations
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType14GroupAssociations|{0x0}|SMBIOS_TABLE_TYPE14|0xD000000F {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType14GroupAssociations.Group[0].ItemType|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType14GroupAssociations.Group[0].ItemHandle|0
+  #
+  # SMBIOS Type 14 BIOS Information Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType14StringGroupName|"Group Name"|VOID*|0xD1000024
+
+  #
+  # SMBIOS Type 15 System Event Log 
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog|{0x0}|SMBIOS_TABLE_TYPE15|0xD0000010 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog.LogAreaLength|0x00
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog.LogHeaderStartOffset|0x00
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog.LogDataStartOffset|0x00
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog.AccessMethod|0x00
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog.LogStatus|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog.LogChangeToken|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog.AccessMethodAddress|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog.LogHeaderFormat|0x00
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog.NumberOfSupportedLogTypeDescriptors|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog.LengthOfLogTypeDescriptor|0x2 
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType15SystemEventLog.NumberOfSupportedLogTypeDescriptors|0x00
+
+  #
+  # SMBIOS Type 16 Physical MemoryArray 
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType16PhysicalMemoryArray|{0x0}|SMBIOS_TABLE_TYPE16|0xD0000011 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType16PhysicalMemoryArray.Location|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType16PhysicalMemoryArray.Use|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType16PhysicalMemoryArray.MemoryErrorCorrection|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType16PhysicalMemoryArray.MaximumCapacity|0x80000000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType16PhysicalMemoryArray.MemoryErrorInformationHandle|0xFFFE
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType16PhysicalMemoryArray.NumberOfMemoryDevices|0
+  # Add for smbios 2.7
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType16PhysicalMemoryArray.ExtendedMaximumCapacity|0x80000000
+
+  #
+  # SMBIOS Type 17 Memory Device
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice|{0x0}|SMBIOS_TABLE_TYPE17|0xD0000012 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemoryArrayHandle|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemoryErrorInformationHandle|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TotalWidth|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.DataWidth|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.Size|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.FormFactor|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.DeviceSet|0xFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemoryType|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.Reserved|0    
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.Other|0       
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.Unknown|1     
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.FastPaged|0   
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.StaticColumn|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.PseudoStatic|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.Rambus|0      
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.Synchronous|0 
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.Cmos|0        
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.Edo|0         
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.WindowDram|0  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.CacheDram|0   
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.Nonvolatile|0 
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.Registered|0  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.Unbuffered|0  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.TypeDetail.LrDimm|0     
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.Speed|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.Attributes|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.ExtendedSize|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.ConfiguredMemoryClockSpeed|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MinimumVoltage|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MaximumVoltage|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.ConfiguredVoltage|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemoryTechnology|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemoryOperatingModeCapability.Bits.Reserved|0                       
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemoryOperatingModeCapability.Bits.Other|0                          
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemoryOperatingModeCapability.Bits.Unknown|1                        
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemoryOperatingModeCapability.Bits.VolatileMemory|0                 
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemoryOperatingModeCapability.Bits.ByteAccessiblePersistentMemory|0 
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemoryOperatingModeCapability.Bits.BlockAccessiblePersistentMemory|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemoryOperatingModeCapability.Bits.Reserved2|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemoryOperatingModeCapability.Uint16|0x4
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.ModuleManufacturerID|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.ModuleProductID|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemorySubsystemControllerManufacturerID|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.MemorySubsystemControllerProductID|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.NonVolatileSize|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.VolatileSize|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.CacheSize|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.LogicalSize|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.ExtendedSpeed|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.ExtendedConfiguredMemorySpeed|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.DeviceLocator|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.BankLocator|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.Manufacturer|0x3
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.SerialNumber|0x4
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.AssetTag|0x5
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.PartNumber|0x6
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17MemoryDevice.FirmwareVersion|0x7
+  #
+  # SMBIOS Type 17 Memory Device Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringDeviceLocator|"Unknown String"|VOID*|0xD1000025
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringBankLocator|"Unknown String"|VOID*|0xD1000026
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringManufacturer|"Unknown String"|VOID*|0xD1000027
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringSerialNumber|"Unknown String"|VOID*|0xD1000028
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringAssetTag|"Unknown String"|VOID*|0xD1000029
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringPartNumber|"Unknown String"|VOID*|0xD100002A
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType17StringFirmwareVersion|"Unknown String"|VOID*|0xD100002B
+
+  #
+  # SMBIOS Type 18 32-bit Memory Error Information 
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1832bitMemoryErrorInformation|{0x0}|SMBIOS_TABLE_TYPE18|0xD0000013 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1832bitMemoryErrorInformation.ErrorType|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1832bitMemoryErrorInformation.ErrorGranularity|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1832bitMemoryErrorInformation.ErrorOperation|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1832bitMemoryErrorInformation.VendorSyndrome|0xFFFFFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1832bitMemoryErrorInformation.MemoryArrayErrorAddress|0xFFFFFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1832bitMemoryErrorInformation.DeviceErrorAddress|0xFFFFFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType1832bitMemoryErrorInformation.ErrorResolution|0xFFFFFFFF
+
+  #
+  # SMBIOS Type 19 Memory Array Mapped Address
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType19MemoryArrayMappedAddress|{0x0}|SMBIOS_TABLE_TYPE19|0xD0000014 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType19MemoryArrayMappedAddress.StartingAddress|0xFFFFFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType19MemoryArrayMappedAddress.EndingAddress|0xFFFFFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType19MemoryArrayMappedAddress.MemoryArrayHandle|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType19MemoryArrayMappedAddress.PartitionWidth|0x0
+  # Add for smbios 2.7
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType19MemoryArrayMappedAddress.ExtendedStartingAddress|0xFFFFFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType19MemoryArrayMappedAddress.ExtendedEndingAddress|0xFFFFFFFF
+
+  #
+  # SMBIOS Type 20 Memory Device Mapped Address
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType20MemoryDeviceMappedAddress|{0x0}|SMBIOS_TABLE_TYPE20|0xD0000015 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType20MemoryDeviceMappedAddress.StartingAddress|0xFFFFFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType20MemoryDeviceMappedAddress.EndingAddress|0xFFFFFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType20MemoryDeviceMappedAddress.MemoryDeviceHandle|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType20MemoryDeviceMappedAddress.MemoryArrayMappedAddressHandle|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType20MemoryDeviceMappedAddress.PartitionRowPosition|0xFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType20MemoryDeviceMappedAddress.InterleavePosition|0xFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType20MemoryDeviceMappedAddress.InterleavedDataDepth|0xFF
+  # Add for smbios 2.7
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType20MemoryDeviceMappedAddress.ExtendedStartingAddress|0xFFFFFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType20MemoryDeviceMappedAddress.ExtendedEndingAddress|0xFFFFFFFF
+
+  #
+  # SMBIOS Type 21 Pointing Device
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType21PointingDevice|{0x0}|SMBIOS_TABLE_TYPE21|0xD0000016 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType21PointingDevice.Type|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType21PointingDevice.Interface|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType21PointingDevice.NumberOfButtons|0x1
+
+  #
+  # SMBIOS Type 22 Portable Battery
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22PortableBattery|{0x0}|SMBIOS_TABLE_TYPE22|0xD0000017 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22PortableBattery.DeviceChemistry|0x00000000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22PortableBattery.DeviceCapacity|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22PortableBattery.DesignVoltage|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22PortableBattery.MaximumErrorInBatteryData|0x00000000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22PortableBattery.SBDSSerialNumber|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22PortableBattery.SBDSManufactureDate|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22PortableBattery.DesignCapacityMultiplier|0x00000000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22PortableBattery.OEMSpecific|0xFFFF
+  #
+  # SMBIOS Type 22 Portable Battery Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringLocation|"Location"|VOID*|0xD100002C
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringManufacturer|"Manufacturer"|VOID*|0xD100002D
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringManufactureDate|"Manufacture Date"|VOID*|0xD100002E
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringSerialNumber|"Serial Number"|VOID*|0xD100002F
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringDeviceName|"Device Name"|VOID*|0xD1000030
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringSBDSVersionNumber|"SBDS Version Number"|VOID*|0xD1000031
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType22StringSBDSDeviceChemistryStr|"SBDS Device Chemistry"|VOID*|0xD1000032
+
+  #
+  # SMBIOS Type 23 Hardware Security
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType23SystemReset|{0x0}|SMBIOS_TABLE_TYPE23|0xD0000018 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType23SystemReset.Capabilities|0x00000000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType23SystemReset.ResetCount|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType23SystemReset.ResetLimit|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType23SystemReset.TimerInterval|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType23SystemReset.Timeout|0xFFFF
+
+  #
+  # SMBIOS Type 24 Hardware Security
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType24HardwareSecurity|{0x0}|SMBIOS_TABLE_TYPE24|0xD0000019 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType24HardwareSecurity.HardwareSecuritySettings|0x00000000
+
+  #
+  # SMBIOS Type 25 System Power Controls
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType25SystemPowerControls|{0x0}|SMBIOS_TABLE_TYPE25|0xD000001A {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType25SystemPowerControls.NextScheduledPowerOnMonth|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType25SystemPowerControls.NextScheduledPowerOnDayOfMonth|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType25SystemPowerControls.NextScheduledPowerOnHour|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType25SystemPowerControls.NextScheduledPowerOnMinute|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType25SystemPowerControls.NextScheduledPowerOnSecond|0x1
+
+  #
+  # SMBIOS Type 26 Voltage Probe
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26VoltageProbe|{0x0}|SMBIOS_TABLE_TYPE26|0xD000001B {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26VoltageProbe.LocationAndStatus.VoltageProbeSite|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26VoltageProbe.LocationAndStatus.VoltageProbeStatus|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26VoltageProbe.MaximumValue|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26VoltageProbe.MinimumValue|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26VoltageProbe.Resolution|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26VoltageProbe.Tolerance|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26VoltageProbe.Accuracy|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26VoltageProbe.OEMDefined|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26VoltageProbe.NominalValue|0x8000
+  #
+  # SMBIOS Type 26 Voltage Probe Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType26StringDescription|"Description"|VOID*|0xD1000033
+
+  #
+  # SMBIOS Type 27 Cooling Device
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType27CoolingDevice|{0x0}|SMBIOS_TABLE_TYPE27|0xD000001C {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType27CoolingDevice.TemperatureProbeHandle|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType27CoolingDevice.DeviceTypeAndStatus.CoolingDevice|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType27CoolingDevice.DeviceTypeAndStatus.CoolingDeviceStatus|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType27CoolingDevice.CoolingUnitGroup|0x00 
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType27CoolingDevice.OEMDefined|0x0 
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType27CoolingDevice.NominalSpeed|0x8000  
+  #
+  # SMBIOS Type 27 Cooling Device Strings
+  #
+  # Add for smbios 2.7
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType27StringDescription|"Description"|VOID*|0xD1000034
+
+
+  #
+  # SMBIOS Type 28 Temperature Probe
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28TemperatureProbe|{0x0}|SMBIOS_TABLE_TYPE28|0xD000001D {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28TemperatureProbe.LocationAndStatus.TemperatureProbeSite|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28TemperatureProbe.LocationAndStatus.TemperatureProbeStatus|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28TemperatureProbe.MaximumValue|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28TemperatureProbe.MinimumValue|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28TemperatureProbe.Resolution|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28TemperatureProbe.Tolerance|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28TemperatureProbe.Accuracy|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28TemperatureProbe.OEMDefined|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28TemperatureProbe.NominalValue|0x8000
+  #
+  # SMBIOS Type 28 Temperature Probe Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType28StringDescription|"Description"|VOID*|0xD1000035
+
+  #
+  # SMBIOS Type 29 System Power Controls
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29ElectricalCurrentProbe|{0x0}|SMBIOS_TABLE_TYPE29|0xD000001E {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29ElectricalCurrentProbe.Description|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29ElectricalCurrentProbe.LocationAndStatus.ElectricalCurrentProbeSite|2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29ElectricalCurrentProbe.LocationAndStatus.ElectricalCurrentProbeStatus|2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29ElectricalCurrentProbe.MaximumValue|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29ElectricalCurrentProbe.MinimumValue|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29ElectricalCurrentProbe.Resolution|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29ElectricalCurrentProbe.Tolerance|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29ElectricalCurrentProbe.Accuracy|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29ElectricalCurrentProbe.OEMDefined|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29ElectricalCurrentProbe.NominalValue|0x8000
+  #
+  # SMBIOS Type 29 Electrical Current Probe Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType29StringDescription|"Unknown String"|VOID*|0xD1000036
+
+  #
+  # SMBIOS Type 30 Out-of-Band Remote Access
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType30OutOfBoundRemoteAccess|{0x0}|SMBIOS_TABLE_TYPE30|0xD000001F {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType30OutOfBoundRemoteAccess.Connections|0x0
+  #
+  # SMBIOS Type 30 Out-of-Band Remote Access String
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType30StringManufacturerName|"Manufacturer Name"|VOID*|0xD1000037
+
+  #
+  # SMBIOS Type 31 Boot Integrity Services (BIS) Entry Point
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType31BISEntryPoint|{0x0}|SMBIOS_TABLE_TYPE31|0xD0000020 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType31BISEntryPoint.Checksum|0x00
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType31BISEntryPoint.Reserved1|0x00
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType31BISEntryPoint.Reserved2|0x0000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType31BISEntryPoint.BisEntry16|0x00000000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType31BISEntryPoint.BisEntry32|0x00000000  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType31BISEntryPoint.Reserved3|0x0000000000000000  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType31BISEntryPoint.Reserved4|0x00000000
+
+  #
+  # SMBIOS Type 32 System Boot Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType32SystemBootInformation|{0x0}|SMBIOS_TABLE_TYPE32|0xD0000021 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType32SystemBootInformation.BootStatus|BootInformationStatusNoError
+
+  #
+  # SMBIOS Type 33 64-Bit Memory Error Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType33_64BitMemoryErrorInformation|{0x0}|SMBIOS_TABLE_TYPE33|0xD0000022 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType33_64BitMemoryErrorInformation.ErrorType|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType33_64BitMemoryErrorInformation.ErrorGranularity|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType33_64BitMemoryErrorInformation.ErrorOperation|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType33_64BitMemoryErrorInformation.VendorSyndrome|0x00000000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType33_64BitMemoryErrorInformation.MemoryArrayErrorAddress|0x8000000000000000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType33_64BitMemoryErrorInformation.DeviceErrorAddress|0x8000000000000000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType33_64BitMemoryErrorInformation.ErrorResolution|0x80000000
+
+  #
+  # SMBIOS Type 34 Management Device
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType34ManagementDevice|{0x0}|SMBIOS_TABLE_TYPE34|0xD0000023 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType34ManagementDevice.Description|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType34ManagementDevice.Type|0x2
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType34ManagementDevice.Address|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType34ManagementDevice.AddressType|0x2
+  #
+  # SMBIOS Type 34 Management Device Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType34StringDescription|"Unknown String"|VOID*|0xD1000038
+
+  #
+  # SMBIOS Type 35 Management Device Component
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType35ManagementDeviceComponent|{0x0}|SMBIOS_TABLE_TYPE35|0xD0000024 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType35ManagementDeviceComponent.Description|0x1  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType35ManagementDeviceComponent.ManagementDeviceHandle|0x0000  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType35ManagementDeviceComponent.ComponentHandle|0x0000  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType35ManagementDeviceComponent.ThresholdHandle|0xFFFF
+
+  #
+  # SMBIOS Type 35 Management Device Component Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType35StringDescription|"Unknown String"|VOID*|0xD1000039
+
+  #
+  # SMBIOS Type 36 Management Device Threshold Data
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType36ManagementDeviceThresholdData|{0x0}|SMBIOS_TABLE_TYPE36|0xD0000025 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType36ManagementDeviceThresholdData.LowerThresholdNonCritical|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType36ManagementDeviceThresholdData.UpperThresholdNonCritical|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType36ManagementDeviceThresholdData.LowerThresholdCritical|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType36ManagementDeviceThresholdData.UpperThresholdCritical|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType36ManagementDeviceThresholdData.LowerThresholdNonRecoverable|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType36ManagementDeviceThresholdData.UpperThresholdNonRecoverable|0x8000
+
+  #
+  # SMBIOS Type 37 Memory Channel Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType37MemoryChannelInformation|{0x0}|SMBIOS_TABLE_TYPE37|0xD0000026 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType37MemoryChannelInformation.ChannelType|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType37MemoryChannelInformation.MaximumChannelLoad|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType37MemoryChannelInformation.MemoryDeviceCount|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType37MemoryChannelInformation.MemoryDevice[0].DeviceLoad|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType37MemoryChannelInformation.MemoryDevice[0].DeviceHandle|0x01
+
+  #
+  # SMBIOS Type 38 IPMI Device Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType38PimiDeviceInformation|{0x0}|SMBIOS_TABLE_TYPE38|0xD0000027 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType38PimiDeviceInformation.InterfaceType|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType38PimiDeviceInformation.IPMISpecificationRevision|0x10
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType38PimiDeviceInformation.I2CSlaveAddress|0xFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType38PimiDeviceInformation.NVStorageDeviceAddress|0xFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType38PimiDeviceInformation.BaseAddress|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType38PimiDeviceInformation.BaseAddressModifier_InterruptInfo|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType38PimiDeviceInformation.InterruptNumber|0x0
+
+  #
+  # SMBIOS Type 39 System Power Supply
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply|{0x0}|SMBIOS_TABLE_TYPE39|0xD0000028 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply.PowerUnitGroup|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply.MaxPowerCapacity|0x8000
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply.PowerSupplyCharacteristics.PowerSupplyHotReplaceable|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply.PowerSupplyCharacteristics.PowerSupplyPresent|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply.PowerSupplyCharacteristics.PowerSupplyUnplugged|1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply.PowerSupplyCharacteristics.InputVoltageRangeSwitch|0001
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply.PowerSupplyCharacteristics.PowerSupplyStatus|001
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply.PowerSupplyCharacteristics.PowerSupplyType|0001
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply.PowerSupplyCharacteristics.Reserved|00
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply.InputVoltageProbeHandle|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply.CoolingDeviceHandle|0xFFFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SystemPowerSupply.InputCurrentProbeHandle|0xFFFF
+  #
+  # SMBIOS Type 39 System Power Supply String
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39StringLocation|"Location"|VOID*|0xD100003A
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39StringDeviceName|"Device Name"|VOID*|0xD100003B
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39Manufacturer|"Manufacturer"|VOID*|0xD100003C
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39SerialNumber|"Serial Number"|VOID*|0xD100003D
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39AssetTagNumber|"Tag Number"|VOID*|0xD100003E
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39ModelPartNumber|"Part Number"|VOID*|0xD100003F
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType39RevisionLevel|"Revision Level"|VOID*|0xD1000040
+
+  #
+  # SMBIOS Type 40 Additional Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType40AdditionalInformation|{0x0}|SMBIOS_TABLE_TYPE40|0xD0000029 {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType40AdditionalInformation.NumberOfAdditionalInformationEntries|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType40AdditionalInformation.AdditionalInfoEntries[0].EntryLength|0x6  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType40AdditionalInformation.AdditionalInfoEntries[0].ReferencedHandle|0x01  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType40AdditionalInformation.AdditionalInfoEntries[0].ReferencedOffset|0x0 
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType40AdditionalInformation.AdditionalInfoEntries[0].EntryString|0x1
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType40AdditionalInformation.AdditionalInfoEntries[0].Value[0]|0x0
+  #
+  # SMBIOS Type 40 Additional Information Strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType40StringEntryString|"Entry String Content"|VOID*|0xD1000041
+
+  #
+  # SMBIOS Type 41 Onboard devices extended information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType41OnboardDevicesExtendedInformation|{0x0}|SMBIOS_TABLE_TYPE41|0xD000002A {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType41OnboardDevicesExtendedInformation.DeviceType|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType41OnboardDevicesExtendedInformation.DeviceTypeInstance|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType41OnboardDevicesExtendedInformation.SegmentGroupNum|0x0FF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType41OnboardDevicesExtendedInformation.BusNum|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType41OnboardDevicesExtendedInformation.DevFuncNum|0
+  #
+  # SMBIOS Type 41 Onboard devices extended information strings
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType41StringReferenceDesignation|"Reference Designation"|VOID*|0xD1000042
+
+  #
+  # SMBIOS Type 42 Management Controller Host Interface
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType42ManagementControllerHostInterface|{0x0}|SMBIOS_TABLE_TYPE42|0xD000002B {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType42ManagementControllerHostInterface.InterfaceType|0xF0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType42ManagementControllerHostInterface.InterfaceTypeSpecificDataLength|0xFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType42ManagementControllerHostInterface.InterfaceTypeSpecificData[0]|0xF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType42ManagementControllerHostInterface.InterfaceTypeSpecificData[1]|0xF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType42ManagementControllerHostInterface.InterfaceTypeSpecificData[2]|0xF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType42ManagementControllerHostInterface.InterfaceTypeSpecificData[3]|0xF
+
+  #
+  # SMBIOS Type 43 TMP Device
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43TMPDevice|{0x0}|SMBIOS_TABLE_TYPE43|0xD000002C {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43TMPDevice.VendorID[0]|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43TMPDevice.VendorID[1]|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43TMPDevice.VendorID[2]|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43TMPDevice.VendorID[3]|0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43TMPDevice.MajorSpecVersion|0x02
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43TMPDevice.MinorSpecVersion|0x00
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43TMPDevice.FirmwareVersion1|0x01
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43TMPDevice.FirmwareVersion2|0x00
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43TMPDevice.Characteristics|0x0
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43TMPDevice.OemDefined|0x0
+  #
+  # SMBIOS Type 43 TMP DEVICE String
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType43StringDescription|"Description"|VOID*|0xD1000043
+
+  #
+  # SMBIOS Type 44 Processor Additional Information
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType44ProcessorAdditionalInformation|{0x0}|SMBIOS_TABLE_TYPE44|0xD000002D {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  }  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType44ProcessorAdditionalInformation.RefHandle|0xFF
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType44ProcessorAdditionalInformation.ProcessorSpecificBlock.Length|0x00  
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType44ProcessorAdditionalInformation.ProcessorSpecificBlock.ProcessorArchType|0x00
+
+  #
+  # SMBIOS Type 126 Inactive
+  #
+  gSmbiosFeaturePkgTokenSpaceGuid.PcdSmbiosType126Inactive|{0x0}|SMBIOS_TABLE_TYPE126|0xD000002E {
+    <HeaderFiles>
+      IndustryStandard/SmBios.h
+    <Packages>
+      MdePkg/MdePkg.dec
+      #SystemInformation/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+      WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dec
+  } 

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dsc
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/Features/SmbiosFeaturePkg/SmbiosFeaturePkg.dsc
@@ -1,0 +1,30 @@
+## @file
+# This package provides advanced feature functionality for System Management BIOS (SMBIOS).
+# This package should only depend on EDK II Core packages, IntelSiliconPkg, and MinPlatformPkg.
+#
+# The DEC files are used by the utilities that parse DSC and
+# INF files to generate AutoGen.c and AutoGen.h files
+# for the build infrastructure.
+#
+# Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  PLATFORM_NAME                  = SmbiosFeaturePkg
+  PLATFORM_GUID                  = 44AF1C2A-16AD-4509-8DF6-988E73E23A85
+  PLATFORM_VERSION               = 0.1
+  DSC_SPECIFICATION              = 0x00010005
+  OUTPUT_DIRECTORY               = Build/$(PLATFORM_NAME)
+  SUPPORTED_ARCHITECTURES        = IA32|X64
+  BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
+  SKUID_IDENTIFIER               = DEFAULT
+  PEI_ARCH                       = IA32
+  DXE_ARCH                       = X64
+
+#
+# This package always builds the feature.
+#
+!include Include/SmbiosFeature.dsc


### PR DESCRIPTION
implemented remaining function types with accompanying files from edk2-platforms/Features/Intel/SystemInformation/SmbiosFeaturePkg
The package is universal and can be used for any platform by modifying board-specific PCDs.

Changes to SmbiosBasicDxe.inf, SmbiosBasicEntryPoint.c, SmbiosFeaturePkg.dec,
and SmbiosFeaturePkg.dsc were done collectively by me (iatsbohdan) and ettorgri.

Signed-off-by: iatsbohdan <iatsbohdan@gmail.com>
Reviewed-by: ettorgri <etorgrimson@gmail.com>