### PR TITLE
Ext4Pkg: Fixes double-free in Ext4ReadSymlink

### DIFF
--- a/Features/Ext4Pkg/Ext4Dxe/Symlink.c
+++ b/Features/Ext4Pkg/Ext4Dxe/Symlink.c
@@ -243,7 +243,6 @@ Ext4ReadSymlink (
       Status
       ));
     FreePool (Symlink16Tmp);
-    FreePool (SymlinkTmp);
     return Status;
   }
 


### PR DESCRIPTION
The SymlinkTmp was deallocated unconditionally, so we shouldn't free it again on EFI_ERROR

Cc: Marvin Häuser <mhaeuser@posteo.de>
Cc: Pedro Falcato <pedro.falcato@gmail.com>
Cc: Vitaly Cheptsov <vit9696@protonmail.com>
Fixes: e81432fbacb7 ("Ext4Pkg: Add symbolic links support")