### PR TITLE
Sophgo/SG2042Pkg: Disable CMO and Sstc features

### DIFF
--- a/Platform/Sophgo/SG2042_EVB_Board/SG2042.dsc
+++ b/Platform/Sophgo/SG2042_EVB_Board/SG2042.dsc
@@ -265,6 +265,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeMemorySize|1
   gEfiMdeModulePkgTokenSpaceGuid.PcdResetOnMemoryTypeInformationChange|FALSE
+  gEfiMdePkgTokenSpaceGuid.PcdRiscVFeatureOverride|0xFFFFFFFFFFFFFFFC
   gEfiMdePkgTokenSpaceGuid.PcdMaximumGuidedExtractHandler|0x10
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize|0x2000
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxHardwareErrorVariableSize|0x8000


### PR DESCRIPTION
Disable CMO and Sstc features because they are not supported by the platform. And use SBI calls itself by default for Sophgo SG2042 platform.

Cc: dahogn <dahogn@hotmail.com>
Cc: meng-cz <mengcz1126@gmail.com>
Cc: USER0FISH <libing1202@outlook.com>

Reviewed-by: Sunil V L <sunilvl@ventanamicro.com>