### PR TITLE
Remove memory cache setting for memory under 1MB

### DIFF
--- a/Platform/Intel/MinPlatformPkg/Library/SetCacheMtrrLib/SetCacheMtrrLib.c
+++ b/Platform/Intel/MinPlatformPkg/Library/SetCacheMtrrLib/SetCacheMtrrLib.c
@@ -245,7 +245,7 @@ SetCacheMtrrAfterEndOfPei (
                          &MtrrSetting,
                          0xC0000,
                          0x40000,
-                         CacheWriteProtected
+                         CacheWriteBack
                          );
   ASSERT_EFI_ERROR ( Status);
 


### PR DESCRIPTION
With the fact that CSM is not supported,
the request is to remove the cache setting for memory under 1MB. This can be treated as the missing part of legacy CSM deprecation.

This patch only set the 00000 to 9FFFF and C0000 to FFFFF as Write Back. A0000-BFFFF range is still uncacheable for VGA.

M: Chasel Chiu <chasel.chiu@intel.com>
M: Nate DeSimone <nathaniel.l.desimone@intel.com>
M: Isaac Oram <isaac.w.oram@intel.com>
R: Liming Gao <gaoliming@byosoft.com.cn>
R: Eric Dong <eric.dong@intel.com>
Signed-off-by: Yuanhao Xie <yuanhao.xie@intel.com>