### PR TITLE
MinPlatformPkg: should build Performance driver only when perf enabled

### DIFF
--- a/Platform/Intel/MinPlatformPkg/Include/Fdf/CorePostMemoryInclude.fdf
+++ b/Platform/Intel/MinPlatformPkg/Include/Fdf/CorePostMemoryInclude.fdf
@@ -1,12 +1,14 @@
 ## @file
 #  FDF file of Platform.
 #
-# Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
 
 !if gMinPlatformPkgTokenSpaceGuid.PcdBootToShellOnly == FALSE
-  INF  MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.inf
+  !if gMinPlatformPkgTokenSpaceGuid.PcdPerformanceEnable == TRUE
+    INF  MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.inf
+  !endif
 !endif


### PR DESCRIPTION
Should build FirmwarePerformancePei only when perf enabled. Avoiding unconditional compilation of performance PEI drivers can save 2KB in PostMem FV, small but important.

Change-Id: I09b8941981105b86d4d4bdc5a291dbc48ec67b2e