### PR TITLE
Platform/Loongson: Pre-allocate 0-4K memory during the Pei phase

### DIFF
--- a/Platform/Loongson/LoongArchQemuPkg/PlatformPei/MemDetect.c
+++ b/Platform/Loongson/LoongArchQemuPkg/PlatformPei/MemDetect.c
@@ -101,4 +101,17 @@ InitializeRamRegions (
 
     AddMemoryRangeHob ( pEntry->BaseAddr, pEntry->BaseAddr + pEntry->Length);
   }
+
+  //
+  //When 0 address protection is enabled,
+  //0-4k memory needs to be preallocated to prevent UEFI applications from allocating use,
+  //such as grub
+  //
+  if (PcdGet8 (PcdNullPointerDetectionPropertyMask) & BIT0) {
+    BuildMemoryAllocationHob (
+          0,
+          EFI_PAGE_SIZE,
+          EfiBootServicesData
+          );
+  }
 }

--- a/Platform/Loongson/LoongArchQemuPkg/PlatformPei/PlatformPei.inf
+++ b/Platform/Loongson/LoongArchQemuPkg/PlatformPei/PlatformPei.inf
@@ -59,6 +59,7 @@
   gLoongArchQemuPkgTokenSpaceGuid.PcdDeviceTreeBase
   gLoongArchQemuPkgTokenSpaceGuid.PcdDeviceTreePadding
   gLoongArchQemuPkgTokenSpaceGuid.PcdRtcBaseAddress
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask
 
 [FixedPcd]
   gLoongArchQemuPkgTokenSpaceGuid.PcdFlashDxeFvBase


### PR DESCRIPTION
When 0 address protection is enabled,
0-4k memory needs to be preallocated to
prevent UEFI applications from allocating use,
such as grub.

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Bibo Mao <maobibo@loongson.cn>
Cc: Chao Li <lichao@loongson.cn>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>