### PR TITLE
UserAuthFeaturePkg/UserAuthenticationSmm: Support Standalone MM.

### DIFF
--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/Include/UserAuthFeature.dsc
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/Include/UserAuthFeature.dsc
@@ -6,7 +6,7 @@
 # INF files to generate AutoGen.c and AutoGen.h files
 # for the build infrastructure.
 #
-# Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -75,3 +75,5 @@
   UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationDxe.inf
   UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthentication2Dxe.inf
   UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.inf
+  UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMm.inf
+  UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMmDxe.inf

--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.h
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.h
@@ -1,7 +1,7 @@
 /** @file
   Header file for UserAuthenticationSmm.
 
-  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -9,7 +9,7 @@
 #ifndef __USER_AUTHENTICATION_SMM_H__
 #define __USER_AUTHENTICATION_SMM_H__
 
-#include <PiSmm.h>
+#include <PiMm.h>
 
 #include <Protocol/SmmVariable.h>
 #include <Protocol/VariableLock.h>
@@ -21,25 +21,16 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/PrintLib.h>
 #include <Library/UefiBootServicesTableLib.h>
-#include <Library/SmmServicesTableLib.h>
+#include <Library/MmServicesTableLib.h>
 #include <Library/MemoryAllocationLib.h>
-#include <Library/SmmServicesTableLib.h>
 #include <Library/BaseCryptLib.h>
 #include <Library/PlatformPasswordLib.h>
 
 #include "KeyService.h"
+#include "UserAuthenticationVariable.h"
 
 #define PASSWORD_SALT_SIZE   32
 #define PASSWORD_HASH_SIZE   32 // SHA256_DIGEST_SIZE
-
-#define PASSWORD_MAX_TRY_COUNT  3
-#define PASSWORD_HISTORY_CHECK_COUNT  5
-
-//
-// Name of the variable
-//
-#define USER_AUTHENTICATION_VAR_NAME L"Password"
-#define USER_AUTHENTICATION_HISTORY_LAST_VAR_NAME L"PasswordLast"
 
 //
 // Variable storage
@@ -48,5 +39,16 @@ typedef struct {
   UINT8        PasswordHash[PASSWORD_HASH_SIZE];
   UINT8        PasswordSalt[PASSWORD_SALT_SIZE];
 } USER_PASSWORD_VAR_STRUCT;
+
+/**
+  Password Smm Init.
+
+  @retval EFI_SUCESS  This function always complete successfully.
+
+**/
+EFI_STATUS
+PasswordSmmInit (
+  VOID
+  );
 
 #endif

--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.inf
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.inf
@@ -3,7 +3,7 @@
 #
 #  This driver provides SMM services for DXE user authentication module.
 #
-# Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2019 - 2023, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -15,13 +15,15 @@
   MODULE_TYPE                    = DXE_SMM_DRIVER
   VERSION_STRING                 = 1.0
   PI_SPECIFICATION_VERSION       = 0x0001000A
-  ENTRY_POINT                    = PasswordSmmInit
+  ENTRY_POINT                    = UserAuthenticationMmEntry
 
 [Sources]
   UserAuthenticationSmm.c
+  UserAuthenticationTraditionalMm.c
   UserAuthenticationSmm.h
   KeyService.c
   KeyService.h
+  UserAuthenticationVariableLock.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -36,17 +38,18 @@
   BaseLib
   BaseMemoryLib
   PrintLib
-  SmmServicesTableLib
+  MmServicesTableLib
   MemoryAllocationLib
-  UefiLib
   BaseCryptLib
   PlatformPasswordLib
+  VariablePolicyHelperLib
 
 [Guids]
   gUserAuthenticationGuid                       ## CONSUMES  ## GUID
+  gEfiEventExitBootServicesGuid                 ## CONSUMES  ## Event
 
 [Protocols]
-  gEdkiiVariableLockProtocolGuid                ## CONSUMES
+  gEdkiiVariablePolicyProtocolGuid              ## CONSUMES
   gEfiSmmVariableProtocolGuid                   ## CONSUMES
   gEdkiiSmmExitBootServicesProtocolGuid         ## CONSUMES
   gEdkiiSmmLegacyBootProtocolGuid               ## CONSUMES

--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMm.c
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMm.c
@@ -1,0 +1,43 @@
+/** @file
+  Entry point of UserAuthenticationStandaloneMm.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "UserAuthenticationSmm.h"
+
+/**
+  NULL implement for Lock password variables.
+  Relies on UserAuthenticationStandaloneMmDxe to lock the password variables.
+
+  @retval EFI_SUCCESS  Always return success.
+
+**/
+EFI_STATUS
+LockPasswordVariable (
+  VOID
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  Main entry for this driver.
+
+  @param ImageHandle     Image handle this driver.
+  @param SystemTable     Pointer to SystemTable.
+
+  @retval EFI_SUCESS     This function always complete successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+UserAuthenticationMmEntry (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return PasswordSmmInit ();
+}

--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMm.inf
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMm.inf
@@ -1,0 +1,58 @@
+## @file
+#  User Authentication Standalone Mm Driver.
+#
+#  This driver provides SMM services for DXE user authentication module.
+#  This Standalone Mm driver lacks of the ability to lock the password
+#  variables. Need to rely on UserAuthenticationStandaloneMmDxe to lock
+#  the variables.
+#
+# Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = UserAuthenticationStandaloneMm
+  FILE_GUID                      = 80130611-a67a-4631-becb-87ce22d6f165
+  MODULE_TYPE                    = MM_STANDALONE
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  ENTRY_POINT                    = UserAuthenticationMmEntry
+
+[Sources]
+  UserAuthenticationSmm.c
+  UserAuthenticationStandaloneMm.c
+  UserAuthenticationSmm.h
+  KeyService.c
+  KeyService.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  CryptoPkg/CryptoPkg.dec
+  UserAuthFeaturePkg/UserAuthFeaturePkg.dec
+
+[LibraryClasses]
+  StandaloneMmDriverEntryPoint
+  DebugLib
+  BaseLib
+  BaseMemoryLib
+  PrintLib
+  MmServicesTableLib
+  MemoryAllocationLib
+  BaseCryptLib
+  PlatformPasswordLib
+
+[Guids]
+  gUserAuthenticationGuid                       ## CONSUMES  ## GUID
+  gEfiEventExitBootServicesGuid                 ## CONSUMES  ## Event
+
+[Protocols]
+  gEdkiiVariableLockProtocolGuid                ## CONSUMES
+  gEfiSmmVariableProtocolGuid                   ## CONSUMES
+  gEdkiiSmmExitBootServicesProtocolGuid         ## CONSUMES
+  gEdkiiSmmLegacyBootProtocolGuid               ## CONSUMES
+
+[Depex]
+  gEfiSmmVariableProtocolGuid

--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMmDxe.c
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMmDxe.c
@@ -1,0 +1,31 @@
+/** @file
+  This Driver mainly locks password variables.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiDxe.h>
+
+#include "UserAuthenticationVariable.h"
+
+/**
+  User Authentication Standalone Mm Dxe driver entry point.
+
+  @param[in] ImageHandle  The image handle.
+  @param[in] SystemTable  The system table.
+
+  @retval EFI_SUCCESS    The entry point is executed successfully.
+  @return  other         Contain some other errors.
+
+**/
+EFI_STATUS
+EFIAPI
+UserAuthenticationStandaloneMmDxeEntry (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return LockPasswordVariable ();
+}

--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMmDxe.inf
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMmDxe.inf
@@ -1,0 +1,42 @@
+## @file
+#  User Authentication Standalone MM Dxe Driver.
+#
+#  This Driver mainly locks the password variable.
+#
+# Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = UserAuthenticationStandaloneMmDxe
+  FILE_GUID                      = 08fc98fb-1cec-45c6-ad02-542096191054
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = UserAuthenticationStandaloneMmDxeEntry
+
+[Sources]
+  UserAuthenticationStandaloneMmDxe.c
+  UserAuthenticationVariableLock.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UserAuthFeaturePkg/UserAuthFeaturePkg.dec
+
+[LibraryClasses]
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  DebugLib
+  PrintLib
+  VariablePolicyHelperLib
+
+[Guids]
+  gUserAuthenticationGuid                       ## CONSUMES  ## GUID
+
+[Protocols]
+  gEdkiiVariablePolicyProtocolGuid              ## CONSUMES
+
+[Depex]
+  gEdkiiVariableLockProtocolGuid

--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationTraditionalMm.c
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationTraditionalMm.c
@@ -1,0 +1,28 @@
+/** @file
+  Entry point of UserAuthenticationSmm.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "UserAuthenticationSmm.h"
+
+/**
+  Main entry for this driver.
+
+  @param[in] ImageHandle  Image handle this driver.
+  @param[in] SystemTable  Pointer to SystemTable.
+
+  @retval EFI_SUCESS  This function always complete successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+UserAuthenticationMmEntry (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return PasswordSmmInit ();
+}

--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationVariable.h
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationVariable.h
@@ -1,0 +1,36 @@
+/** @file
+  Header file for definition of User Authentication Variable.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef USER_AUTHENTICATION_VARIABLE_H_
+#define USER_AUTHENTICATION_VARIABLE_H_
+
+#define PASSWORD_MAX_TRY_COUNT        3
+#define PASSWORD_HISTORY_CHECK_COUNT  5
+
+//
+// Name of the variable
+//
+#define USER_AUTHENTICATION_VAR_NAME               L"Password"
+#define USER_AUTHENTICATION_HISTORY_LAST_VAR_NAME  L"PasswordLast"
+
+/**
+  Lock password variables for security concern.
+
+  @retval EFI_SUCCESS           Succeed to lock variable.
+  @retval EFI_NOT_FOUND         Variable Lock protocol is not found.
+  @retval EFI_ACCESS_DENIED     EFI_END_OF_DXE_EVENT_GROUP_GUID or EFI_EVENT_GROUP_READY_TO_BOOT has
+                                already been signaled.
+  @retval EFI_OUT_OF_RESOURCES  There is not enough resource to hold the lock request.
+
+**/
+EFI_STATUS
+LockPasswordVariable (
+  VOID
+  );
+
+#endif

--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationVariableLock.c
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationVariableLock.c
@@ -1,0 +1,84 @@
+/** @file
+  Source code to lock password variables.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiDxe.h>
+
+#include <Protocol/VariablePolicy.h>
+
+#include <Library/PrintLib.h>
+#include <Library/DebugLib.h>
+#include <Library/VariablePolicyHelperLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+#include <Guid/UserAuthentication.h>
+
+#include "UserAuthenticationVariable.h"
+
+/**
+  Lock password variables for security concern.
+
+  @retval EFI_SUCCESS           Succeed to lock variable.
+  @retval EFI_NOT_FOUND         Variable Lock protocol is not found.
+  @retval EFI_ACCESS_DENIED     EFI_END_OF_DXE_EVENT_GROUP_GUID or EFI_EVENT_GROUP_READY_TO_BOOT has
+                                already been signaled.
+  @retval EFI_OUT_OF_RESOURCES  There is not enough resource to hold the lock request.
+
+**/
+EFI_STATUS
+LockPasswordVariable (
+  VOID
+  )
+{
+  EFI_STATUS                      Status;
+  CHAR16                          PasswordHistoryName[sizeof (USER_AUTHENTICATION_VAR_NAME)/sizeof (CHAR16) + 5];
+  UINTN                           Index;
+  EDKII_VARIABLE_POLICY_PROTOCOL  *VariablePolicy;
+
+  Status = gBS->LocateProtocol (&gEdkiiVariablePolicyProtocolGuid, NULL, (VOID **)&VariablePolicy);
+  if (!EFI_ERROR (Status)) {
+    Status = RegisterBasicVariablePolicy (
+               VariablePolicy,
+               &gUserAuthenticationGuid,
+               USER_AUTHENTICATION_VAR_NAME,
+               VARIABLE_POLICY_NO_MIN_SIZE,
+               VARIABLE_POLICY_NO_MAX_SIZE,
+               VARIABLE_POLICY_NO_MUST_ATTR,
+               VARIABLE_POLICY_NO_CANT_ATTR,
+               VARIABLE_POLICY_TYPE_LOCK_NOW
+               );
+    ASSERT_EFI_ERROR (Status);
+    for (Index = 1; Index <= PASSWORD_HISTORY_CHECK_COUNT; Index++) {
+      UnicodeSPrint (PasswordHistoryName, sizeof (PasswordHistoryName), L"%s%04x", USER_AUTHENTICATION_VAR_NAME, Index);
+      Status = RegisterBasicVariablePolicy (
+                 VariablePolicy,
+                 &gUserAuthenticationGuid,
+                 PasswordHistoryName,
+                 VARIABLE_POLICY_NO_MIN_SIZE,
+                 VARIABLE_POLICY_NO_MAX_SIZE,
+                 VARIABLE_POLICY_NO_MUST_ATTR,
+                 VARIABLE_POLICY_NO_CANT_ATTR,
+                 VARIABLE_POLICY_TYPE_LOCK_NOW
+                 );
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    Status = RegisterBasicVariablePolicy (
+               VariablePolicy,
+               &gUserAuthenticationGuid,
+               USER_AUTHENTICATION_HISTORY_LAST_VAR_NAME,
+               VARIABLE_POLICY_NO_MIN_SIZE,
+               VARIABLE_POLICY_NO_MAX_SIZE,
+               VARIABLE_POLICY_NO_MUST_ATTR,
+               VARIABLE_POLICY_NO_CANT_ATTR,
+               VARIABLE_POLICY_TYPE_LOCK_NOW
+               );
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return Status;
+}


### PR DESCRIPTION
Refactor UserAuthenticationSmm to support Standalone MM.
- Factor out variable lock code logic that references boot services.
- UserAuthenticationStandaloneMmDxe is added to lock the variables. It is only used for UserAuthenticationStandaloneMm.
- UserAuthenticationStandaloneMm doesn't lock the variables, needs to rely on UserAuthenticationStandaloneMmDxe to do the lock.
- UserAuthenticationSmm still locks the variables by itself, no need to include UserAuthenticationStandaloneMmDxe.
- Register gEfiEventExitBootServicesGuid notify which is used by the StandaloneMmCore.

Since gEdkiiVariableLockProtocolGuid is a deprecated interface, use gEdkiiVariablePolicyProtocolGuid to lock password variables instead.

Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>