### PR TITLE
SG2042Pkg/Sec:Modify Calculation LowestMemSize

### DIFF
--- a/Silicon/Sophgo/SG2042Pkg/Sec/Memory.c
+++ b/Silicon/Sophgo/SG2042Pkg/Sec/Memory.c
@@ -301,8 +301,8 @@ MemoryPeimInitialization (
   }
 
   if (UefiMemoryBase > LowestMemBase) {
+    LowestMemSize -= (UefiMemoryBase - LowestMemBase);
     LowestMemBase = UefiMemoryBase;
-    LowestMemSize -= UefiMemoryBase;
   }
 
   DEBUG ((


### PR DESCRIPTION
Adapting memory addresses may not start from 0x0,
for example, the starting memory address starts
from 0x8000_0000.

I understand: LowestMemBase is the lowest DDR
address in the system.

UefiMemoryBase = LowestMemBase +
CodeSize(opensbi+UEFI);

LowestMemSize -= CodeSize(UefiMemoryBase -
LowestMemBase)

Cc: Sunil V L <sunilvl@ventanamicro.com>
Cc: USER0FISH <libing1202@outlook.com>
Cc: caiyuqing379 <caiyuqing_hz@outlook.com>
Cc: dahogn <dahogn@hotmail.com>
Cc: meng-cz <mengcz1126@gmail.com>

Reviewed-by: Sunil V L <sunilvl@ventanamicro.com>
Reviewed-by: Jingyu Li <jingyu.li01@sophgo.com>