### PR TITLE
Qemu: SbsaQemu: Set the DSDT revision value to 2 to use 64-bit math

### DIFF
--- a/Silicon/Qemu/SbsaQemu/AcpiTables/Dsdt.asl
+++ b/Silicon/Qemu/SbsaQemu/AcpiTables/Dsdt.asl
@@ -6,6 +6,7 @@
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
+#include <IndustryStandard/Acpi60.h>
 #include <IndustryStandard/SbsaQemuAcpi.h>
 
 #define LINK_DEVICE(Uid, LinkName, Irq)                                        \
@@ -25,8 +26,9 @@
             Address, Pin, Link, Zero                                           \
           }
 
-DefinitionBlock ("DsdtTable.aml", "DSDT", 1, "LINARO", "SBSAQEMU",
-                 FixedPcdGet32 (PcdAcpiDefaultOemRevision)) {
+DefinitionBlock ("DsdtTable.aml", "DSDT",
+                 EFI_ACPI_6_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_REVISION,
+                 "LINARO", "SBSAQEMU", FixedPcdGet32 (PcdAcpiDefaultOemRevision)) {
   Scope (_SB) {
     // UART PL011
     Device (COM0) {


### PR DESCRIPTION
Set the DSDT revision value to 2 by using the define from Acpi60.h
EFI_ACPI_6_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_REVISION. This
causes the AML interpreter to use full 64-bit integers and math.

Signed-off-by: Rebecca Cran <rebecca@nuviainc.com>