### PR TITLE
Platform/ARM: Update Morello and SgiPkg ARM_CORE_INFO clusters/cores

### DIFF
--- a/Platform/ARM/Morello/Library/PlatformLib/PlatformLib.c
+++ b/Platform/ARM/Morello/Library/PlatformLib/PlatformLib.c
@@ -10,10 +10,10 @@
 #include <Ppi/ArmMpCoreInfo.h>
 
 STATIC ARM_CORE_INFO mCoreInfoTable[] = {
-  { 0x0, 0x0 }, // Cluster 0, Core 0
-  { 0x0, 0x1 }, // Cluster 0, Core 1
-  { 0x1, 0x0 }, // Cluster 1, Core 0
-  { 0x1, 0x1 }  // Cluster 1, Core 1
+  { 0x000 }, // Cluster 0, Core 0
+  { 0x001 }, // Cluster 0, Core 1
+  { 0x100 }, // Cluster 1, Core 0
+  { 0x101 }  // Cluster 1, Core 1
 };
 
 /**

--- a/Platform/ARM/SgiPkg/Library/PlatformLib/PlatformLib.c
+++ b/Platform/ARM/SgiPkg/Library/PlatformLib/PlatformLib.c
@@ -20,7 +20,7 @@ STATIC SGI_NT_FW_CONFIG_INFO_PPI mNtFwConfigDtInfoPpi;
 STATIC ARM_CORE_INFO mCoreInfoTable[] = {
   {
     // Cluster 0, Core 0
-    0x0, 0x0,
+    0x000,
   },
 };
 


### PR DESCRIPTION
The ARM_CORE_INFO struct now has a single Mpidr field instead of separate ClusterId and CoreId fields. Update mCoreInfoTable in PlatformLib.c in Morello and SgiPkg.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>