### PR TITLE
SpiFvbServiceStandaloneMm: Add changes for rewrite varstore header

### DIFF
--- a/Silicon/Intel/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceStandaloneMm.inf
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceStandaloneMm.inf
@@ -44,6 +44,8 @@
 [Pcd]
   gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvBase         ## CONSUMES
   gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvSize         ## CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashVariableStoreType       ## SOMETIMES_CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashNvStorageAdditionalSize ## CONSUMES
 
 [Sources]
   FvbInfo.c
@@ -60,6 +62,8 @@
 [Guids]
   gEfiFirmwareFileSystem2Guid                   ## CONSUMES
   gEfiSystemNvDataFvGuid                        ## CONSUMES
+  gEfiVariableGuid                              ## SOMETIMES_CONSUMES
+  gEfiAuthenticatedVariableGuid                 ## SOMETIMES_CONSUMES
 
 [Depex]
   TRUE

--- a/Silicon/Intel/IntelSiliconPkg/IntelSiliconPkg.dec
+++ b/Silicon/Intel/IntelSiliconPkg/IntelSiliconPkg.dec
@@ -188,7 +188,8 @@
 
   ## Define Flash Variable Store type.<BR><BR>
   #  When Flash Variable Store corruption happened, the SpiFvbService will recreate Variable Store
-  #  with valid header information provided by this PCD value.<BR>
+  #  with valid header information provided by this PCD value.
+  #  Note: This PCD must be FixedAtBuild when using Standalone MM.
   #  0: Variable Store is gEfiVariableGuid type.<BR>
   #  1: Variable Store is gEfiAuthenticatedVariableGuid type.<BR>
   #  Other value: reserved for future use.<BR>
@@ -199,6 +200,7 @@
   #  Platform may implement a Regular variable region and an additional region, which will require this PCD
   #  to tell SpiFvbService to include both regions.
   #  Note: This PCD is for compatible with legacy usages that should be deprecated.
+  #  Note: This PCD must be FixedAtBuild when using Standalone MM.
   #  The new usage model should define separate regions without implicit connections to UEFI Variable or FTW regions.<BR>
   #  Example legacy usage is to set this PCD equal to platform PcdFlashFvNvStorageEventLogSize.
   #  0: No additional NVS region.<BR>


### PR DESCRIPTION
Updates the Standalone MM module to have the necessary INF changes
to build with the following two recent commits made to rewrite the
the variable store header in the MM SPI FVB service.

  - e95c798
  - 88d44c5

Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Isaac Oram <isaac.w.oram@intel.com>
Cc: Rangasai V Chaganty <rangasai.v.chaganty@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Chasel Chiu <chasel.chiu@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>