### PR TITLE
Platform/Loongson: loongarch supports parsing multi-chip flash

### DIFF
--- a/Platform/Loongson/LoongArchQemuPkg/Library/NorFlashQemuLib/NorFlashQemuLib.inf
+++ b/Platform/Loongson/LoongArchQemuPkg/Library/NorFlashQemuLib/NorFlashQemuLib.inf
@@ -35,6 +35,8 @@
   gFdtClientProtocolGuid
 
 [Pcd]
+gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFdBaseAddress
+gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFirmwareFdSize
 gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
 gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize
 gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize

--- a/Platform/Loongson/LoongArchQemuPkg/Loongson.fdf
+++ b/Platform/Loongson/LoongArchQemuPkg/Loongson.fdf
@@ -12,8 +12,8 @@
 
 #####################################################################################################
 [FD.QEMU_EFI]
-BaseAddress   = $(FD_BASE_ADDRESS)
-Size          = $(FD_SIZE)
+BaseAddress   = $(FD_BASE_ADDRESS)|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFdBaseAddress
+Size          = $(FD_SIZE)|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFirmwareFdSize
 ErasePolarity = 1
 BlockSize     = $(BLOCK_SIZE)
 NumBlocks     = $(FD_BLOCKS)


### PR DESCRIPTION
The current implementation of loongarch NorFlashQemuLib is to parse fdt and think that the first flash address resolved to the NVRAM space, with the evolution of qemu code, loongarch uses the first flash to store UEFI code and the second flash as NVRAM space, so NorFlashQemuLib needs to be able to parse multiple flash base addresses. By default, the first piece of flash other than UEFI code is considered as NVRAM space.

Cc: Andrea Bolognani <abologna@redhat.com>
Cc: Bibo Mao <maobibo@loongson.cn>
Cc: Chao Li <lichao@loongson.cn>