### PR TITLE
BoardBdsHookLib [Patch V2] GCC compiler fix + PCD based Uefi shell load

### DIFF
--- a/Platform/Intel/BoardModulePkg/Library/BoardBdsHookLib/BoardBdsHookLib.c
+++ b/Platform/Intel/BoardModulePkg/Library/BoardBdsHookLib/BoardBdsHookLib.c
@@ -3,6 +3,7 @@
   implementation instance of the BDS hook library
 
   Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -131,7 +132,7 @@ IsTrustedConsole (
 
   switch (ConsoleType) {
     case ConIn:
-      TrustedConsoleDevicepath = PcdGetPtr (PcdTrustedConsoleInputDevicePath);
+      TrustedConsoleDevicepath = DuplicateDevicePath (PcdGetPtr (PcdTrustedConsoleInputDevicePath));
       break;
     case ConOut:
       //
@@ -147,7 +148,7 @@ IsTrustedConsole (
         TempDevicePath = NextDevicePathNode (TempDevicePath);
       }
 
-      TrustedConsoleDevicepath = PcdGetPtr (PcdTrustedConsoleOutputDevicePath);
+      TrustedConsoleDevicepath = DuplicateDevicePath (PcdGetPtr (PcdTrustedConsoleOutputDevicePath));
       break;
     default:
       ASSERT (FALSE);
@@ -171,7 +172,9 @@ IsTrustedConsole (
   } while (TempDevicePath != NULL);
 
   FreePool (ConsoleDevice);
-
+  if (TrustedConsoleDevicepath != NULL) {
+    FreePool (TrustedConsoleDevicepath);
+  }
   return FALSE;
 }
 
@@ -624,7 +627,7 @@ ConnectTrustedStorage (
   EFI_STATUS                Status;
   EFI_HANDLE                DeviceHandle;
 
-  TrustedStorageDevicepath = PcdGetPtr (PcdTrustedStorageDevicePath);
+  TrustedStorageDevicepath = DuplicateDevicePath (PcdGetPtr (PcdTrustedStorageDevicePath));
   DumpDevicePath (L"TrustedStorage", TrustedStorageDevicepath);
 
   TempDevicePath = TrustedStorageDevicepath;
@@ -649,6 +652,9 @@ ConnectTrustedStorage (
 
     FreePool (Instance);
   } while (TempDevicePath != NULL);
+  if (TrustedStorageDevicepath != NULL) {
+    FreePool (TrustedStorageDevicepath);
+  }
 }
 
 
@@ -1031,7 +1037,7 @@ AddConsoleVariable (
   EFI_HANDLE                GraphicsControllerHandle;
   EFI_DEVICE_PATH           *GopDevicePath;
 
-  TempDevicePath = ConsoleDevicePath;
+  TempDevicePath = DuplicateDevicePath (ConsoleDevicePath);
   do {
     Instance = GetNextDevicePathInstance (&TempDevicePath, &Size);
     if (Instance == NULL) {
@@ -1074,6 +1080,9 @@ AddConsoleVariable (
 
     FreePool (Instance);
   } while (TempDevicePath != NULL);
+  if (TempDevicePath != NULL) {
+    FreePool (TempDevicePath);
+  }
 }
 
 

--- a/Platform/Intel/BoardModulePkg/Library/BoardBdsHookLib/BoardBdsHookLib.inf
+++ b/Platform/Intel/BoardModulePkg/Library/BoardBdsHookLib/BoardBdsHookLib.inf
@@ -2,6 +2,7 @@
 # Module Information file for the Bds Hook Library.
 #
 # Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -59,6 +60,8 @@
   gMinPlatformPkgTokenSpaceGuid.PcdTrustedConsoleInputDevicePath    ## CONSUMES
   gMinPlatformPkgTokenSpaceGuid.PcdTrustedConsoleOutputDevicePath   ## CONSUMES
   gMinPlatformPkgTokenSpaceGuid.PcdTrustedStorageDevicePath         ## CONSUMES
+  gMinPlatformPkgTokenSpaceGuid.PcdShellFile                        ## CONSUMES
+  gMinPlatformPkgTokenSpaceGuid.PcdShellFileDesc                    ## CONSUMES
 
 [Sources]
   BoardBdsHook.h

--- a/Platform/Intel/BoardModulePkg/Library/BoardBdsHookLib/BoardBootOption.c
+++ b/Platform/Intel/BoardModulePkg/Library/BoardBdsHookLib/BoardBootOption.c
@@ -2,6 +2,8 @@
   Driver for Platform Boot Options support.
 
 Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.<BR>
+
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -335,7 +337,6 @@ PlatformBootManagerWaitCallback (
 
 EFI_GUID gUefiShellFileGuid = { 0x7C04A583, 0x9E3E, 0x4f1c, { 0xAD, 0x65, 0xE0, 0x52, 0x68, 0xD0, 0xB4, 0xD1 } };
 
-#define INTERNAL_UEFI_SHELL_NAME      L"Internal UEFI Shell 2.0"
 #define UEFI_HARD_DRIVE_NAME          L"UEFI Hard Drive"
 
 /**
@@ -352,7 +353,8 @@ RegisterDefaultBootOption (
 
     ShellData = NULL;
     ShellDataSize = 0;
-    RegisterFvBootOption (&gUefiShellFileGuid,      INTERNAL_UEFI_SHELL_NAME, (UINTN) -1, LOAD_OPTION_ACTIVE, (UINT8 *)ShellData, ShellDataSize);
+    CopyMem (&gUefiShellFileGuid, PcdGetPtr (PcdShellFile), sizeof (GUID));
+    RegisterFvBootOption (&gUefiShellFileGuid, (CHAR16 *) PcdGetPtr (PcdShellFileDesc), (UINTN) -1, LOAD_OPTION_ACTIVE, (UINT8 *)ShellData, ShellDataSize);
 
   //
   // Boot Menu
@@ -557,7 +559,7 @@ BootOptionPriority (
       return 6;
 
     }
-    if (StrCmp (BootOption->Description, INTERNAL_UEFI_SHELL_NAME) == 0) {
+    if (StrCmp (BootOption->Description, (CHAR16 *) PcdGetPtr (PcdShellFileDesc)) == 0) {
       if (PcdGetBool (PcdBootToShellOnly)) {
         return 0;
       }

--- a/Platform/Intel/MinPlatformPkg/MinPlatformPkg.dec
+++ b/Platform/Intel/MinPlatformPkg/MinPlatformPkg.dec
@@ -7,6 +7,7 @@
 # for the build infrastructure.
 #
 # Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -265,6 +266,10 @@
   gMinPlatformPkgTokenSpaceGuid.PcdFlashFvFspUBase|0x00000000|UINT32|0x2000002A
   gMinPlatformPkgTokenSpaceGuid.PcdFlashFvFspUSize|0x00000000|UINT32|0x2000002B
   gMinPlatformPkgTokenSpaceGuid.PcdFlashFvFspUOffset|0x00000000|UINT32|0x2000002C
+
+  # GUID of Shell file to be loaded, default value is gUefiShellFileGuid define in ShellPkg.dec
+  gMinPlatformPkgTokenSpaceGuid.PcdShellFile|{GUID({0x7c04a583, 0x9e3e, 0x4f1c, {0xad, 0x65, 0xe0, 0x52, 0x68, 0xd0, 0xb4, 0xd1}})}|VOID*|0x20000230
+  gMinPlatformPkgTokenSpaceGuid.PcdShellFileDesc|L"Internal UEFI Shell 2.0"|VOID*|0x20000231
 
 [PcdsDynamic, PcdsDynamicEx]
   gMinPlatformPkgTokenSpaceGuid.PcdPcIoApicEnable|0x0|UINT32|0x90000019


### PR DESCRIPTION
Patch 1: handles GCC compiler boot time page fault exception by making copy of PcdPtr values.
Patch 2: Adds PCDs to hold UEFI shell file Guid and description