### PR TITLE
Silicon/Marvell: Update the comments of GetInformation function.

### DIFF
--- a/Silicon/Marvell/Drivers/Net/Pp2Dxe/Pp2Dxe.c
+++ b/Silicon/Marvell/Drivers/Net/Pp2Dxe/Pp2Dxe.c
@@ -1384,7 +1384,9 @@ Pp2DxeSnpInstall (
 
   This function returns information of type InformationType from the adapter.
   If an adapter does not support the requested informational type, then
-  EFI_UNSUPPORTED is returned.
+  EFI_UNSUPPORTED is returned. If an adapter does not contain Information for
+  the requested InformationType, it fills InformationBlockSize with 0 and
+  returns EFI_NOT_FOUND.
 
   @param[in]  This                   A pointer to the EFI_ADAPTER_INFORMATION_PROTOCOL instance.
   @param[in]  InformationType        A pointer to an EFI_GUID that defines the contents of InformationBlock.
@@ -1394,6 +1396,7 @@ Pp2DxeSnpInstall (
 
   @retval EFI_SUCCESS                The InformationType information was retrieved.
   @retval EFI_UNSUPPORTED            The InformationType is not known.
+  @retval EFI_NOT_FOUND              Information is not available for the requested information type.
   @retval EFI_DEVICE_ERROR           The device reported an error.
   @retval EFI_OUT_OF_RESOURCES       The request could not be completed due to a lack of resources.
   @retval EFI_INVALID_PARAMETER      This is NULL.


### PR DESCRIPTION
Refer to Uefi spec 2.10 section 11.11.2, add a new retval EFI_NOT_FOUND to EFI_ADAPTER_INFORMATION_PROTOCOL.GetInformation(). Reference: [mantis #1866] - GetInfo() of Adapter Information Protocol should have a provision for IHV to return no data.

Cc: Marcin Wojtas <mw@semihalf.com>
Signed-off-by: Qingyu <qingyu.shang@intel.com>
Signed-off-by: Gahan Saraiya <gahan.saraiya@intel.com>
Reviewed-by: Marcin Wojtas <mw@semihalf.com>