### PR TITLE
Fix undefined reference to AllocatePool in GenericElog/Smm

### DIFF
--- a/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericElog/Smm/GenericElog.inf
+++ b/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericElog/Smm/GenericElog.inf
@@ -28,6 +28,7 @@
   UefiDriverEntryPoint
   DebugLib
   SmmServicesTableLib
+  MemoryAllocationLib
 
 [Protocols]
   gSmmGenericElogProtocolGuid     # PROTOCOL ALWAYS_PRODUCED


### PR DESCRIPTION
Missing MemoryAllocationLib import causes undefined reference when building. 

Signed-off-by: Stefanie Dukovac <dukovac.stefanie@live.ca>