### PR TITLE
Fixing typo in Dsdt.asl

### DIFF
--- a/Platform/Intel/SimicsOpenBoardPkg/AcpiTables/Dsdt.asl
+++ b/Platform/Intel/SimicsOpenBoardPkg/AcpiTables/Dsdt.asl
@@ -372,7 +372,7 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 1, "INTEL ", "SIMICS  ", 4) {
 
             Package () {0x000EFFFF, 0x00, 0, 16},
             Package () {0x000EFFFF, 0x01, 0, 17},
-            Package () {0x000EFFFF, 0x02, 0C, 18},
+            Package () {0x000EFFFF, 0x02, 0, 18},
             Package () {0x000EFFFF, 0x03, 0, 19},
 
             Package () {0x000FFFFF, 0x00, 0, 16},


### PR DESCRIPTION
Looks like a small typo in Platform/Intel/SimicsOpenBoardPkg/AcpiTables/Dsdt.asl. 