### PR TITLE
 [edk2-platforms PATCH v2 0/4] clean up ProcessLibraryConstructorList() declarations in SEC modules

### DIFF
--- a/Platform/BeagleBoard/BeagleBoardPkg/PrePi/PeiUniCore.inf
+++ b/Platform/BeagleBoard/BeagleBoardPkg/PrePi/PeiUniCore.inf
@@ -9,7 +9,7 @@
 #**/
 
 [Defines]
-  INF_VERSION                    = 0x0001001A
+  INF_VERSION                    = 1.30
   BASE_NAME                      = BeagleBoardPrePiUniCore
   FILE_GUID                      = 8a5dc3de-fe31-4ad9-9c93-dd73626932e7
   MODULE_TYPE                    = SEC

--- a/Platform/BeagleBoard/BeagleBoardPkg/PrePi/PrePi.h
+++ b/Platform/BeagleBoard/BeagleBoardPkg/PrePi/PrePi.h
@@ -81,10 +81,4 @@ ArchInitialize (
   VOID
   );
 
-VOID
-EFIAPI
-ProcessLibraryConstructorList (
-  VOID
-  );
-
 #endif /* _PREPI_H_ */

--- a/Platform/Intel/SimicsOpenBoardPkg/SecCore/SecMain.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SecCore/SecMain.c
@@ -9,7 +9,6 @@
 
 #include <PiPei.h>
 
-#include <Library/PeimEntryPoint.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
@@ -738,7 +737,7 @@ SecCoreStartupWithStack (
     Table[Index] = 0;
   }
 
-  ProcessLibraryConstructorList (NULL, NULL);
+  ProcessLibraryConstructorList ();
 
   DEBUG ((EFI_D_INFO,
     "SecCoreStartupWithStack(0x%x, 0x%x)\n",

--- a/Platform/Intel/SimicsOpenBoardPkg/SecCore/SecMain.inf
+++ b/Platform/Intel/SimicsOpenBoardPkg/SecCore/SecMain.inf
@@ -8,7 +8,7 @@
 ##
 
 [Defines]
-  INF_VERSION                    = 0x00010005
+  INF_VERSION                    = 1.30
   BASE_NAME                      = SecMain
   FILE_GUID                      = e67f156f-54c5-47f3-a35d-07c045881e14
   MODULE_TYPE                    = SEC

--- a/Platform/Loongson/LoongArchQemuPkg/Sec/SecMain.c
+++ b/Platform/Loongson/LoongArchQemuPkg/Sec/SecMain.c
@@ -9,7 +9,6 @@
 
 #include <PiPei.h>
 
-#include <Library/PeimEntryPoint.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
@@ -378,7 +377,7 @@ SecCoreStartupWithStack (
 
   DEBUG ((DEBUG_INFO, "Entering C environment\n"));
 
-  ProcessLibraryConstructorList (NULL, NULL);
+  ProcessLibraryConstructorList ();
 
   DEBUG ((DEBUG_INFO,
     "SecCoreStartupWithStack (0x%lx, 0x%lx)\n",

--- a/Platform/Loongson/LoongArchQemuPkg/Sec/SecMain.inf
+++ b/Platform/Loongson/LoongArchQemuPkg/Sec/SecMain.inf
@@ -8,7 +8,7 @@
 ##
 
 [Defines]
-  INF_VERSION                    = 0x00010005
+  INF_VERSION                    = 1.30
   BASE_NAME                      = SecMain
   FILE_GUID                      = 57d02d4f-5a5d-4bfa-b7d6-ba0a4d2c72ce
   MODULE_TYPE                    = SEC

--- a/Silicon/Sophgo/SG2042Pkg/Sec/Memory.c
+++ b/Silicon/Sophgo/SG2042Pkg/Sec/Memory.c
@@ -19,7 +19,6 @@ Module Name:
 #include <Library/HobLib.h>
 #include <Library/IoLib.h>
 #include <Library/PcdLib.h>
-#include <Library/PeimEntryPoint.h>
 #include <Library/ResourcePublicationLib.h>
 #include <Register/RiscV64/RiscVEncoding.h>
 #include <Library/PrePiLib.h>

--- a/Silicon/Sophgo/SG2042Pkg/Sec/SecMain.h
+++ b/Silicon/Sophgo/SG2042Pkg/Sec/SecMain.h
@@ -50,18 +50,6 @@ SecStartup (
   );
 
 /**
-  Auto-generated function that calls the library constructors for all of the module's
-  dependent libraries.  This function must be called by the SEC Core once a stack has
-  been established.
-
-**/
-VOID
-EFIAPI
-ProcessLibraryConstructorList (
-  VOID
-  );
-
-/**
   Perform Platform PEIM initialization.
 
   @return EFI_SUCCESS     The platform initialized successfully.

--- a/Silicon/Sophgo/SG2042Pkg/Sec/SecMain.inf
+++ b/Silicon/Sophgo/SG2042Pkg/Sec/SecMain.inf
@@ -9,7 +9,7 @@
 ##
 
 [Defines]
-  INF_VERSION                    = 0x0001001B
+  INF_VERSION                    = 1.30
   BASE_NAME                      = SecMainRiscV64
   FILE_GUID                      = 125E1236-9D4F-457B-BF7E-6311C88A1621
   MODULE_TYPE                    = SEC


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/116378
msgid `<20240305120126.70259-1-lersek@redhat.com>`
~~~
Bugzilla:
- https://bugzilla.tianocore.org/show_bug.cgi?id=990

This patch series puts the recent BaseTools feature to use in which
AutoGen generates the ProcessLibraryConstructorList() declaration in
"AutoGen.h" for such non-library SEC modules whose INF_VERSION is at
least 1.30. The BaseTools feature is present in both edk2 [1] and
edk2-basetools [2], and has been documented in the Build spec [3] and
the Inf spec [4]. Kudos to Rebecca for tagging a new edk2-basetools
release [5] [6] with the new feature.

[1] edk2 commit bac9c74080cf
[2] edk2-basetools commit 5b7161de22ee
[3] edk2-BuildSpecification commit range db69f5661cae..7a7165a7d199
[4] edk2-InfSpecification commit range a31e3c842bee..1ea6546578fe
[5] https://github.com/tianocore/edk2-basetools/releases/tag/v0.1.51
[6] https://pypi.org/project/edk2-basetools/0.1.51/

The edk2-basetools part is adopted in the first patch (for
"pip-requirements.txt") of the edk2 series

  [edk2-devel] [PATCH v2 00/10]
  clean up ProcessLibraryConstructorList() declarations in SEC modules

  https://edk2.groups.io/g/devel/message/116367
  msgid <20240305113843.68812-1-lersek@redhat.com>

The rest of the patches clean up -- superfluous, or even incorrect --
ProcessLibraryConstructorList() declarations (and, in some cases,
incorrect calls), together with raising the INF_VERSIONs in the related
SEC module INF files to 1.30.

Comparing this version to v1 is not useful, as the compatibility
approach is different, and so this version is structured differently.
Please review any patches for your subsystem from scratch (they are not
difficult or large).

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Sai Chaganty <rangasai.v.chaganty@intel.com>
Cc: Bibo Mao <maobibo@loongson.cn>
Cc: Chao Li <lichao@loongson.cn>
Cc: Xianglai li <lixianglai@loongson.cn>
Cc: Sunil V L <sunilvl@ventanamicro.com>
Cc: USER0FISH <libing1202@outlook.com>
Cc: caiyuqing379 <caiyuqing_hz@outlook.com>
Cc: dahogn <dahogn@hotmail.com>
Cc: meng-cz <mengcz1126@gmail.com>

Thanks,
Laszlo

Laszlo Ersek (4):
  BeagleBoardPkg: auto-generate SEC ProcessLibraryConstructorList() decl
  SimicsOpenBoardPkg: auto-gen & fix SEC ProcessLibraryConstructorList()
    decl
  LoongArchQemuPkg: auto-gen & fix SEC ProcessLibraryConstructorList()
    decl
  SG2042Pkg/Sec: clean up ProcessLibraryConstructorList() decl

 Platform/BeagleBoard/BeagleBoardPkg/PrePi/PeiUniCore.inf |  2 +-
 Platform/BeagleBoard/BeagleBoardPkg/PrePi/PrePi.h        |  6 ------
 Platform/Intel/SimicsOpenBoardPkg/SecCore/SecMain.c      |  3 +--
 Platform/Intel/SimicsOpenBoardPkg/SecCore/SecMain.inf    |  2 +-
 Platform/Loongson/LoongArchQemuPkg/Sec/SecMain.c         |  3 +--
 Platform/Loongson/LoongArchQemuPkg/Sec/SecMain.inf       |  2 +-
 Silicon/Sophgo/SG2042Pkg/Sec/Memory.c                    |  1 -
 Silicon/Sophgo/SG2042Pkg/Sec/SecMain.h                   | 12 ------------
 Silicon/Sophgo/SG2042Pkg/Sec/SecMain.inf                 |  2 +-
 9 files changed, 6 insertions(+), 27 deletions(-)


base-commit: fe41713668d42b20a2370dab27de3269e877e454
~~~