### PR TITLE
AlderlakeSiliconPkg: Update for SPI2 Protocol and Identify flash regi…

### DIFF
--- a/Silicon/Intel/AlderlakeSiliconPkg/Cpu/Include/Register/CommonMsr.h
+++ b/Silicon/Intel/AlderlakeSiliconPkg/Cpu/Include/Register/CommonMsr.h
@@ -56,5 +56,9 @@ typedef union {
 
 } MSR_CORE_THREAD_COUNT_REGISTER;
 
+/**
+  Special Chipset Usage MSR
+**/
+#define MSR_SPCL_CHIPSET_USAGE 0x000001FE
 
 #endif /* _COMMONMSR_h */

--- a/Silicon/Intel/AlderlakeSiliconPkg/Fru/AdlPch/CommonLib.dsc
+++ b/Silicon/Intel/AlderlakeSiliconPkg/Fru/AdlPch/CommonLib.dsc
@@ -11,7 +11,7 @@
 
   EspiLib|$(PLATFORM_SI_PACKAGE)/IpBlock/Espi/Library/PeiDxeSmmEspiLib/PeiDxeSmmEspiLib.inf
 
-
+  SpiAccessLib|$(PLATFORM_SI_PACKAGE)/IpBlock/Spi/Library/PeiDxeSmmSpiAccessLib/PeiDxeSmmSpiAccessLib.inf
   PmcLib|$(PLATFORM_SI_PACKAGE)/IpBlock/Pmc/Library/PeiDxeSmmPmcLib/PeiDxeSmmPmcLib.inf
   PmcPrivateLib|$(PLATFORM_SI_PACKAGE)/IpBlock/Pmc/LibraryPrivate/PeiDxeSmmPmcPrivateLib/PeiDxeSmmPmcPrivateLib.inf
   SpiCommonLib|$(PLATFORM_SI_PACKAGE)/IpBlock/Spi/LibraryPrivate/BaseSpiCommonLib/BaseSpiCommonLib.inf

--- a/Silicon/Intel/AlderlakeSiliconPkg/Fru/AdlPch/PeiLib.dsc
+++ b/Silicon/Intel/AlderlakeSiliconPkg/Fru/AdlPch/PeiLib.dsc
@@ -5,8 +5,6 @@
 #   SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
-  SpiLib|$(PLATFORM_SI_PACKAGE)/IpBlock/Spi/Library/PeiSpiLib/PeiSpiLib.inf
-
   GpioHelpersLib|$(PLATFORM_SI_PACKAGE)/IpBlock/Gpio/LibraryPrivate/PeiGpioHelpersLib/PeiGpioHelpersLib.inf
 
 

--- a/Silicon/Intel/AlderlakeSiliconPkg/Include/Library/SpiAccessLib.h
+++ b/Silicon/Intel/AlderlakeSiliconPkg/Include/Library/SpiAccessLib.h
@@ -1,0 +1,44 @@
+/** @file
+  SPI library header for abstraction of SPI HW registers accesses
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef _SPI_ACCESS_LIB_H_
+#define _SPI_ACCESS_LIB_H_
+
+
+/**
+  Returns SPI BAR0 value
+
+  @retval  UINT32  PCH SPI BAR0 value
+**/
+UINT32
+SpiGetBar0 (
+  VOID
+  );
+
+/**
+  Checks if PCH SPI Controler is present and available
+
+  @retval TRUE    PCH SPI controller is avaialable
+  @retval FALSE   PCH SPI controller is not available
+**/
+BOOLEAN
+SpiIsControllerAvailable (
+  VOID
+  );
+
+/**
+  Checks if Device Attached Flash (DAF) mode is active
+
+  @retval TRUE    SAF mode is active
+  @retval FALSE   SAF mode is not active
+**/
+BOOLEAN
+SpiIsSafModeActive (
+  VOID
+  );
+
+#endif // _SPI_ACCESS_LIB_H_

--- a/Silicon/Intel/AlderlakeSiliconPkg/Include/Register/PttPtpRegs.h
+++ b/Silicon/Intel/AlderlakeSiliconPkg/Include/Register/PttPtpRegs.h
@@ -1,0 +1,26 @@
+/** @file
+  Register definitions for PTT HCI (Platform Trust Technology - Host Controller Interface).
+
+  Conventions:
+
+  - Prefixes:
+    Definitions beginning with "R_" are registers
+    Definitions beginning with "B_" are bits within registers
+    Definitions beginning with "V_" are meaningful values of bits within the registers
+    Definitions beginning with "S_" are register sizes
+    Definitions beginning with "N_" are the bit position
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef _PTT_HCI_REGS_H_
+#define _PTT_HCI_REGS_H_
+
+///
+/// LT public space registers
+///
+#define R_LT_UCS                           0xFED30880
+
+
+#endif

--- a/Silicon/Intel/AlderlakeSiliconPkg/Include/Register/TcoRegs.h
+++ b/Silicon/Intel/AlderlakeSiliconPkg/Include/Register/TcoRegs.h
@@ -62,6 +62,7 @@
 
 #define R_TCO_IO_TCO1_CNT                            0x08
 #define S_TCO_IO_TCO1_CNT                            2
+#define B_TCO_IO_TCO1_CNT_TMR_HLT                    BIT11
 #define N_TCO_IO_TCO1_CNT_NMI2SMI_EN                 9
 
 #define R_TCO_IO_TCO2_CNT                            0x0A

--- a/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/IncludePrivate/Library/SpiCommonLib.h
+++ b/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/IncludePrivate/Library/SpiCommonLib.h
@@ -7,7 +7,7 @@
 #ifndef _SPI_COMMON_LIB_H_
 #define _SPI_COMMON_LIB_H_
 
-#include <Protocol/Spi.h>
+#include <Protocol/Spi2.h>
 
 //
 // Maximum time allowed while waiting the SPI cycle to complete
@@ -49,7 +49,7 @@ typedef enum {
 typedef struct {
   UINT32                Signature;
   EFI_HANDLE            Handle;
-  PCH_SPI_PROTOCOL      SpiProtocol;
+  PCH_SPI2_PROTOCOL     SpiProtocol;
   UINT16                PchAcpiBase;
   UINT64                PchSpiBase;
   UINT8                 ReadPermission;
@@ -157,8 +157,8 @@ IsSpiControllerSaveRestoreEnabled (
 /**
   Read data from the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
-  @param[in] FlashRegionType      The Flash Region type for flash cycle which is listed in the Descriptor.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
+  @param[in] FlashRegionGuid      The Flash Region GUID for flash cycle which corresponds to the type in the descriptor.
   @param[in] Address              The Flash Linear Address must fall within a region for which BIOS has access permissions.
   @param[in] ByteCount            Number of bytes in the data portion of the SPI cycle.
   @param[out] Buffer              The Pointer to caller-allocated buffer containing the dada received.
@@ -171,8 +171,8 @@ IsSpiControllerSaveRestoreEnabled (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashRead (
-  IN     PCH_SPI_PROTOCOL   *This,
-  IN     FLASH_REGION_TYPE  FlashRegionType,
+  IN     PCH_SPI2_PROTOCOL  *This,
+  IN     EFI_GUID           *FlashRegionGuid,
   IN     UINT32             Address,
   IN     UINT32             ByteCount,
   OUT    UINT8              *Buffer
@@ -181,8 +181,8 @@ SpiProtocolFlashRead (
 /**
   Write data to the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
-  @param[in] FlashRegionType      The Flash Region type for flash cycle which is listed in the Descriptor.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
+  @param[in] FlashRegionGuid      The Flash Region GUID for flash cycle which corresponds to the type in the descriptor.
   @param[in] Address              The Flash Linear Address must fall within a region for which BIOS has access permissions.
   @param[in] ByteCount            Number of bytes in the data portion of the SPI cycle.
   @param[in] Buffer               Pointer to caller-allocated buffer containing the data sent during the SPI cycle.
@@ -194,8 +194,8 @@ SpiProtocolFlashRead (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashWrite (
-  IN     PCH_SPI_PROTOCOL   *This,
-  IN     FLASH_REGION_TYPE  FlashRegionType,
+  IN     PCH_SPI2_PROTOCOL  *This,
+  IN     EFI_GUID           *FlashRegionGuid,
   IN     UINT32             Address,
   IN     UINT32             ByteCount,
   IN     UINT8              *Buffer
@@ -204,8 +204,8 @@ SpiProtocolFlashWrite (
 /**
   Erase some area on the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
-  @param[in] FlashRegionType      The Flash Region type for flash cycle which is listed in the Descriptor.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
+  @param[in] FlashRegionGuid      The Flash Region GUID for flash cycle which corresponds to the type in the descriptor.
   @param[in] Address              The Flash Linear Address must fall within a region for which BIOS has access permissions.
   @param[in] ByteCount            Number of bytes in the data portion of the SPI cycle.
 
@@ -216,8 +216,8 @@ SpiProtocolFlashWrite (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashErase (
-  IN     PCH_SPI_PROTOCOL   *This,
-  IN     FLASH_REGION_TYPE  FlashRegionType,
+  IN     PCH_SPI2_PROTOCOL  *This,
+  IN     EFI_GUID           *FlashRegionGuid,
   IN     UINT32             Address,
   IN     UINT32             ByteCount
   );
@@ -225,7 +225,7 @@ SpiProtocolFlashErase (
 /**
   Read SFDP data from the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] ComponentNumber      The Componen Number for chip select
   @param[in] Address              The starting byte address for SFDP data read.
   @param[in] ByteCount            Number of bytes in SFDP data portion of the SPI cycle
@@ -239,7 +239,7 @@ SpiProtocolFlashErase (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashReadSfdp (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINT8              ComponentNumber,
   IN     UINT32             Address,
   IN     UINT32             ByteCount,
@@ -249,7 +249,7 @@ SpiProtocolFlashReadSfdp (
 /**
   Read Jedec Id from the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] ComponentNumber      The Componen Number for chip select
   @param[in] ByteCount            Number of bytes in JedecId data portion of the SPI cycle, the data size is 3 typically
   @param[out] JedecId             The Pointer to caller-allocated buffer containing JEDEC ID received
@@ -262,7 +262,7 @@ SpiProtocolFlashReadSfdp (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashReadJedecId (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINT8              ComponentNumber,
   IN     UINT32             ByteCount,
   OUT    UINT8              *JedecId
@@ -271,7 +271,7 @@ SpiProtocolFlashReadJedecId (
 /**
   Write the status register in the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] ByteCount            Number of bytes in Status data portion of the SPI cycle, the data size is 1 typically
   @param[in] StatusValue          The Pointer to caller-allocated buffer containing the value of Status register writing
 
@@ -282,7 +282,7 @@ SpiProtocolFlashReadJedecId (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashWriteStatus (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINT32             ByteCount,
   IN     UINT8              *StatusValue
   );
@@ -290,7 +290,7 @@ SpiProtocolFlashWriteStatus (
 /**
   Read status register in the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] ByteCount            Number of bytes in Status data portion of the SPI cycle, the data size is 1 typically
   @param[out] StatusValue         The Pointer to caller-allocated buffer containing the value of Status register received.
 
@@ -301,7 +301,7 @@ SpiProtocolFlashWriteStatus (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashReadStatus (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINT32             ByteCount,
   OUT    UINT8              *StatusValue
   );
@@ -309,8 +309,8 @@ SpiProtocolFlashReadStatus (
 /**
   Get the SPI region base and size, based on the enum type
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
-  @param[in] FlashRegionType      The Flash Region type for for the base address which is listed in the Descriptor.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
+  @param[in] FlashRegionGuid      The Flash Region GUID for flash cycle which corresponds to the type in the descriptor.
   @param[out] BaseAddress         The Flash Linear Address for the Region 'n' Base
   @param[out] RegionSize          The size for the Region 'n'
 
@@ -321,8 +321,8 @@ SpiProtocolFlashReadStatus (
 EFI_STATUS
 EFIAPI
 SpiProtocolGetRegionAddress (
-  IN     PCH_SPI_PROTOCOL   *This,
-  IN     FLASH_REGION_TYPE  FlashRegionType,
+  IN     PCH_SPI2_PROTOCOL  *This,
+  IN     EFI_GUID           *FlashRegionGuid,
   OUT    UINT32             *BaseAddress,
   OUT    UINT32             *RegionSize
   );
@@ -330,7 +330,7 @@ SpiProtocolGetRegionAddress (
 /**
   Read PCH Soft Strap Values
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] SoftStrapAddr        PCH Soft Strap address offset from FPSBA.
   @param[in] ByteCount            Number of bytes in SoftStrap data portion of the SPI cycle
   @param[out] SoftStrapValue      The Pointer to caller-allocated buffer containing PCH Soft Strap Value.
@@ -344,7 +344,7 @@ SpiProtocolGetRegionAddress (
 EFI_STATUS
 EFIAPI
 SpiProtocolReadPchSoftStrap (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINT32             SoftStrapAddr,
   IN     UINT32             ByteCount,
   OUT    VOID               *SoftStrapValue
@@ -353,7 +353,7 @@ SpiProtocolReadPchSoftStrap (
 /**
   Read CPU Soft Strap Values
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] SoftStrapAddr        CPU Soft Strap address offset from FCPUSBA.
   @param[in] ByteCount            Number of bytes in SoftStrap data portion of the SPI cycle.
   @param[out] SoftStrapValue      The Pointer to caller-allocated buffer containing CPU Soft Strap Value.
@@ -367,7 +367,7 @@ SpiProtocolReadPchSoftStrap (
 EFI_STATUS
 EFIAPI
 SpiProtocolReadCpuSoftStrap (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINT32             SoftStrapAddr,
   IN     UINT32             ByteCount,
   OUT    VOID               *SoftStrapValue

--- a/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/IncludePrivate/Register/SpiRegs.h
+++ b/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/IncludePrivate/Register/SpiRegs.h
@@ -62,6 +62,7 @@
 //
 // BIOS Flash Program Registers (based on SPI_BAR0)
 //
+#define R_SPI_MEM_BFPR                      0x00                          ///< BIOS Flash Primary Region Register(32bits), which is RO and contains the same value from FREG1
 #define R_SPI_MEM_HSFSC                     0x04                          ///< Hardware Sequencing Flash Status and Control Register(32bits)
 #define B_SPI_MEM_HSFSC_FDBC_MASK           0x3F000000                    ///< Flash Data Byte Count ( <= 64), Count = (Value in this field) + 1.
 #define N_SPI_MEM_HSFSC_FDBC                24
@@ -78,12 +79,8 @@
 #define B_SPI_MEM_HSFSC_CYCLE_FGO           BIT16                         ///< Flash Cycle Go.
 #define B_SPI_MEM_HSFSC_FDV                 BIT14                         ///< Flash Descriptor Valid, once valid software can use hareware sequencing regs
 #define B_SPI_MEM_HSFSC_WRSDIS              BIT11                         ///< Write Status Disable
-#define B_SPI_MEM_HSFSC_SAF_CE              BIT8                          ///< SAF ctype error
-#define B_SPI_MEM_HSFSC_SAF_LE              BIT6                          ///< SAF link error
+#define B_SPI_MEM_HSFSC_SAF_MODE_ACTIVE     BIT7                          ///< Indicates flash is attached either directly to the PCH via the SPI bus or EC/BMC
 #define B_SPI_MEM_HSFSC_SCIP                BIT5                          ///< SPI cycle in progress
-#define B_SPI_MEM_HSFSC_SAF_DLE             BIT4                          ///< SAF Data length error
-#define B_SPI_MEM_HSFSC_SAF_ERROR           BIT3                          ///< SAF Error
-#define B_SPI_MEM_HSFSC_AEL                 BIT2                          ///< Access Error Log
 #define B_SPI_MEM_HSFSC_FCERR               BIT1                          ///< Flash Cycle Error
 #define B_SPI_MEM_HSFSC_FDONE               BIT0                          ///< Flash Cycle Done
 #define R_SPI_MEM_FADDR                     0x08                          ///< SPI Flash Address
@@ -112,5 +109,6 @@
 
 #define B_SPI_MEM_SFDPX_VSCCX_EO_64K        BIT29                         ///< 64k Erase valid (EO_64k_valid)
 #define R_SPI_MEM_SFDP1_VSCC1               0xC8                          ///< Vendor Specific Component Capabilities Register(32 bits)
+
 
 #endif

--- a/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/Library/PeiDxeSmmSpiAccessLib/PeiDxeSmmSpiAccessLib.inf
+++ b/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/Library/PeiDxeSmmSpiAccessLib/PeiDxeSmmSpiAccessLib.inf
@@ -1,0 +1,33 @@
+## @file
+# Component description file for PCH SPI access library
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+[Defines]
+INF_VERSION     = 0x00010017
+BASE_NAME       = PeiDxeSmmSpiAccessLib
+FILE_GUID       = A6D4C05A-F6CB-46D5-4BA1-8C47B139DCA6
+VERSION_STRING  = 1.0
+MODULE_TYPE     = BASE
+LIBRARY_CLASS   = SpiAccessLib
+
+
+[LibraryClasses]
+BaseLib
+IoLib
+DebugLib
+PciSegmentLib
+PchPciBdfLib
+PchPcrLib
+
+[Packages]
+MdePkg/MdePkg.dec
+AlderlakeSiliconPkg/SiPkg.dec
+
+
+[Sources]
+SpiAccessLib.c

--- a/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/Library/PeiDxeSmmSpiAccessLib/SpiAccessLib.c
+++ b/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/Library/PeiDxeSmmSpiAccessLib/SpiAccessLib.c
@@ -1,0 +1,75 @@
+/** @file
+  SPI library for abstraction of SPI HW registers accesses
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Uefi/UefiBaseType.h>
+#include <IndustryStandard/Pci22.h>
+#include <Library/BaseLib.h>
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PciSegmentLib.h>
+#include <Library/SpiAccessLib.h>
+#include <Library/PchPciBdfLib.h>
+#include <Register/SpiRegs.h>
+#include <Register/FlashRegs.h>
+#include <Register/PchRegs.h>
+#include <Register/PchDmiRegs.h>
+
+
+/**
+  Checks if PCH SPI Controler is present and available
+
+  @retval TRUE    PCH SPI controller is avaialable
+  @retval FALSE   PCH SPI controller is not available
+**/
+BOOLEAN
+SpiIsControllerAvailable (
+  VOID
+  )
+{
+  //
+  // Checks for SPI controller
+  //
+  return (PciSegmentRead16 (SpiPciCfgBase () + PCI_VENDOR_ID_OFFSET) != 0xFFFF);
+}
+
+/**
+  Returns PCH SPI BAR0 value
+
+  @retval  UINT32  PCH SPI BAR0 value
+**/
+UINT32
+SpiGetBar0 (
+  VOID
+  )
+{
+  UINT32  SpiBar0;
+
+  ASSERT (SpiIsControllerAvailable ());
+  SpiBar0 = PciSegmentRead32 (SpiPciCfgBase () + R_SPI_CFG_BAR0) & ~B_SPI_CFG_BAR0_MASK;
+  ASSERT (SpiBar0 != 0);
+
+  return SpiBar0;
+}
+
+/**
+  Checks if device Attached Flash (DAF) mode is active
+
+  @retval TRUE    SAF mode is active
+  @retval FALSE   SAF mode is not active
+**/
+BOOLEAN
+SpiIsSafModeActive (
+  VOID
+  )
+{
+  UINT32 SpiBar0;
+  SpiBar0 = SpiGetBar0 ();
+
+  return !!(MmioRead32 (SpiBar0 + R_SPI_MEM_HSFSC) & B_SPI_MEM_HSFSC_SAF_MODE_ACTIVE);
+}

--- a/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/Library/PeiSpiLib/PchSpi.c
+++ b/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/Library/PeiSpiLib/PchSpi.c
@@ -9,7 +9,7 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/PciSegmentLib.h>
-#include <Ppi/Spi.h>
+#include <Ppi/Spi2.h>
 #include <Library/SpiCommonLib.h>
 #include <PchReservedResources.h>
 #include <IndustryStandard/Pci30.h>

--- a/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/Library/PeiSpiLib/PeiSpiLib.inf
+++ b/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/Library/PeiSpiLib/PeiSpiLib.inf
@@ -30,7 +30,7 @@ PchPciBdfLib
 [Packages]
 MdePkg/MdePkg.dec
 AlderlakeSiliconPkg/SiPkg.dec
-
+IntelSiliconPkg/IntelSiliconPkg.dec
 
 [Sources]
 PchSpi.c

--- a/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/LibraryPrivate/BaseSpiCommonLib/BaseSpiCommonLib.inf
+++ b/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/LibraryPrivate/BaseSpiCommonLib/BaseSpiCommonLib.inf
@@ -19,11 +19,28 @@
 [Packages]
   MdePkg/MdePkg.dec
   AlderlakeSiliconPkg/SiPkg.dec
+  IntelSiliconPkg/IntelSiliconPkg.dec
 
 [LibraryClasses]
   IoLib
   DebugLib
   PmcLib
   PchPciBdfLib
+  SpiAccessLib
 
-[Pcd]
+[Guids]
+  gFlashRegionDescriptorGuid
+  gFlashRegionBiosGuid
+  gFlashRegionMeGuid
+  gFlashRegionGbeGuid
+  gFlashRegionPlatformDataGuid
+  gFlashRegionDerGuid
+  gFlashRegionSecondaryBiosGuid
+  gFlashRegionMicrocodePatchGuid
+  gFlashRegionEcGuid
+  gFlashRegionDeviceExpansionGuid
+  gFlashRegionIeGuid
+  gFlashRegion10GbeAGuid
+  gFlashRegion10GbeBGuid
+  gFlashRegionAllGuid
+  gFlashRegionMaxGuid

--- a/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/LibraryPrivate/BaseSpiCommonLib/SpiCommon.c
+++ b/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/LibraryPrivate/BaseSpiCommonLib/SpiCommon.c
@@ -12,16 +12,136 @@
 #include <IndustryStandard/Pci30.h>
 #include <Library/PmcLib.h>
 #include <Library/PciSegmentLib.h>
-#include <Protocol/Spi.h>
+#include <Protocol/Spi2.h>
 #include <Library/SpiCommonLib.h>
 #include <Register/PchRegs.h>
 #include <Register/SpiRegs.h>
 #include <Register/FlashRegs.h>
 #include <Register/PmcRegs.h>
 #include <Library/PchPciBdfLib.h>
+#include <Library/SpiAccessLib.h>
 
 #define DEFAULT_CPU_STRAP_BASE_OFFSET 0x300 // Default CPU Straps base offset
 #define B_SPI_MEM_HSFSC_SAVE_MASK     (B_SPI_MEM_HSFSC_FDBC_MASK | B_SPI_MEM_HSFSC_CYCLE_MASK)
+
+typedef enum {
+  FlashRegionDescriptor,
+  FlashRegionBios,
+  FlashRegionMe,
+  FlashRegionGbe,
+  FlashRegionPlatformData,
+  FlashRegionDer,
+  FlashRegionSecondaryBios,
+  FlashRegionMicrocodePatch,
+  FlashRegionEc,
+  FlashRegionDeviceExpansion,
+  FlashRegionIe,
+  FlashRegion10GbeA,
+  FlashRegion10GbeB,
+  FlashRegionAll = 16,
+  FlashRegionMax
+} FLASH_REGION_TYPE;
+
+typedef struct {
+  EFI_GUID            *Guid;
+  FLASH_REGION_TYPE   Type;
+} FLASH_REGION_MAPPING;
+
+FLASH_REGION_MAPPING mFlashRegionTypes[] = {
+  {
+    &gFlashRegionDescriptorGuid,
+    FlashRegionDescriptor
+  },
+  {
+    &gFlashRegionBiosGuid,
+    FlashRegionBios
+  },
+  {
+    &gFlashRegionMeGuid,
+    FlashRegionMe
+  },
+  {
+    &gFlashRegionGbeGuid,
+    FlashRegionGbe
+  },
+  {
+    &gFlashRegionPlatformDataGuid,
+    FlashRegionPlatformData
+  },
+  {
+    &gFlashRegionDerGuid,
+    FlashRegionDer
+  },
+  {
+    &gFlashRegionSecondaryBiosGuid,
+    FlashRegionSecondaryBios
+  },
+  {
+    &gFlashRegionMicrocodePatchGuid,
+    FlashRegionMicrocodePatch
+  },
+  {
+    &gFlashRegionEcGuid,
+    FlashRegionEc
+  },
+  {
+    &gFlashRegionDeviceExpansionGuid,
+    FlashRegionDeviceExpansion
+  },
+  {
+    &gFlashRegionIeGuid,
+    FlashRegionIe
+  },
+  {
+    &gFlashRegion10GbeAGuid,
+    FlashRegion10GbeA
+  },
+  {
+    &gFlashRegion10GbeBGuid,
+    FlashRegion10GbeB
+  },
+  {
+    &gFlashRegionAllGuid,
+    FlashRegionAll
+  },
+  {
+    &gFlashRegionMaxGuid,
+    FlashRegionMax
+  }
+};
+
+/**
+  Returns the type of a flash region given its GUID.
+
+  @param[in]    FlashRegionGuid   Pointer to the flash region GUID.
+  @param[out]   FlashRegionType   Pointer to a buffer that will be set to the flash region type value.
+
+  @retval       EFI_SUCCESS             The flash region type was found for the given flash region GUID.
+  @retval       EFI_INVALID_PARAMETER   A pointer argument passed to the function is NULL.
+  @retval       EFI_NOT_FOUND           The flash region type was not found for the given flash region GUID.
+
+**/
+EFI_STATUS
+GetFlashRegionType (
+  IN     EFI_GUID           *FlashRegionGuid,
+  OUT    FLASH_REGION_TYPE  *FlashRegionType
+  )
+{
+  UINTN   Index;
+
+  if (FlashRegionGuid == NULL || FlashRegionType == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Index = 0; Index < ARRAY_SIZE (mFlashRegionTypes); Index++) {
+    if (CompareGuid (mFlashRegionTypes[Index].Guid, FlashRegionGuid)) {
+      *FlashRegionType = mFlashRegionTypes[Index].Type;
+      return EFI_SUCCESS;
+    }
+  }
+
+  return EFI_NOT_FOUND;
+}
 
 /**
   Initialize an SPI protocol instance.
@@ -184,7 +304,7 @@ SpiProtocolConstructor (
   // If CPU Strap base address is different than 0x300 need to add MDTBA value for final location
   //
   if (SpiInstance->CpuStrapBaseAddr != DEFAULT_CPU_STRAP_BASE_OFFSET) {
-    Status = SpiProtocolFlashRead (&(SpiInstance->SpiProtocol), FlashRegionAll, R_FLASH_UMAP1, sizeof (Data32), (UINT8 *) (&Data32));
+    Status = SpiProtocolFlashRead (&(SpiInstance->SpiProtocol), &gFlashRegionAllGuid, R_FLASH_UMAP1, sizeof (Data32), (UINT8 *) (&Data32));
     ASSERT_EFI_ERROR (Status);
     Mdtba = (UINT16)(((Data32 & B_FLASH_UMAP1_MDTBA) >> N_FLASH_UMAP1_MDTBA) << N_FLASH_UMAP1_MDTBA_REPR);
     DEBUG ((DEBUG_INFO, "Mdtba : %0x\n", Mdtba));
@@ -279,7 +399,7 @@ PchPmTimerStallRuntimeSafe (
 STATIC
 BOOLEAN
 WaitForSpiCycleComplete (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINTN              PchSpiBar0,
   IN     BOOLEAN            ErrorCheck
   )
@@ -317,7 +437,7 @@ WaitForSpiCycleComplete (
   This function waits for a pending SPI transaction to complete without clearing
   status fields
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] PchSpiBar0           SPI MMIO address
 
   @retval TRUE                    SPI cycle completed on the interface.
@@ -327,7 +447,7 @@ WaitForSpiCycleComplete (
 BOOLEAN
 STATIC
 WaitForScipNoClear (
-  IN      PCH_SPI_PROTOCOL    *This,
+  IN      PCH_SPI2_PROTOCOL   *This,
   IN      UINTN               PchSpiBar0
   )
 {
@@ -353,86 +473,10 @@ WaitForScipNoClear (
 }
 
 /**
-  This function sets the FDONE and optionally FCERR bits in the HSFS_CTL register
-
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
-  @param[in] PchSpiBar0           SPI MMIO address
-  @param[in] SetErrorBit          Set to TRUE to set the FCERR bit
-
-**/
-VOID
-STATIC
-SetHsfscFdone (
-  IN      PCH_SPI_PROTOCOL    *This,
-  IN      UINTN               PchSpiBar0,
-  IN      BOOLEAN             SetFcErrorBit
-  )
-{
-  EFI_STATUS    Status;
-  UINT32        HardwareSpiAddr;
-  UINT32        FlashRegionSize;
-  UINT32        Index;
-  UINT8         DataCount;
-
-  Status = SpiProtocolGetRegionAddress (This, FlashRegionBios, &HardwareSpiAddr, &FlashRegionSize);
-  if (EFI_ERROR (Status)) {
-    return;
-  }
-
-  //
-  // Clear FDONE and FCERR
-  //
-  MmioWrite8 (PchSpiBar0 + R_SPI_MEM_HSFSC, B_SPI_MEM_HSFSC_FCERR | B_SPI_MEM_HSFSC_FDONE);
-
-  //
-  // Fill data buffer
-  //
-  if (SetFcErrorBit) {
-    for (Index = 0; Index < 64; Index += sizeof (UINT32)) {
-      MmioWrite32 (PchSpiBar0 + R_SPI_MEM_FDATA00 + Index, 0xFFFFFFFF);
-    }
-  }
-
-  //
-  // Set the Flash Address
-  //
-  MmioWrite32 (
-    (PchSpiBar0 + R_SPI_MEM_FADDR),
-    (UINT32) (HardwareSpiAddr & B_SPI_MEM_FADDR_MASK)
-    );
-  //
-  // Set Data count, Flash cycle, and Set Go bit to start a cycle
-  //
-  if (SetFcErrorBit) {
-    DataCount = 0x3F;
-  } else {
-    DataCount = 0;
-  }
-  MmioAndThenOr32 (
-    PchSpiBar0 + R_SPI_MEM_HSFSC,
-    (UINT32) (~(B_SPI_MEM_HSFSC_FDBC_MASK | B_SPI_MEM_HSFSC_CYCLE_MASK)),
-    (UINT32) (((DataCount << N_SPI_MEM_HSFSC_FDBC) & B_SPI_MEM_HSFSC_FDBC_MASK) |
-              (V_SPI_MEM_HSFSC_CYCLE_READ << N_SPI_MEM_HSFSC_CYCLE)             |
-              B_SPI_MEM_HSFSC_CYCLE_FGO)
-    );
-
-  if (SetFcErrorBit) {
-    //
-    // Intentionally write to FDATA while a cycle is in progress to generate an error
-    //
-    for (Index = 0; Index < 64; Index += sizeof (UINT32)) {
-      MmioWrite32 (PchSpiBar0 + R_SPI_MEM_FDATA00 + Index, 0x0);
-    }
-  }
-
-  WaitForScipNoClear (This, PchSpiBar0);
-}
-
-/**
   This function sends the programmed SPI command to the device.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
-  @param[in] SpiRegionType        The SPI Region type for flash cycle which is listed in the Descriptor
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
+  @param[in] FlashRegionGuid      The Flash Region GUID for flash cycle which corresponds to the type in the descriptor.
   @param[in] FlashCycleType       The Flash SPI cycle type list in HSFC (Hardware Sequencing Flash Control Register) register
   @param[in] Address              The Flash Linear Address must fall within a region for which BIOS has access permissions.
   @param[in] ByteCount            Number of bytes in the data portion of the SPI cycle.
@@ -446,8 +490,8 @@ SetHsfscFdone (
 STATIC
 EFI_STATUS
 SendSpiCmd (
-  IN     PCH_SPI_PROTOCOL   *This,
-  IN     FLASH_REGION_TYPE  FlashRegionType,
+  IN     PCH_SPI2_PROTOCOL  *This,
+  IN     EFI_GUID           *FlashRegionGuid,
   IN     FLASH_CYCLE_TYPE   FlashCycleType,
   IN     UINT32             Address,
   IN     UINT32             ByteCount,
@@ -564,7 +608,7 @@ SendSpiCmd (
     }
   }
 
-  Status = SpiProtocolGetRegionAddress (This, FlashRegionType, &HardwareSpiAddr, &FlashRegionSize);
+  Status = SpiProtocolGetRegionAddress (This, FlashRegionGuid, &HardwareSpiAddr, &FlashRegionSize);
   if (EFI_ERROR (Status)) {
     goto SendSpiCmdEnd;
   }
@@ -752,31 +796,6 @@ SendSpiCmd (
 
 SendSpiCmdEnd:
   //
-  // Restore SPI controller state
-  //
-  if (RestoreState) {
-    if (HsfscFdoneSave) {
-      SetHsfscFdone (This, PchSpiBar0, HsfscFcerrSave);
-    }
-    MmioAndThenOr32 (
-      PchSpiBar0 + R_SPI_MEM_HSFSC,
-      (UINT32)  ~(B_SPI_MEM_HSFSC_SAVE_MASK |
-                  B_SPI_MEM_HSFSC_SAF_CE    |   // This bit clears when set to 1, ensure 0 is written
-                  B_SPI_MEM_HSFSC_SAF_LE    |   // This bit clears when set to 1, ensure 0 is written
-                  B_SPI_MEM_HSFSC_SAF_DLE   |   // This bit clears when set to 1, ensure 0 is written
-                  B_SPI_MEM_HSFSC_SAF_ERROR |   // This bit clears when set to 1, ensure 0 is written
-                  B_SPI_MEM_HSFSC_AEL       |   // This bit clears when set to 1, ensure 0 is written
-                  B_SPI_MEM_HSFSC_FCERR     |   // This bit clears when set to 1, ensure 0 is written
-                  B_SPI_MEM_HSFSC_FDONE),       // This bit clears when set to 1, ensure 0 is written
-      HsfscSave
-      );
-    MmioWrite32 (PchSpiBar0 + R_SPI_MEM_FADDR, FaddrSave);
-    for (Index = 0; Index < 64; Index += sizeof (UINT32)) {
-      MmioWrite32 (PchSpiBar0 + R_SPI_MEM_FDATA00 + Index, FdataSave[Index >> 2]);
-    }
-  }
-
-  //
   // Restore the settings for SPI Prefetching and Caching and enable BIOS Write Protect
   //
   if ((FlashCycleType == FlashCycleWrite) ||
@@ -801,8 +820,8 @@ SendSpiCmdEnd:
 /**
   Read data from the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
-  @param[in] FlashRegionType      The Flash Region type for flash cycle which is listed in the Descriptor.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
+  @param[in] FlashRegionGuid      The Flash Region GUID for flash cycle which corresponds to the type in the descriptor.
   @param[in] Address              The Flash Linear Address must fall within a region for which BIOS has access permissions.
   @param[in] ByteCount            Number of bytes in the data portion of the SPI cycle.
   @param[out] Buffer              The Pointer to caller-allocated buffer containing the dada received.
@@ -815,8 +834,8 @@ SendSpiCmdEnd:
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashRead (
-  IN     PCH_SPI_PROTOCOL   *This,
-  IN     FLASH_REGION_TYPE  FlashRegionType,
+  IN     PCH_SPI2_PROTOCOL  *This,
+  IN     EFI_GUID           *FlashRegionGuid,
   IN     UINT32             Address,
   IN     UINT32             ByteCount,
   OUT    UINT8              *Buffer
@@ -829,7 +848,7 @@ SpiProtocolFlashRead (
   //
   Status = SendSpiCmd (
              This,
-             FlashRegionType,
+             FlashRegionGuid,
              FlashCycleRead,
              Address,
              ByteCount,
@@ -841,8 +860,8 @@ SpiProtocolFlashRead (
 /**
   Write data to the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
-  @param[in] FlashRegionType      The Flash Region type for flash cycle which is listed in the Descriptor.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
+  @param[in] FlashRegionGuid      The Flash Region GUID for flash cycle which corresponds to the type in the descriptor.
   @param[in] Address              The Flash Linear Address must fall within a region for which BIOS has access permissions.
   @param[in] ByteCount            Number of bytes in the data portion of the SPI cycle.
   @param[in] Buffer               Pointer to caller-allocated buffer containing the data sent during the SPI cycle.
@@ -854,8 +873,8 @@ SpiProtocolFlashRead (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashWrite (
-  IN     PCH_SPI_PROTOCOL   *This,
-  IN     FLASH_REGION_TYPE  FlashRegionType,
+  IN     PCH_SPI2_PROTOCOL  *This,
+  IN     EFI_GUID           *FlashRegionGuid,
   IN     UINT32             Address,
   IN     UINT32             ByteCount,
   IN     UINT8              *Buffer
@@ -868,7 +887,7 @@ SpiProtocolFlashWrite (
   //
   Status = SendSpiCmd (
              This,
-             FlashRegionType,
+             FlashRegionGuid,
              FlashCycleWrite,
              Address,
              ByteCount,
@@ -880,8 +899,8 @@ SpiProtocolFlashWrite (
 /**
   Erase some area on the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
-  @param[in] FlashRegionType      The Flash Region type for flash cycle which is listed in the Descriptor.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
+  @param[in] FlashRegionGuid      The Flash Region GUID for flash cycle which corresponds to the type in the descriptor.
   @param[in] Address              The Flash Linear Address must fall within a region for which BIOS has access permissions.
   @param[in] ByteCount            Number of bytes in the data portion of the SPI cycle.
 
@@ -892,8 +911,8 @@ SpiProtocolFlashWrite (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashErase (
-  IN     PCH_SPI_PROTOCOL   *This,
-  IN     FLASH_REGION_TYPE  FlashRegionType,
+  IN     PCH_SPI2_PROTOCOL  *This,
+  IN     EFI_GUID           *FlashRegionGuid,
   IN     UINT32             Address,
   IN     UINT32             ByteCount
   )
@@ -905,7 +924,7 @@ SpiProtocolFlashErase (
   //
   Status = SendSpiCmd (
              This,
-             FlashRegionType,
+             FlashRegionGuid,
              FlashCycleErase,
              Address,
              ByteCount,
@@ -917,7 +936,7 @@ SpiProtocolFlashErase (
 /**
   Read SFDP data from the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] ComponentNumber      The Componen Number for chip select
   @param[in] Address              The starting byte address for SFDP data read.
   @param[in] ByteCount            Number of bytes in SFDP data portion of the SPI cycle
@@ -932,20 +951,53 @@ SpiProtocolFlashErase (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashReadSfdp (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINT8              ComponentNumber,
   IN     UINT32             Address,
   IN     UINT32             ByteCount,
   OUT    UINT8              *SfdpData
   )
 {
-  return EFI_SUCCESS;
+  SPI_INSTANCE      *SpiInstance;
+  EFI_STATUS        Status;
+  UINT32            FlashAddress;
+
+  if (SpiIsSafModeActive ()) {
+    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __FUNCTION__));
+    return EFI_UNSUPPORTED;
+  }
+
+  SpiInstance       = SPI_INSTANCE_FROM_SPIPROTOCOL (This);
+  Status            = EFI_SUCCESS;
+
+  if (ComponentNumber > SpiInstance->NumberOfComponents) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FlashAddress = 0;
+  if (ComponentNumber == FlashComponent1) {
+    FlashAddress = SpiInstance->Component1StartAddr;
+  }
+  FlashAddress += Address;
+  //
+  // Sends the command to the SPI interface to execute.
+  //
+  Status = SendSpiCmd (
+             This,
+             &gFlashRegionAllGuid,
+             FlashCycleReadSfdp,
+             FlashAddress,
+             ByteCount,
+             SfdpData
+             );
+  return Status;
 }
 
 /**
   Read Jedec Id from the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] ComponentNumber      The Componen Number for chip select
   @param[in] ByteCount            Number of bytes in JedecId data portion of the SPI cycle, the data size is 3 typically
   @param[out] JedecId             The Pointer to caller-allocated buffer containing JEDEC ID received
@@ -959,19 +1011,52 @@ SpiProtocolFlashReadSfdp (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashReadJedecId (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINT8              ComponentNumber,
   IN     UINT32             ByteCount,
   OUT    UINT8              *JedecId
   )
 {
-  return EFI_SUCCESS;
+  SPI_INSTANCE      *SpiInstance;
+  EFI_STATUS        Status;
+  UINT32            Address;
+
+  if (SpiIsSafModeActive ()) {
+    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __FUNCTION__));
+    return EFI_UNSUPPORTED;
+  }
+
+  SpiInstance       = SPI_INSTANCE_FROM_SPIPROTOCOL (This);
+  Status            = EFI_SUCCESS;
+
+  if (ComponentNumber > SpiInstance->NumberOfComponents) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Address = 0;
+  if (ComponentNumber == FlashComponent1) {
+    Address = SpiInstance->Component1StartAddr;
+  }
+
+  //
+  // Sends the command to the SPI interface to execute.
+  //
+  Status = SendSpiCmd (
+             This,
+             &gFlashRegionAllGuid,
+             FlashCycleReadJedecId,
+             Address,
+             ByteCount,
+             JedecId
+             );
+  return Status;
 }
 
 /**
   Write the status register in the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] ByteCount            Number of bytes in Status data portion of the SPI cycle, the data size is 1 typically
   @param[in] StatusValue          The Pointer to caller-allocated buffer containing the value of Status register writing
 
@@ -983,18 +1068,36 @@ SpiProtocolFlashReadJedecId (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashWriteStatus (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINT32             ByteCount,
   IN     UINT8              *StatusValue
   )
 {
-  return EFI_SUCCESS;
+  EFI_STATUS        Status;
+
+  if (SpiIsSafModeActive ()) {
+    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __FUNCTION__));
+    return EFI_UNSUPPORTED;
+  }
+
+  //
+  // Sends the command to the SPI interface to execute.
+  //
+  Status = SendSpiCmd (
+             This,
+             &gFlashRegionAllGuid,
+             FlashCycleWriteStatus,
+             0,
+             ByteCount,
+             StatusValue
+             );
+  return Status;
 }
 
 /**
   Read status register in the flash part.
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] ByteCount            Number of bytes in Status data portion of the SPI cycle, the data size is 1 typically
   @param[out] StatusValue         The Pointer to caller-allocated buffer containing the value of Status register received.
 
@@ -1006,19 +1109,37 @@ SpiProtocolFlashWriteStatus (
 EFI_STATUS
 EFIAPI
 SpiProtocolFlashReadStatus (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINT32             ByteCount,
   OUT    UINT8              *StatusValue
   )
 {
-  return EFI_SUCCESS;
+  EFI_STATUS        Status;
+
+  if (SpiIsSafModeActive ()) {
+    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __FUNCTION__));
+    return EFI_UNSUPPORTED;
+  }
+
+  //
+  // Sends the command to the SPI interface to execute.
+  //
+  Status = SendSpiCmd (
+             This,
+             &gFlashRegionAllGuid,
+             FlashCycleReadStatus,
+             0,
+             ByteCount,
+             StatusValue
+             );
+  return Status;
 }
 
 /**
   Get the SPI region base and size, based on the enum type
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
-  @param[in] FlashRegionType      The Flash Region type for for the base address which is listed in the Descriptor.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
+  @param[in] FlashRegionGuid      The Flash Region GUID for flash cycle which corresponds to the type in the descriptor.
   @param[out] BaseAddress         The Flash Linear Address for the Region 'n' Base
   @param[out] RegionSize          The size for the Region 'n'
 
@@ -1029,18 +1150,24 @@ SpiProtocolFlashReadStatus (
 EFI_STATUS
 EFIAPI
 SpiProtocolGetRegionAddress (
-  IN     PCH_SPI_PROTOCOL   *This,
-  IN     FLASH_REGION_TYPE  FlashRegionType,
+  IN     PCH_SPI2_PROTOCOL  *This,
+  IN     EFI_GUID           *FlashRegionGuid,
   OUT    UINT32             *BaseAddress,
   OUT    UINT32             *RegionSize
   )
 {
+  EFI_STATUS          Status;
+  FLASH_REGION_TYPE   FlashRegionType;
   SPI_INSTANCE    *SpiInstance;
   UINTN           PchSpiBar0;
   UINT32          ReadValue;
 
   SpiInstance     = SPI_INSTANCE_FROM_SPIPROTOCOL (This);
 
+  Status = GetFlashRegionType (FlashRegionGuid, &FlashRegionType);
+  if (EFI_ERROR (Status)) {
+    return EFI_INVALID_PARAMETER;
+  }
   if (FlashRegionType >= FlashRegionMax) {
     return EFI_INVALID_PARAMETER;
   }
@@ -1053,10 +1180,8 @@ SpiProtocolGetRegionAddress (
 
   PchSpiBar0      = AcquireSpiBar0 (SpiInstance);
 
-  ReadValue = MmioRead32 (PchSpiBar0 + (R_SPI_MEM_FREG0_FLASHD + (S_SPI_MEM_FREGX * ((UINT32) FlashRegionType))));
-
   ReleaseSpiBar0 (SpiInstance);
-
+  ReadValue = MmioRead32 (PchSpiBar0 + (R_SPI_MEM_FREG0_FLASHD + (S_SPI_MEM_FREGX * ((UINT32) FlashRegionType))));
   //
   // If the region is not used, the Region Base is 7FFFh and Region Limit is 0000h
   //
@@ -1077,7 +1202,7 @@ SpiProtocolGetRegionAddress (
 /**
   Read PCH Soft Strap Values
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] SoftStrapAddr        PCH Soft Strap address offset from FPSBA.
   @param[in] ByteCount            Number of bytes in SoftStrap data portion of the SPI cycle
   @param[out] SoftStrapValue      The Pointer to caller-allocated buffer containing PCH Soft Strap Value.
@@ -1091,19 +1216,51 @@ SpiProtocolGetRegionAddress (
 EFI_STATUS
 EFIAPI
 SpiProtocolReadPchSoftStrap (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINT32             SoftStrapAddr,
   IN     UINT32             ByteCount,
   OUT    VOID               *SoftStrapValue
   )
 {
-  return EFI_SUCCESS;
+  SPI_INSTANCE      *SpiInstance;
+  UINT32            StrapFlashAddr;
+  EFI_STATUS        Status;
+
+  SpiInstance     = SPI_INSTANCE_FROM_SPIPROTOCOL (This);
+
+  if (ByteCount == 0) {
+    *(UINT16 *) SoftStrapValue = SpiInstance->PchStrapSize;
+    return EFI_SUCCESS;
+  }
+
+  if ((SoftStrapAddr + ByteCount) > (UINT32) SpiInstance->PchStrapSize) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // PCH Strap Flash Address = FPSBA + RamAddr
+  //
+  StrapFlashAddr = SpiInstance->PchStrapBaseAddr + SoftStrapAddr;
+
+  //
+  // Read PCH Soft straps from using execute command
+  //
+  Status = SendSpiCmd (
+             This,
+              &gFlashRegionDescriptorGuid,
+             FlashCycleRead,
+             StrapFlashAddr,
+             ByteCount,
+             SoftStrapValue
+             );
+  return Status;
 }
 
 /**
   Read CPU Soft Strap Values
 
-  @param[in] This                 Pointer to the PCH_SPI_PROTOCOL instance.
+  @param[in] This                 Pointer to the PCH_SPI2_PROTOCOL instance.
   @param[in] SoftStrapAddr        CPU Soft Strap address offset from FCPUSBA.
   @param[in] ByteCount            Number of bytes in SoftStrap data portion of the SPI cycle.
   @param[out] SoftStrapValue      The Pointer to caller-allocated buffer containing CPU Soft Strap Value.
@@ -1117,11 +1274,43 @@ SpiProtocolReadPchSoftStrap (
 EFI_STATUS
 EFIAPI
 SpiProtocolReadCpuSoftStrap (
-  IN     PCH_SPI_PROTOCOL   *This,
+  IN     PCH_SPI2_PROTOCOL  *This,
   IN     UINT32             SoftStrapAddr,
   IN     UINT32             ByteCount,
   OUT    VOID               *SoftStrapValue
   )
 {
-  return EFI_SUCCESS;
+  SPI_INSTANCE      *SpiInstance;
+  UINT32            StrapFlashAddr;
+  EFI_STATUS        Status;
+
+  SpiInstance     = SPI_INSTANCE_FROM_SPIPROTOCOL (This);
+
+  if (ByteCount == 0) {
+    *(UINT16 *) SoftStrapValue = SpiInstance->CpuStrapSize;
+    return EFI_SUCCESS;
+  }
+
+  if ((SoftStrapAddr + ByteCount) > (UINT32) SpiInstance->CpuStrapSize) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // CPU Strap Flash Address = FCPUSBA + RamAddr
+  //
+  StrapFlashAddr = SpiInstance->CpuStrapBaseAddr + SoftStrapAddr;
+
+  //
+  // Read Cpu Soft straps from using execute command
+  //
+  Status = SendSpiCmd (
+             This,
+             &gFlashRegionDescriptorGuid,
+             FlashCycleRead,
+             StrapFlashAddr,
+             ByteCount,
+             SoftStrapValue
+             );
+  return Status;
 }

--- a/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/Smm/SpiSmm.inf
+++ b/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/Smm/SpiSmm.inf
@@ -24,19 +24,20 @@ UefiBootServicesTableLib
 BaseLib
 SmmServicesTableLib
 SpiCommonLib
+SmmPchPrivateLib
 PchPciBdfLib
 
 [Packages]
 MdePkg/MdePkg.dec
 AlderlakeSiliconPkg/SiPkg.dec
-
+IntelSiliconPkg/IntelSiliconPkg.dec
 
 [Sources]
 Spi.c
 
 
 [Protocols]
-gPchSmmSpiProtocolGuid                ## PRODUCES
+gPchSmmSpi2ProtocolGuid                ## PRODUCES
 gEfiSmmCpuProtocolGuid                ## CONSUMES
 gEdkiiSmmExitBootServicesProtocolGuid ## CONSUMES
 

--- a/Silicon/Intel/AlderlakeSiliconPkg/Pch/IncludePrivate/Library/SmmPchPrivateLib.h
+++ b/Silicon/Intel/AlderlakeSiliconPkg/Pch/IncludePrivate/Library/SmmPchPrivateLib.h
@@ -1,0 +1,27 @@
+/** @file
+  Header file for private PCH SMM Lib.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef _SMM_PCH_PRIVATE_LIB_H_
+#define _SMM_PCH_PRIVATE_LIB_H_
+
+/**
+  Set InSmm.Sts bit
+**/
+VOID
+PchSetInSmmSts (
+  VOID
+  );
+
+/**
+  Clear InSmm.Sts bit
+**/
+VOID
+PchClearInSmmSts (
+  VOID
+  );
+
+#endif // _SMM_PCH_PRIVATE_LIB_H_

--- a/Silicon/Intel/AlderlakeSiliconPkg/Pch/LibraryPrivate/SmmPchPrivateLib/SmmPchPrivateLib.c
+++ b/Silicon/Intel/AlderlakeSiliconPkg/Pch/LibraryPrivate/SmmPchPrivateLib/SmmPchPrivateLib.c
@@ -1,0 +1,61 @@
+/** @file
+  PCH SMM private lib.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/BaseLib.h>
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+#include <Library/CpuPlatformLib.h>
+#include <CpuRegs.h>
+#include <Register/CommonMsr.h>
+#include <Register/PttPtpRegs.h>
+
+
+/**
+  Set InSmm.Sts bit
+**/
+VOID
+PchSetInSmmSts (
+  VOID
+  )
+{
+  UINT32      Data32;
+
+  ///
+  /// Read memory location FED30880h OR with 00000001h, place the result in EAX,
+  /// and write data to lower 32 bits of MSR 1FEh (sample code available)
+  ///
+  Data32 = MmioRead32 (R_LT_UCS);
+  AsmWriteMsr32 (MSR_SPCL_CHIPSET_USAGE, Data32 | BIT0);
+  ///
+  /// Read FED30880h back to ensure the setting went through.
+  ///
+  Data32 = MmioRead32 (R_LT_UCS);
+}
+
+/**
+  Clear InSmm.Sts bit
+**/
+VOID
+PchClearInSmmSts (
+  VOID
+  )
+{
+  UINT32      Data32;
+
+  ///
+  /// Read memory location FED30880h AND with FFFFFFFEh, place the result in EAX,
+  /// and write data to lower 32 bits of MSR 1FEh (sample code available)
+  ///
+  Data32 = MmioRead32 (R_LT_UCS);
+  AsmWriteMsr32 (MSR_SPCL_CHIPSET_USAGE, Data32 & (UINT32) (~BIT0));
+  ///
+  /// Read FED30880h back to ensure the setting went through.
+  ///
+  Data32 = MmioRead32 (R_LT_UCS);
+}

--- a/Silicon/Intel/AlderlakeSiliconPkg/Pch/LibraryPrivate/SmmPchPrivateLib/SmmPchPrivateLib.inf
+++ b/Silicon/Intel/AlderlakeSiliconPkg/Pch/LibraryPrivate/SmmPchPrivateLib/SmmPchPrivateLib.inf
@@ -1,0 +1,32 @@
+## @file
+#  PCH SMM private lib.
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+[Defines]
+INF_VERSION = 0x00010017
+BASE_NAME = SmmPchPrivateLib
+FILE_GUID = FE6495FB-7AA9-4A24-BF3E-4698F7BCE0EE
+VERSION_STRING = 1.0
+MODULE_TYPE = DXE_SMM_DRIVER
+LIBRARY_CLASS = SmmPchPrivateLib
+
+
+[LibraryClasses]
+BaseLib
+IoLib
+DebugLib
+CpuPlatformLib
+
+
+[Packages]
+MdePkg/MdePkg.dec
+AlderlakeSiliconPkg/SiPkg.dec
+
+
+[Sources]
+SmmPchPrivateLib.c

--- a/Silicon/Intel/AlderlakeSiliconPkg/Product/Alderlake/SiPkgDxeLib.dsc
+++ b/Silicon/Intel/AlderlakeSiliconPkg/Product/Alderlake/SiPkgDxeLib.dsc
@@ -12,6 +12,11 @@
 !include $(PLATFORM_SI_PACKAGE)/Fru/AdlPch/DxeLib.dsc
 
 #
+# Pch
+#
+ SmmPchPrivateLib|$(PLATFORM_SI_PACKAGE)/Pch/LibraryPrivate/SmmPchPrivateLib/SmmPchPrivateLib.inf
+
+#
 # Common
 #
  AslUpdateLib|IntelSiliconPkg/Library/DxeAslUpdateLib/DxeAslUpdateLib.inf

--- a/Silicon/Intel/AlderlakeSiliconPkg/SiPkg.dec
+++ b/Silicon/Intel/AlderlakeSiliconPkg/SiPkg.dec
@@ -33,6 +33,7 @@ IpBlock/HostBridge/IncludePrivate
 
 # Cpu
 Cpu/IncludePrivate
+Pch/IncludePrivate
 
 IncludePrivate
 
@@ -355,6 +356,7 @@ PchInfoLib|Pch/Include/Library/PchInfoLib.h
 PchPcieRpLib|Include/Library/PchPcieRpLib.h
 PchPcrLib|Include/Library/PchPcrLib.h
 PchSbiAccessLib|IpBlock/P2sb/IncludePrivate/Library/PchSbiAccessLib.h
+SmmPchPrivateLib|Pch/IncludePrivate/Library/SmmPchPrivateLib.h
 PchPciBdfLib|Pch/Include/Library/PchPciBdfLib.h
 PchRasLib|Pch/Include/Library/PchRasLib.h
 PchRtcLib|Pch/Include/Library/PchRtcLib.h
@@ -394,7 +396,7 @@ OcPlatformLib|Include/Library/OcPlatformLib.h
 PeiSpsPreMemPolicyLib|Include/Library/PeiSpsPreMemPolicyLib.h
 PmcLib|Include/Library/PmcLib.h
 PmcSsramLib|Include/Library/PmcSsramLib.h
-SpiLib|Include/Library/SpiLib.h
+SpiAccessLib|Include/Library/SpiAccessLib.h
 SpsDxeLib|Include/Library/SpsDxeLib.h
 SpsGetDxeConfigBlockLib|Include/Library/SpsGetDxeConfigBlock.h
 MeGetPeiConfigBlock|Include/Library/MeGetConfigBlock.h


### PR DESCRIPTION
…ons by GUID

https://bugzilla.tianocore.org/show_bug.cgi?id=4664

1. Updates references to the "PCH_SPI_PROTOCOL" to instead refer to "PCH_SPI2_PROTOCOL".
2. Updates the library to identify flash regions by GUID and internally map the GUID entries to values specific to AlderlakeSiliconPkg.
3. Libs/modules that need to reference IntelSiliconPkg are updated.
4. Add gUsbConfigGuid to fix USB not working issue in OS.

Cc: Sai Chaganty <rangasai.v.chaganty@intel.com>
Cc: Rosen Chuang <rosen.chuang@intel.com>
Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Haoyu Tang <haoyu.tang@intel.com>