### PR TITLE
MinPlatformPkg: Remove IA32 in PeiFspWrapperPlatformLib

### DIFF
--- a/Platform/Intel/MinPlatformPkg/FspWrapper/Library/PeiFspWrapperPlatformLib/PeiFspWrapperPlatformLib.inf
+++ b/Platform/Intel/MinPlatformPkg/FspWrapper/Library/PeiFspWrapperPlatformLib/PeiFspWrapperPlatformLib.inf
@@ -51,7 +51,7 @@
   IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
   MinPlatformPkg/MinPlatformPkg.dec
 
-[LibraryClasses.IA32]
+[LibraryClasses]
   SiliconPolicyInitLib
   SiliconPolicyUpdateLib
   PeiServicesTablePointerLib


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4508

Remove IA32 only dependency, Because we need to support both IA32 and X64. Apply to a modern platform supporting x64.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Isaac Oram <isaac.w.oram@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Rangasai V Chaganty <rangasai.v.chaganty@intel.com>
Cc: Rosen Chuang <rosen.chuang@intel.com>
Cc: Ted Kuo <ted.kuo@intel.com>