### PR TITLE
IntelSiliconPkg/VTd: Remove ASSERT in VTdSetAttribute

### DIFF
--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/IntelVTdCoreDxe.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/IntelVTdCoreDxe.c
@@ -253,7 +253,6 @@ VTdSetAttribute (
       //
       // Force no IOMMU access attribute request recording before DMAR table is installed.
       //
-      ASSERT_EFI_ERROR (EFI_NOT_READY);
       return EFI_NOT_READY;
     }
     Status = RequestAccessAttribute (Segment, SourceId, DeviceAddress, Length, IoMmuAccess);

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/IntelVTdDxe.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/IntelVTdDxe.c
@@ -252,7 +252,6 @@ VTdSetAttribute (
       //
       // Force no IOMMU access attribute request recording before DMAR table is installed.
       //
-      ASSERT_EFI_ERROR (EFI_NOT_READY);
       return EFI_NOT_READY;
     }
     Status = RequestAccessAttribute (Segment, SourceId, DeviceAddress, Length, IoMmuAccess);


### PR DESCRIPTION
When PcdVTdPolicyPropertyMask BIT2 is set and ACPI DMAR table is not ready, It is no need to hit an assert, and just returns EFI_NOT_READY.

Reviewed-by : Jenny Huang <jenny.huang@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Rangasai V Chaganty <rangasai.v.chaganty@intel.com>
Cc: Chiang Chris <chris.chiang@intel.com>