### PR TITLE
Silicon/RISC-V: Fix build failures caused by duplicated definition

### DIFF
--- a/Platform/RISC-V/PlatformPkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/Platform/RISC-V/PlatformPkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -2,13 +2,14 @@
   Reset System Library functions for RISC-V
 
   Copyright (c) 2021, Hewlett Packard Development LP. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #include <Library/DebugLib.h>
 #include <Library/ResetSystemLib.h>
-#include <Library/RiscVEdk2SbiLib.h>
+#include <Library/BaseRiscVSbiLib.h>
 
 /**
   This function causes a system-wide reset (cold reset), in which

--- a/Platform/RISC-V/PlatformPkg/Library/ResetSystemLib/ResetSystemLib.inf
+++ b/Platform/RISC-V/PlatformPkg/Library/ResetSystemLib/ResetSystemLib.inf
@@ -2,6 +2,7 @@
 #  Library instance for ResetSystem library class for RISC-V using SBI ecalls
 #
 #  Copyright (c) 2021, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -29,4 +30,4 @@
 
 [LibraryClasses]
   DebugLib
-  RiscVEdk2SbiLib
+  RiscVSbiLib

--- a/Silicon/RISC-V/ProcessorPkg/Include/IndustryStandard/RiscV.h
+++ b/Silicon/RISC-V/ProcessorPkg/Include/IndustryStandard/RiscV.h
@@ -2,6 +2,7 @@
   RISC-V package definitions.
 
   Copyright (c) 2021-2022, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -62,7 +63,6 @@
 #define RISCV_CSR_MACHINE_MIE      0x304
 #define RISCV_CSR_MACHINE_MTVEC    0x305
 
-#define RISCV_TIMER_COMPARE_BITS  32
 //
 // Machine Timer and Counter.
 //

--- a/Silicon/RISC-V/ProcessorPkg/Include/Library/RiscVCpuLib.h
+++ b/Silicon/RISC-V/ProcessorPkg/Include/Library/RiscVCpuLib.h
@@ -2,6 +2,7 @@
   RISC-V CPU library definitions.
 
   Copyright (c) 2016 - 2022, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -93,25 +94,6 @@ RiscVReadMachineArchitectureId (
 
 UINT64
 RiscVReadMachineImplementId (
-  VOID
-  );
-
-VOID
-  RiscVSetSupervisorAddressTranslationRegister (UINT64);
-
-VOID
-  RiscVSetSupervisorScratch (UINT64);
-
-UINT64
-RiscVGetSupervisorScratch (
-  VOID
-  );
-
-VOID
-  RiscVSetSupervisorStvec (UINT64);
-
-UINT64
-RiscVGetSupervisorStvec (
   VOID
   );
 

--- a/Silicon/RISC-V/ProcessorPkg/Include/Library/RiscVEdk2SbiLib.h
+++ b/Silicon/RISC-V/ProcessorPkg/Include/Library/RiscVEdk2SbiLib.h
@@ -10,8 +10,8 @@
     - Hart - Hardware Thread, similar to a CPU core
 **/
 
-#ifndef RISCV_SBI_LIB_H_
-#define RISCV_SBI_LIB_H_
+#ifndef RISCV_SBI_LIB2_H_
+#define RISCV_SBI_LIB2_H_
 
 #include <Uefi.h>
 #include <IndustryStandard/RiscVOpensbi.h>

--- a/Silicon/RISC-V/ProcessorPkg/Include/Library/RiscVEdk2SbiLib.h
+++ b/Silicon/RISC-V/ProcessorPkg/Include/Library/RiscVEdk2SbiLib.h
@@ -2,6 +2,7 @@
   Library to call the RISC-V SBI ecalls
 
   Copyright (c) 2021-2022, Hewlett Packard Development LP. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -472,42 +473,6 @@ SbiRemoteHfenceVvma (
   IN  UINTN  HartMaskBase,
   IN  UINTN  StartAddr,
   IN  UINTN  Size
-  );
-
-///
-/// Firmware System Reset (SRST) Extension
-///
-
-/**
-  Reset the system
-
-  The System Reset Extension provides a function that allow the supervisor
-  software to request system-level reboot or shutdown. The term "system" refers
-  to the world-view of supervisor software and the underlying SBI
-  implementation could be machine mode firmware or hypervisor.
-
-  Valid parameters for ResetType and ResetReason are defined in sbi_ecall_interface.h
-
-  #define SBI_SRST_RESET_TYPE_SHUTDOWN    0x0
-  #define SBI_SRST_RESET_TYPE_COLD_REBOOT 0x1
-  #define SBI_SRST_RESET_TYPE_WARM_REBOOT 0x2
-
-  #define SBI_SRST_RESET_REASON_NONE      0x0
-  #define SBI_SRST_RESET_REASON_SYSFAIL   0x1
-
-  When the call is successful, it will not return.
-
-  @param[in]  ResetType            Typ of reset: Shutdown, cold-, or warm-reset.
-  @param[in]  ResetReason          Why the system resets. No reason or system failure.
-  @retval EFI_INVALID_PARAMETER    Either ResetType or ResetReason is invalid.
-  @retval EFI_UNSUPPORTED          ResetType is valid but not implemented on the platform.
-  @retval EFI_DEVICE_ERROR         Unknown error.
-**/
-EFI_STATUS
-EFIAPI
-SbiSystemReset (
-  IN  UINTN  ResetType,
-  IN  UINTN  ResetReason
   );
 
 ///

--- a/Silicon/RISC-V/ProcessorPkg/Library/RiscVCpuLib/Cpu.S
+++ b/Silicon/RISC-V/ProcessorPkg/Library/RiscVCpuLib/Cpu.S
@@ -3,6 +3,7 @@
 // RISC-V CPU functions.
 //
 // Copyright (c) 2016 - 2021, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+// Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -100,44 +101,3 @@ ASM_FUNC (RiscVReadMachineArchitectureId)
 ASM_FUNC (RiscVReadMachineImplementId)
     csrr a0, RISCV_CSR_MACHINE_MIMPID
     ret
-
-//
-// Set Supervisor mode scratch.
-// @param a0 : Value set to Supervisor mode scratch
-//
-ASM_FUNC (RiscVSetSupervisorScratch)
-    csrrw a1, RISCV_CSR_SUPERVISOR_SSCRATCH, a0
-    ret
-
-//
-// Get Supervisor mode scratch.
-// @retval a0 : Value in Supervisor mode scratch
-//
-ASM_FUNC (RiscVGetSupervisorScratch)
-    csrr a0, RISCV_CSR_SUPERVISOR_SSCRATCH
-    ret
-
-//
-// Set Supervisor mode trap vector.
-// @param a0 : Value set to Supervisor mode trap vector
-//
-ASM_FUNC (RiscVSetSupervisorStvec)
-    csrrw a1, RISCV_CSR_SUPERVISOR_STVEC, a0
-    ret
-
-//
-// Get Supervisor mode scratch.
-// @retval a0 : Value in Supervisor mode trap vector
-//
-ASM_FUNC (RiscVGetSupervisorStvec)
-    csrr a0, RISCV_CSR_SUPERVISOR_STVEC
-    ret
-
-//
-// Set Supervisor Address Translation and
-// Protection Register.
-//
-ASM_FUNC (RiscVSetSupervisorAddressTranslationRegister)
-    csrw  RISCV_CSR_SUPERVISOR_SATP, a0
-    ret
-

--- a/Silicon/RISC-V/ProcessorPkg/Library/RiscVEdk2SbiLib/RiscVEdk2SbiLib.c
+++ b/Silicon/RISC-V/ProcessorPkg/Library/RiscVEdk2SbiLib/RiscVEdk2SbiLib.c
@@ -16,6 +16,7 @@
   - SbiLegacyShutdown            -> Wait for new System Reset extension
 
   Copyright (c) 2021-2022, Hewlett Packard Development LP. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Revision Reference:
@@ -762,51 +763,6 @@ SbiRemoteHFenceVvma (
           HartMaskBase,
           StartAddr,
           Size
-          );
-
-  return TranslateError (Ret.Error);
-}
-
-/**
-  Reset the system
-
-  The System Reset Extension provides a function that allow the supervisor
-  software to request system-level reboot or shutdown. The term "system" refers
-  to the world-view of supervisor software and the underlying SBI
-  implementation could be machine mode firmware or hypervisor.
-
-  Valid parameters for ResetType and ResetReason are defined in sbi_ecall_interface.h
-
-  #define SBI_SRST_RESET_TYPE_SHUTDOWN    0x0
-  #define SBI_SRST_RESET_TYPE_COLD_REBOOT 0x1
-  #define SBI_SRST_RESET_TYPE_WARM_REBOOT 0x2
-
-  #define SBI_SRST_RESET_REASON_NONE      0x0
-  #define SBI_SRST_RESET_REASON_SYSFAIL   0x1
-
-  When the call is successful, it will not return.
-
-  @param[in]  ResetType            Typ of reset: Shutdown, cold-, or warm-reset.
-  @param[in]  ResetReason          Why the system resets. No reason or system failure.
-  @retval EFI_INVALID_PARAMETER    Either ResetType or ResetReason is invalid.
-  @retval EFI_UNSUPPORTED          ResetType is valid but not implemented on the platform.
-  @retval EFI_DEVICE_ERROR         Unknown error.
-**/
-EFI_STATUS
-EFIAPI
-SbiSystemReset (
-  IN  UINTN  ResetType,
-  IN  UINTN  ResetReason
-  )
-{
-  SBI_RET  Ret;
-
-  Ret = SbiCall (
-          SBI_EXT_SRST,
-          SBI_EXT_SRST_RESET,
-          2,
-          ResetType,
-          ResetReason
           );
 
   return TranslateError (Ret.Error);

--- a/Silicon/RISC-V/ProcessorPkg/Library/RiscVTimerLib/RiscVTimerLib.c
+++ b/Silicon/RISC-V/ProcessorPkg/Library/RiscVTimerLib/RiscVTimerLib.c
@@ -2,6 +2,7 @@
   RISC-V instance of Timer Library.
 
   Copyright (c) 2016 - 2022, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -12,6 +13,7 @@
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
 #include <Library/RiscVCpuLib.h>
+#include <Register/RiscV64/RiscVImpl.h>
 
 /**
   Stalls the CPU for at least the given number of ticks.


### PR DESCRIPTION
Clean up redundant function code becasue they were merged to MdePkg.