### PR TITLE
Platform/SiFive: Add VariablePolicyHelperLib to the dsc files

### DIFF
--- a/Platform/SiFive/U5SeriesPkg/FreedomU500VC707Board/U500.dsc
+++ b/Platform/SiFive/U5SeriesPkg/FreedomU500VC707Board/U500.dsc
@@ -99,6 +99,7 @@
   SortLib|MdeModulePkg/Library/BaseSortLib/BaseSortLib.inf
   UefiBootManagerLib|MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
   FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf
+  VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
 
 # RISC-V Platform Library
   TimeBaseLib|EmbeddedPkg//Library/TimeBaseLib/TimeBaseLib.inf

--- a/Platform/SiFive/U5SeriesPkg/FreedomU540HiFiveUnleashedBoard/U540.dsc
+++ b/Platform/SiFive/U5SeriesPkg/FreedomU540HiFiveUnleashedBoard/U540.dsc
@@ -99,6 +99,7 @@
   SortLib|MdeModulePkg/Library/BaseSortLib/BaseSortLib.inf
   UefiBootManagerLib|MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
   FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf
+  VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
 
 # RISC-V Platform Library
   TimeBaseLib|EmbeddedPkg//Library/TimeBaseLib/TimeBaseLib.inf


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3489

Fix build error of U540 and U500 caused by BdsDxe.
The edk2 patch
 MdeModulePkg/BdsDxe: Update BdsEntry to use Variable Policy
requires VariablePolicyHelperLib, but U500.dsc and U540.dsc
didn't have it in the LibraryClasses section.

Cc: Abner Chang <abner.chang@hpe.com>
Cc: Gilbert Chen <gilbert.chen@hpe.com>
Cc: Daniel Schaefer <daniel.schaefer@hpe.com>
Signed-off-by: Takuto Naito <naitaku@gmail.com>
Reviewed-by: Abner Chang <abner.chang@hpe.com>