### PR TITLE
Platform/ARM: Update Morello and N1Sdp to use PrePeiCoreUniCore

### DIFF
--- a/Platform/ARM/Morello/MorelloPlatform.dsc.inc
+++ b/Platform/ARM/Morello/MorelloPlatform.dsc.inc
@@ -148,7 +148,7 @@
   # PEI Phase modules
   ArmPkg/Drivers/CpuPei/CpuPei.inf
   ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.inf
-  ArmPlatformPkg/PrePeiCore/PrePeiCoreMPCore.inf
+  ArmPlatformPkg/PrePeiCore/PrePeiCoreUniCore.inf
   ArmPlatformPkg/PlatformPei/PlatformPeim.inf
   MdeModulePkg/Core/Pei/PeiMain.inf
   MdeModulePkg/Universal/PCD/Pei/Pcd.inf {

--- a/Platform/ARM/Morello/MorelloPlatformFvp.fdf
+++ b/Platform/ARM/Morello/MorelloPlatformFvp.fdf
@@ -187,7 +187,7 @@ READ_LOCK_STATUS   = TRUE
   INF ArmPkg/Drivers/CpuPei/CpuPei.inf
   INF ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.inf
   INF ArmPlatformPkg/PlatformPei/PlatformPeim.inf
-  INF ArmPlatformPkg/PrePeiCore/PrePeiCoreMPCore.inf
+  INF ArmPlatformPkg/PrePeiCore/PrePeiCoreUniCore.inf
   INF MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
   INF MdeModulePkg/Core/Pei/PeiMain.inf
   INF MdeModulePkg/Universal/PCD/Pei/Pcd.inf

--- a/Platform/ARM/N1Sdp/N1SdpPlatform.dsc
+++ b/Platform/ARM/N1Sdp/N1SdpPlatform.dsc
@@ -176,7 +176,7 @@
   # PEI Phase modules
   ArmPkg/Drivers/CpuPei/CpuPei.inf
   ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.inf
-  ArmPlatformPkg/PrePeiCore/PrePeiCoreMPCore.inf
+  ArmPlatformPkg/PrePeiCore/PrePeiCoreUniCore.inf
   ArmPlatformPkg/PlatformPei/PlatformPeim.inf
   MdeModulePkg/Core/Pei/PeiMain.inf
   MdeModulePkg/Universal/PCD/Pei/Pcd.inf {

--- a/Platform/ARM/N1Sdp/N1SdpPlatform.fdf
+++ b/Platform/ARM/N1Sdp/N1SdpPlatform.fdf
@@ -190,7 +190,7 @@ READ_LOCK_STATUS   = TRUE
   INF ArmPkg/Drivers/CpuPei/CpuPei.inf
   INF ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.inf
   INF ArmPlatformPkg/PlatformPei/PlatformPeim.inf
-  INF ArmPlatformPkg/PrePeiCore/PrePeiCoreMPCore.inf
+  INF ArmPlatformPkg/PrePeiCore/PrePeiCoreUniCore.inf
   INF MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
   INF MdeModulePkg/Core/Pei/PeiMain.inf
   INF MdeModulePkg/Universal/PCD/Pei/Pcd.inf


### PR DESCRIPTION
Modern platforms that use TF-A should use PrePeiCoreUniCore, since any secondary cores will be put in the TF-A holding pen and won't reach EDK2.

Update the Morello and N1Sdp files to use PrePeiCoreUniCore instead of PrePeiCoreMPCore.

Signed-off-by: Rebecca Cran <rebecca@quicinc.com>