### PR TITLE
U5SeriesPkg/FreedomU540HiFiveUnleashedBoard: Support MMU with SV39/48…

### DIFF
--- a/Platform/SiFive/U5SeriesPkg/FreedomU540HiFiveUnleashedBoard/U540.dsc
+++ b/Platform/SiFive/U5SeriesPkg/FreedomU540HiFiveUnleashedBoard/U540.dsc
@@ -65,6 +65,7 @@
 !include MdePkg/MdeLibs.dsc.inc
 
 [LibraryClasses]
+  RiscVMmuLib|UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.inf
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf


### PR DESCRIPTION
By following https://github.com/riscv-admin/riscv-uefi-edk2-docs to build edk2 for riscv qemu(u540).
`build -a RISCV64 -p Platform/SiFive/U5SeriesPkg/FreedomU540HiFiveUnleashedBoard/U540.dsc -t GCC5`
it will occur build error like :
![image](https://github.com/tianocore/edk2-platforms/assets/9338816/10135905-4c20-4c3e-b33d-db8b5f8e4c2a)

It will build success after add missing library class. 
![image](https://github.com/tianocore/edk2-platforms/assets/9338816/97a48f15-d30d-4197-a267-00d6ba930523)
