### PR TITLE
Update simics board to work with latest edk2

### DIFF
--- a/Platform/Intel/SimicsOpenBoardPkg/AcpiTables/Dsdt.asl
+++ b/Platform/Intel/SimicsOpenBoardPkg/AcpiTables/Dsdt.asl
@@ -372,7 +372,7 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 1, "INTEL ", "SIMICS  ", 4) {
 
             Package () {0x000EFFFF, 0x00, 0, 16},
             Package () {0x000EFFFF, 0x01, 0, 17},
-            Package () {0x000EFFFF, 0x02, 0C, 18},
+            Package () {0x000EFFFF, 0x02, 0, 18},
             Package () {0x000EFFFF, 0x03, 0, 19},
 
             Package () {0x000FFFFF, 0x00, 0, 16},

--- a/Platform/Intel/SimicsOpenBoardPkg/BoardX58Ich10/OpenBoardPkgPcd.dsc
+++ b/Platform/Intel/SimicsOpenBoardPkg/BoardX58Ich10/OpenBoardPkgPcd.dsc
@@ -38,6 +38,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportUpdateCapsuleReset|FALSE
   gUefiCpuPkgTokenSpaceGuid.PcdCpuHotPlugSupport|FALSE
   gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmEnableBspElection|FALSE
+  gUefiCpuPkgTokenSpaceGuid.PcdSmmFeatureControlEnable|FALSE
 
   ######################################
   # Platform Configuration


### PR DESCRIPTION
Building the Simics QSP UEFI (and being able to run it) requires some minor updates to SimicsOpenBoardPkg:

- A bug fix in Dsdt.asl that was not found by older iasl versions
- Overriding a Pcd from base package (set to false), because the Simics platform does not have the MSRs guarded by the Pcd and having it "true" will trigger a GP fault due to accessing a non-existing MSR.