### PR TITLE
MinPlatformPkg: Add missed call to FreePool

### DIFF
--- a/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/BmcAcpi/BmcAcpi.c
+++ b/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/BmcAcpi/BmcAcpi.c
@@ -250,6 +250,7 @@ BmcAcpiEntryPoint (
       // Increment the instance
       //
       Instance++;
+      FreePool (CurrentTable);
     }
   }
 


### PR DESCRIPTION
Adding missed out call to FreePool API to free the allocated memory.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Eric Dong <eric.dong@intel.com>