### PR TITLE
VirtualKeyboardFeaturePkg: Update the comments of ReadKeyStroke and R…

### DIFF
--- a/Features/Intel/UserInterface/VirtualKeyboardFeaturePkg/VirtualKeyboardDxe/Keyboard.c
+++ b/Features/Intel/UserInterface/VirtualKeyboardFeaturePkg/VirtualKeyboardDxe/Keyboard.c
@@ -1101,6 +1101,7 @@ End:
   @retval EFI_NOT_READY    There was no keystroke data available.
   @retval EFI_DEVICE_ERROR The keystroke information was not returned due to
                            hardware errors.
+  @retval EFI_UNSUPPORTED  The device does not support the ability to read keystroke data.
 
 **/
 EFI_STATUS
@@ -1154,6 +1155,7 @@ End:
   @retval EFI_SUCCESS            The keystroke information was returned.
   @retval EFI_NOT_READY          There was no keystroke data available.
   @retval EFI_INVALID_PARAMETER  This or KeyData is NULL.
+  @retval EFI_UNSUPPORTED  The device does not support the ability to read keystroke data.
 
 **/
 EFI_STATUS

--- a/Features/Intel/UserInterface/VirtualKeyboardFeaturePkg/VirtualKeyboardDxe/VirtualKeyboard.h
+++ b/Features/Intel/UserInterface/VirtualKeyboardFeaturePkg/VirtualKeyboardDxe/VirtualKeyboard.h
@@ -464,6 +464,7 @@ VkKeyboardReset (
   @retval EFI_NOT_READY    There was no keystroke data available.
   @retval EFI_DEVICE_ERROR The keystroke information was not returned due to
                            hardware errors.
+  @retval EFI_UNSUPPORTED  The device does not support the ability to read keystroke data.
 
 **/
 EFI_STATUS
@@ -512,6 +513,7 @@ VkKeyboardResetEx (
   @retval EFI_SUCCESS            The keystroke information was returned.
   @retval EFI_NOT_READY          There was no keystroke data available.
   @retval EFI_INVALID_PARAMETER  This or KeyData is NULL.
+  @retval EFI_UNSUPPORTED  The device does not support the ability to read keystroke data.
 
 **/
 EFI_STATUS


### PR DESCRIPTION
Refer to Uefi spec 2.10 section 12.3.3, Add a new retval EFI_UNSUPPORTED to EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.ReadKeyStrokeEx and EFI_SIMPLE_TEXT_INPUT_PROTOCOL.ReadKeyStroke().

Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>