### PR TITLE
RISC-V/RiscVExceptionLib: Follow new CpuExceptionHandlerLib APIs

### DIFF
--- a/Silicon/RISC-V/ProcessorPkg/Library/RiscVExceptionLib/CpuExceptionHandlerLib.c
+++ b/Silicon/RISC-V/ProcessorPkg/Library/RiscVExceptionLib/CpuExceptionHandlerLib.c
@@ -45,31 +45,6 @@ InitializeCpuExceptionHandlers (
 }
 
 /**
-  Initializes all CPU interrupt/exceptions entries and provides the default interrupt/exception handlers.
-
-  Caller should try to get an array of interrupt and/or exception vectors that are in use and need to
-  persist by EFI_VECTOR_HANDOFF_INFO defined in PI 1.3 specification.
-  If caller cannot get reserved vector list or it does not exists, set VectorInfo to NULL.
-  If VectorInfo is not NULL, the exception vectors will be initialized per vector attribute accordingly.
-
-  @param[in]  VectorInfo    Pointer to reserved vector list.
-
-  @retval EFI_SUCCESS           All CPU interrupt/exception entries have been successfully initialized
-                                with default interrupt/exception handlers.
-  @retval EFI_INVALID_PARAMETER VectorInfo includes the invalid content if VectorInfo is not NULL.
-  @retval EFI_UNSUPPORTED       This function is not supported.
-
-**/
-EFI_STATUS
-EFIAPI
-InitializeCpuInterruptHandlers (
-  IN EFI_VECTOR_HANDOFF_INFO  *VectorInfo OPTIONAL
-  )
-{
-  return EFI_SUCCESS;
-}
-
-/**
   Registers a function to be called from the processor interrupt handler.
 
   This function registers and enables the handler specified by InterruptHandler for a processor
@@ -135,39 +110,6 @@ RiscVSupervisorModeTrapHandler (
 }
 
 /**
-  Initializes all CPU exceptions entries with optional extra initializations.
-
-  By default, this method should include all functionalities implemented by
-  InitializeCpuExceptionHandlers(), plus extra initialization works, if any.
-  This could be done by calling InitializeCpuExceptionHandlers() directly
-  in this method besides the extra works.
-
-  InitData is optional and its use and content are processor arch dependent.
-  The typical usage of it is to convey resources which have to be reserved
-  elsewhere and are necessary for the extra initializations of exception.
-
-  @param[in]  VectorInfo    Pointer to reserved vector list.
-  @param[in]  InitData      Pointer to data optional for extra initializations
-                            of exception.
-
-  @retval EFI_SUCCESS             The exceptions have been successfully
-                                  initialized.
-  @retval EFI_INVALID_PARAMETER   VectorInfo or InitData contains invalid
-                                  content.
-  @retval EFI_UNSUPPORTED         This function is not supported.
-
-**/
-EFI_STATUS
-EFIAPI
-InitializeCpuExceptionHandlersEx (
-  IN EFI_VECTOR_HANDOFF_INFO  *VectorInfo OPTIONAL,
-  IN CPU_EXCEPTION_INIT_DATA  *InitData OPTIONAL
-  )
-{
-  return InitializeCpuExceptionHandlers (VectorInfo);
-}
-
-/**
   The constructor function to initial interrupt handlers in
   RISCV_MACHINE_MODE_CONTEXT.
 
@@ -190,5 +132,29 @@ CpuExceptionHandlerLibConstructor (
   //
   csr_write (CSR_STVEC, SupervisorModeTrap);
 
+  return EFI_SUCCESS;
+}
+
+/**
+  Setup separate stacks for certain exception handlers.
+  If the input Buffer and BufferSize are both NULL, use global variable if possible.
+
+  @param[in]       Buffer        Point to buffer used to separate exception stack.
+  @param[in, out]  BufferSize    On input, it indicates the byte size of Buffer.
+                                 If the size is not enough, the return status will
+                                 be EFI_BUFFER_TOO_SMALL, and output BufferSize
+                                 will be the size it needs.
+
+  @retval EFI_SUCCESS             The stacks are assigned successfully.
+  @retval EFI_UNSUPPORTED         This function is not supported.
+  @retval EFI_BUFFER_TOO_SMALL    This BufferSize is too small.
+**/
+EFI_STATUS
+EFIAPI
+InitializeSeparateExceptionStacks (
+  IN     VOID   *Buffer,
+  IN OUT UINTN  *BufferSize
+  )
+{
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
CpuExceptionHandlerLib (in EDK2) has been refactored with following changes
1. Removed InitializeCpuInterruptHandlers in 2a09527ebcb459b40
2. Removed InitializeCpuExceptionHandlersEx and
   added InitializeSeparateExceptionStacks in e7abb94d1fb8a0e7

The patch updates RISC-V version of CpuExceptionHandlerLib to follow
the API changes, based on the ARM changes in e2ae0bed29ca0900bd35.

The functionality to RISC-V platforms should be none.

Signed-off-by: Daniel Schaefer <daniel.schaefer@hpe.com>
Reviewed-by: Sunil V L <sunilvl@ventanamicro.com>