### PR TITLE
Platform/Loongson: Allow building with stack protector support

### DIFF
--- a/Platform/Loongson/LoongArchQemuPkg/Loongson.dsc
+++ b/Platform/Loongson/LoongArchQemuPkg/Loongson.dsc
@@ -95,6 +95,9 @@
   TlsLib|CryptoPkg/Library/TlsLib/TlsLib.inf
 !endif
 
+  # For stack protector support
+  NULL                             | MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
+
   BaseLib                          | MdePkg/Library/BaseLib/BaseLib.inf
   SafeIntLib                       | MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
   TimeBaseLib                      | EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.inf


### PR DESCRIPTION
Some toolchains have stack protection enabled by default, so without the appropriate library included the build will fail with missing symbols during link.

Mail thread with reviews: https://edk2.groups.io/g/devel/message/100746

Cc: Bibo Mao <maobibo@loongson.cn>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: devel@edk2.groups.io
Reviewed-by: Chao Li <lichao@loongson.cn>
Reviewed-by: Xianglai Li <lixianglai@loongson.cn>