### PR TITLE
Platform/Sifive: fix building failure caused by not found RiscVMmuLib

### DIFF
--- a/Platform/SiFive/U5SeriesPkg/FreedomU540HiFiveUnleashedBoard/U540.dsc
+++ b/Platform/SiFive/U5SeriesPkg/FreedomU540HiFiveUnleashedBoard/U540.dsc
@@ -151,6 +151,7 @@
 !endif
   RiscVCpuLib|Silicon/RISC-V/ProcessorPkg/Library/RiscVCpuLib/RiscVCpuLib.inf
   RiscVSbiLib|MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.inf
+  RiscVMmuLib|UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.inf
   RiscVPlatformTimerLib|Platform/SiFive/U5SeriesPkg/Library/RiscVPlatformTimerLib/RiscVPlatformTimerLib.inf
   #MachineModeTimerLib|Silicon/RISC-V/ProcessorPkg/Library/RiscVReadMachineModeTimer/MachineModeTimerLib/MachineModeTimerLib.inf
   MachineModeTimerLib|Silicon/RISC-V/ProcessorPkg/Library/RiscVReadMachineModeTimer/EmulatedMachineModeTimerLib/EmulatedMachineModeTimerLib.inf


### PR DESCRIPTION
This patch fixes the following errors during compilation

$ build -a RISCV64 -t GCC5 -p Platform/SiFive/U5SeriesPkg/FreedomU540HiFiveUnleashedBoard/U540.dsc

build.py...
/home/tianocore/edk2-platforms/Platform/SiFive/U5SeriesPkg/FreedomU540HiFiveUnleashedBoard/U540.dsc(...): error 4000: Instance of library class [RiscVMmuLib] is not found
	in [/home/tianocore/edk2/UefiCpuPkg/CpuDxeRiscV64/CpuDxeRiscV64.inf] [RISCV64]
	consumed by module [/home/tianocore/edk2/UefiCpuPkg/CpuDxeRiscV64/CpuDxeRiscV64.inf]

- Failed - Build end time: 21:21:11, May.06 2024
Build total time: 00:00:01

Cc: Sunil V L <sunilvl@ventanamicro.com>
Cc: Daniel Schaefer <daniel.schaefer@hpe.com>