### PR TITLE
Silicon/RISC-V: Fix a build failure in RiscVCpuLib

### DIFF
--- a/Silicon/RISC-V/ProcessorPkg/Include/Library/RiscVCpuLib.h
+++ b/Silicon/RISC-V/ProcessorPkg/Include/Library/RiscVCpuLib.h
@@ -2,6 +2,7 @@
   RISC-V CPU library definitions.
 
   Copyright (c) 2016 - 2022, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -95,9 +96,6 @@ UINT64
 RiscVReadMachineImplementId (
   VOID
   );
-
-VOID
-  RiscVSetSupervisorAddressTranslationRegister (UINT64);
 
 VOID
   RiscVSetSupervisorScratch (UINT64);

--- a/Silicon/RISC-V/ProcessorPkg/Include/Library/RiscVEdk2SbiLib.h
+++ b/Silicon/RISC-V/ProcessorPkg/Include/Library/RiscVEdk2SbiLib.h
@@ -2,6 +2,7 @@
   Library to call the RISC-V SBI ecalls
 
   Copyright (c) 2021-2022, Hewlett Packard Development LP. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -9,8 +10,8 @@
     - Hart - Hardware Thread, similar to a CPU core
 **/
 
-#ifndef RISCV_SBI_LIB_H_
-#define RISCV_SBI_LIB_H_
+#ifndef RISCV_SBI_LIB2_H_
+#define RISCV_SBI_LIB2_H_
 
 #include <Uefi.h>
 #include <IndustryStandard/RiscVOpensbi.h>

--- a/Silicon/RISC-V/ProcessorPkg/Library/RiscVCpuLib/Cpu.S
+++ b/Silicon/RISC-V/ProcessorPkg/Library/RiscVCpuLib/Cpu.S
@@ -3,6 +3,7 @@
 // RISC-V CPU functions.
 //
 // Copyright (c) 2016 - 2021, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+// Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -132,12 +133,3 @@ ASM_FUNC (RiscVSetSupervisorStvec)
 ASM_FUNC (RiscVGetSupervisorStvec)
     csrr a0, RISCV_CSR_SUPERVISOR_STVEC
     ret
-
-//
-// Set Supervisor Address Translation and
-// Protection Register.
-//
-ASM_FUNC (RiscVSetSupervisorAddressTranslationRegister)
-    csrw  RISCV_CSR_SUPERVISOR_SATP, a0
-    ret
-


### PR DESCRIPTION
RiscVSetSupervisorAddressTranslationRegister() should be moved out from RiscVCpuLib since it had been merged to MdePkg/Include/Library/BaseLib.h, to avoid a multiple definition problem in building.