### PR TITLE
IntelSiliconPkg/SpiFvbServiceSmm: Support Other NVS variable region.

### DIFF
--- a/Silicon/Intel/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceCommon.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceCommon.c
@@ -568,6 +568,28 @@ GetVariableFvInfo (
     return;
   }
 
+  //
+  // GetVariableFlashNvStorageInfo () only reports regular variable region information,
+  // if platform implemented an additional NVS region following the regular variable region,
+  // the both region size should be included as overall NVS region size.
+  //
+  // The below PcdFlashNvStorageAdditionalSize is for compatible with legacy usages that should be deprecated.
+  // The new usage model should define separate regions without implicit connections to UEFI Variable or FTW regions.
+  //
+  // Example NVS flash map for such legacy usage:
+  // Note: PcdFlashNvStorageAdditionalSize is equal to platform PcdFlashFvNvStorageEventLogSize.
+  //  ---------------
+  //  |UEFI Variable|
+  //  ---------------
+  //  |EventLog     | <= this is Additional NVS region
+  //  ---------------
+  //  |FTW Working  |
+  //  ---------------
+  //  |FTW Spare    |
+  //  ---------------
+  //
+  NvStoreLength += PcdGet32 (PcdFlashNvStorageAdditionalSize);
+
   Status = GetVariableFlashFtwSpareInfo (&NvBaseAddress, &Length64);
   if (!EFI_ERROR (Status)) {
     // Stay within the current UINT32 size assumptions in the variable stack.

--- a/Silicon/Intel/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceSmm.inf
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceSmm.inf
@@ -43,9 +43,10 @@
   IntelSiliconPkg/IntelSiliconPkg.dec
 
 [Pcd]
-  gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvBase         ## CONSUMES
-  gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvSize         ## CONSUMES
-  gIntelSiliconPkgTokenSpaceGuid.PcdFlashVariableStoreType       ## SOMETIMES_CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvBase            ## CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvSize            ## CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashVariableStoreType          ## SOMETIMES_CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashNvStorageAdditionalSize    ## CONSUMES
 
 [Sources]
   FvbInfo.c

--- a/Silicon/Intel/IntelSiliconPkg/IntelSiliconPkg.dec
+++ b/Silicon/Intel/IntelSiliconPkg/IntelSiliconPkg.dec
@@ -194,3 +194,14 @@
   #  Other value: reserved for future use.<BR>
   # @Prompt Flash Variable Store type.
   gIntelSiliconPkgTokenSpaceGuid.PcdFlashVariableStoreType|0x00|UINT8|0x0000000E
+
+  ## Declares Additional NVS Region Size.<BR><BR>
+  #  Platform may implement a Regular variable region and an additional region, which will require this PCD
+  #  to tell SpiFvbService to include both regions.
+  #  Note: This PCD is for compatible with legacy usages that should be deprecated.
+  #  The new usage model should define separate regions without implicit connections to UEFI Variable or FTW regions.<BR>
+  #  Example legacy usage is to set this PCD equal to platform PcdFlashFvNvStorageEventLogSize.
+  #  0: No additional NVS region.<BR>
+  #  non-zero: The size of an additional NVS region following the Regular variable region.<BR>
+  # @Prompt Additional NVS Region Size.
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashNvStorageAdditionalSize|0x00000000|UINT32|0x0000000F


### PR DESCRIPTION
Platform may implement Other NVS variable region following Regular variable region and in this case SpiFvbService should include both region size when calculating the total NVS region size.

One usage model is EventLog NVS region and there could be others.

Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Isaac Oram <isaac.w.oram@intel.com>
Cc: Rangasai V Chaganty <rangasai.v.chaganty@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Michael Kubacki <michael.kubacki@microsoft.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>