### PR TITLE
AmdPlatform/SpiHcPlatformLib: Implements SpiHcPlatformLib library

### DIFF
--- a/Platform/AMD/AmdPlatformPkg/AmdPlatformPkg.dsc
+++ b/Platform/AMD/AmdPlatformPkg/AmdPlatformPkg.dsc
@@ -63,6 +63,7 @@
   BootLogoLib|MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   PlatformSocLib|AmdPlatformPkg/Library/DxePlatformSocLib/DxePlatformSocLibNull.inf
+  SpiHcPlatformLib|AmdPlatformPkg/Universal/Spi/SpiFvb/SpiFvbDxe.inf
 
 [LibraryClasses.common.SMM_CORE]
   SmmCoreAmdSpiHcHookLib|AmdPlatformPkg/Library/SmmCoreAmdSpiHcHookLib/SmmCoreAmdSpiHcHookLib.inf
@@ -71,6 +72,7 @@
 [LibraryClasses.common.DXE_SMM_DRIVER]
   MemoryAllocationLib|MdePkg/Library/SmmMemoryAllocationLib/SmmMemoryAllocationLib.inf
   SmmServicesTableLib|MdePkg/Library/SmmServicesTableLib/SmmServicesTableLib.inf
+  SpiHcPlatformLib|AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLibSmm.inf
 
 [Components]
   AmdPlatformPkg/Library/BaseAlwaysFalseDepexLib/BaseAlwaysFalseDepexLib.inf
@@ -78,6 +80,8 @@
   AmdPlatformPkg/Library/SimulatorSerialPortLibPort80/SimulatorSerialPortLibPort80.inf
   AmdPlatformPkg/Library/SmmCoreAmdSpiHcHookLib/SmmCoreAmdSpiHcHookLib.inf
   AmdPlatformPkg/Library/SmmCorePlatformHookLib/SmmCorePlatformHookLib.inf
+  AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLibDxe.inf
+  AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLibSmm.inf
   AmdPlatformPkg/Universal/Acpi/AcpiCommon/AcpiCommon.inf
   AmdPlatformPkg/Universal/HiiConfigRouting/AmdConfigRouting.inf
   AmdPlatformPkg/Universal/LogoDxe/JpegLogoDxe.inf                                           # Server platform JPEG logo driver

--- a/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcInternal.c
+++ b/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcInternal.c
@@ -1,0 +1,308 @@
+/** @file
+
+  Internal functions used by platform SPI HC library
+
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Library/BaseLib.h>
+#include <Library/IoLib.h>
+#include <Library/PcdLib.h>
+#include <Library/TimerLib.h>
+#include <Library/PciSegmentLib.h>
+#include <Protocol/SpiSmmHc.h>
+#include <FchRegistersCommon.h>
+#include <Library/SpiHcPlatformLib.h>
+#include "SpiHcInternal.h"
+
+extern EFI_PHYSICAL_ADDRESS  mHcAddress;
+
+/**
+  Check that SPI Conroller is Not Busy.
+
+  @retval EFI_SUCCESS       Spi Execute command executed properly
+  @retval EFI_DEVICE_ERROR  Spi Execute command failed
+**/
+EFI_STATUS
+EFIAPI
+FchSpiControllerNotBusy (
+  )
+{
+  UINT32  SpiReg00;
+  UINT32  LpcDmaStatus;
+  UINT32  RetryCount;
+  UINTN   DelayMicroseconds;
+
+  DelayMicroseconds = FixedPcdGet32 (PcdSpiNorFlashOperationDelayMicroseconds);
+  SpiReg00          = FCH_SPI_BUSY;
+  RetryCount        = FixedPcdGet32 (PcdAmdSpiRetryCount);
+  do {
+    SpiReg00     = MmioRead32 (mHcAddress + FCH_SPI_MMIO_REG4C_SPISTATUS);
+    LpcDmaStatus = PciSegmentRead32 (
+                     PCI_SEGMENT_LIB_ADDRESS (
+                       0x00,
+                       FCH_LPC_BUS,
+                       FCH_LPC_DEV,
+                       FCH_LPC_FUNC,
+                       FCH_LPC_REGB8
+                       )
+                     );
+    if (  ((SpiReg00 & FCH_SPI_BUSY) == 0)
+       && ((LpcDmaStatus & FCH_LPC_DMA_SPI_BUSY) == 0))
+    {
+      break;
+    }
+
+    MicroSecondDelay (DelayMicroseconds);
+    RetryCount--;
+  } while (RetryCount > 0);
+
+  if (RetryCount == 0) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Check for SPI transaction failure(s).
+
+  @retval EFI_SUCCESS   Spi Execute command executed properly
+  @retval others        Spi Execute command failed
+**/
+EFI_STATUS
+EFIAPI
+FchSpiTransactionCheckFailure (
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      Data;
+
+  Status = FchSpiControllerNotBusy ();
+  if (!EFI_ERROR (Status)) {
+    Data = MmioRead32 (mHcAddress + FCH_SPI_MMIO_REG00);
+    if ((Data & FCH_SPI_FIFO_PTR_CRL) != 0) {
+      Status = EFI_ACCESS_DENIED;
+    }
+  }
+
+  return Status;
+}
+
+/**
+  If SPI controller is not busy, execute SPI command.  Then wait until SPI
+  controller is not busy.
+
+  @retval EFI_SUCCESS   Spi Execute command executed properly
+  @retval others        Spi Execute command failed
+**/
+EFI_STATUS
+EFIAPI
+FchSpiExecute (
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = FchSpiControllerNotBusy ();
+  if (!EFI_ERROR (Status)) {
+    MmioOr8 (mHcAddress + FCH_SPI_MMIO_REG47_CMDTRIGGER, BIT7);
+    Status = FchSpiControllerNotBusy ();
+    if (!EFI_ERROR (Status)) {
+      Status = FchSpiTransactionCheckFailure ();
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Block SPI Flash Write Enable Opcode.  This will block anything that requires
+  the Opcode equivalent to the SPI Flash Memory Write Enable Opcode.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+
+  Calls during DXE will only work until the SPI controller is locked.
+
+  Calls to these functions from SMM will only be valid during SMM, restore state
+  will wipe out any changes.
+
+  @param[in]  HcAddress   Host controller physical address.
+  @param[in]  Opcode      SPI opcode to be passed.
+  @retval     EFI_SUCCESS If executed successfully.
+              Others      If fails.
+**/
+EFI_STATUS
+EFIAPI
+InternalFchSpiBlockOpcode (
+  IN CONST EFI_PHYSICAL_ADDRESS  HcAddress,
+  IN UINT8                       Opcode
+  )
+{
+  EFI_STATUS  Status;
+  BOOLEAN     OpcodeBlocked;
+  UINTN       RestrictedCmd;
+  UINT8       Data;
+
+  Status        = EFI_OUT_OF_RESOURCES;
+  OpcodeBlocked = FALSE;
+
+  // Allow only one copy of Opcode in RestrictedCmd register
+  for (RestrictedCmd = 0; RestrictedCmd <= 3; RestrictedCmd++) {
+    Data = MmioRead8 (HcAddress + FCH_SPI_MMIO_REG04 + RestrictedCmd);
+
+    if ((Data == Opcode) && (OpcodeBlocked == FALSE)) {
+      OpcodeBlocked = TRUE;
+    } else if ((Data == Opcode) && (OpcodeBlocked == TRUE)) {
+      MmioWrite8 (HcAddress + FCH_SPI_MMIO_REG04 + RestrictedCmd, 0x00);
+    } else if ((Data == 0x00) && (OpcodeBlocked == FALSE)) {
+      MmioWrite8 (HcAddress + FCH_SPI_MMIO_REG04 + RestrictedCmd, Opcode);
+      OpcodeBlocked = TRUE;
+    }
+  }
+
+  if (OpcodeBlocked) {
+    Status = EFI_SUCCESS;
+  }
+
+  return Status;
+}
+
+/**
+  Un-Block SPI Flash Write Enable Opcode.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+
+  Calls during DXE will only work until the SPI controller is locked.
+
+  Calls to these functions from SMM will only be valid during SMM, restore state
+  will wipe out any changes.
+  @param[in]  HcAddress   Host controller physical address.
+  @param[in]  Opcode      SPI opcode to be passed.
+  @retval     EFI_SUCCESS If executed successfully.
+              Others      If fails.
+**/
+EFI_STATUS
+EFIAPI
+InternalFchSpiUnblockOpcode (
+  IN CONST EFI_PHYSICAL_ADDRESS  HcAddress,
+  IN UINT8                       Opcode
+  )
+{
+  UINTN  RestrictedCmd;
+
+  // Unblock any copies of the Opcode
+  for (RestrictedCmd = 0; RestrictedCmd <= 3; RestrictedCmd++) {
+    if (MmioRead8 (HcAddress + FCH_SPI_MMIO_REG04 + RestrictedCmd) == Opcode) {
+      MmioWrite8 (HcAddress + FCH_SPI_MMIO_REG04 + RestrictedCmd, 0x00);
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Un-Block any blocked SPI Opcodes.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+
+  Calls during DXE will only work until the SPI controller is locked.
+
+  Calls to these functions from SMM will only be valid during SMM, restore state
+  will wipe out any changes.
+
+  @param[in]  HcAddress   Host controller physical address
+  @retval     EFI_SUCCESS If executed successfully.
+              Others      If fails
+**/
+EFI_STATUS
+EFIAPI
+InternalFchSpiUnblockAllOpcodes (
+  IN CONST EFI_PHYSICAL_ADDRESS  HcAddress
+  )
+{
+  MmioWrite32 (HcAddress + FCH_SPI_MMIO_REG04, 0x00);
+  return EFI_SUCCESS;
+}
+
+/**
+  Lock SPI host controller registers.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+
+  @param[in]  HcAddress   Host controller physical address
+  @retval     EFI_SUCCESS If executed successfully.
+              Others      If fails
+**/
+EFI_STATUS
+EFIAPI
+InternalFchSpiLockSpiHostControllerRegisters (
+  IN CONST EFI_PHYSICAL_ADDRESS  HcAddress
+  )
+{
+  MmioBitFieldAnd32 (
+    HcAddress + FCH_SPI_MMIO_REG00,
+    22,
+    23,
+    0x0
+    );
+  if (MmioBitFieldRead32 (HcAddress + FCH_SPI_MMIO_REG00, 22, 23)
+      == 0x0)
+  {
+    return EFI_SUCCESS;
+  }
+
+  return EFI_DEVICE_ERROR;
+}
+
+/**
+  Unlock SPI host controller registers.  This unlock function will only work in
+  SMM.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04).
+
+  @param[in]  HcAddress   Host controller physical address
+  @retval     EFI_SUCCESS If executed successfully.
+              Others      If fails
+**/
+EFI_STATUS
+EFIAPI
+InternalFchSpiUnlockSpiHostControllerRegisters (
+  IN CONST EFI_PHYSICAL_ADDRESS  HcAddress
+  )
+{
+  MmioBitFieldOr32 (
+    HcAddress + FCH_SPI_MMIO_REG00,
+    22,
+    23,
+    BIT0 | BIT1
+    );
+  if (MmioBitFieldRead32 (HcAddress + FCH_SPI_MMIO_REG00, 22, 23)
+      == (BIT0 | BIT1))
+  {
+    return EFI_SUCCESS;
+  }
+
+  return EFI_DEVICE_ERROR;
+}

--- a/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcInternal.h
+++ b/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcInternal.h
@@ -1,0 +1,128 @@
+/** @file
+
+  Internal functions used by platform SPI HC library
+
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SPI_HC_INTERNAL_H_
+#define SPI_HC_INTERNAL_H_
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/SpiHcPlatformLib.h>
+#include <Library/DevicePathLib.h>
+#include <Uefi/UefiBaseType.h>
+#include <Protocol/SpiHc.h>
+#include <Protocol/SpiConfiguration.h>
+
+#define FCH_LPC_DMA_SPI_BUSY             BIT0
+#define FCH_SPI_MMIO_REG04               0x04// SPI_RestrictedCmd
+#define FCH_SPI_FRAME_SIZE_SUPPORT_MASK  (1 << (8 - 1))
+#define FCH_SPI_LOCK_CONTROLLER          0x00
+#define FCH_SPI_UNLOCK_CONTROLLER        BIT0 | BIT1
+
+/**
+  Check that SPI Conroller is Not Busy
+
+  @retval EFI_SUCCESS       Spi Execute command executed properly
+  @retval EFI_DEVICE_ERROR  Spi Execute command failed
+**/
+EFI_STATUS
+EFIAPI
+FchSpiControllerNotBusy (
+  );
+
+/**
+  Execute SPI command
+
+  @retval EFI_SUCCESS   Spi Execute command executed properly
+  @retval others        Spi Execute command failed
+**/
+EFI_STATUS
+EFIAPI
+FchSpiExecute (
+  );
+
+/**
+  Block SPI Flash Write Enable Opcode.  This will block anything that requires
+  the Opcode equivalent to the SPI Flash Memory Write Enable Opcode.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+**/
+EFI_STATUS
+EFIAPI
+InternalFchSpiBlockOpcode (
+  IN CONST EFI_PHYSICAL_ADDRESS  HcAddress,
+  IN UINT8                       Opcode
+  );
+
+/**
+  Un-Block SPI Flash Write Enable Opcode.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+**/
+EFI_STATUS
+EFIAPI
+InternalFchSpiUnblockOpcode (
+  IN CONST EFI_PHYSICAL_ADDRESS  HcAddress,
+  IN UINT8                       Opcode
+  );
+
+/**
+  Un-Block any blocked SPI Opcodes.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+**/
+EFI_STATUS
+EFIAPI
+InternalFchSpiUnblockAllOpcodes (
+  IN CONST EFI_PHYSICAL_ADDRESS  HcAddress
+  );
+
+/**
+  Lock SPI host controller registers.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+**/
+EFI_STATUS
+EFIAPI
+InternalFchSpiLockSpiHostControllerRegisters (
+  IN CONST EFI_PHYSICAL_ADDRESS  HcAddress
+  );
+
+/**
+  Unlock SPI host controller registers.  This unlock function will only work in
+  SMM.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+**/
+EFI_STATUS
+EFIAPI
+InternalFchSpiUnlockSpiHostControllerRegisters (
+  IN CONST EFI_PHYSICAL_ADDRESS  HcAddress
+  );
+
+#endif // SPI_HC_INTERNAL_H__

--- a/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLib.c
+++ b/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLib.c
@@ -1,0 +1,307 @@
+/** @file
+
+  SPI HC platform library implementation. This code touches the SPI controllers and performs
+  the hardware transaction
+
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/PcdLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Protocol/SpiHc.h>
+#include <Spi/AmdSpiHcChipSelectParameters.h>
+#include <Spi/AmdSpiDevicePaths.h>
+#include <Library/PciSegmentLib.h>
+#include <Library/SpiHcPlatformLib.h>
+#include "SpiHcInternal.h"
+#include <IndustryStandard/SpiNorFlashJedecSfdp.h>
+#include <FchRegistersCommon.h>
+
+extern EFI_PHYSICAL_ADDRESS  mHcAddress;
+
+SPI_CONTROLLER_DEVICE_PATH  mFchDevicePath = FCH_DEVICE_PATH;
+
+/**
+  This function reports the device path of SPI host controller. This is needed in order for the SpiBus
+  to match the correct SPI_BUS to the SPI host controller
+
+  @param[out] DevicePath The device path for this SPI HC is returned in this variable
+
+  @retval EFI_SUCCESS
+**/
+EFI_STATUS
+EFIAPI
+GetSpiHcDevicePath (
+  OUT EFI_DEVICE_PATH_PROTOCOL  **DevicePath
+  )
+{
+  *DevicePath = (EFI_DEVICE_PATH_PROTOCOL *)&mFchDevicePath;
+  return EFI_SUCCESS;
+}
+
+/**
+  This is the platform specific Spi Chip select function.
+  Assert or de-assert the SPI chip select.
+
+  This routine is called at TPL_NOTIFY.
+  Update the value of the chip select line for a SPI peripheral. The SPI bus
+  layer calls this routine either in the board layer or in the SPI controller
+  to manipulate the chip select pin at the start and end of a SPI transaction.
+
+  @param[in] This           Pointer to an EFI_SPI_HC_PROTOCOL structure.
+  @param[in] SpiPeripheral  The address of an EFI_SPI_PERIPHERAL data structure
+                            describing the SPI peripheral whose chip select pin
+                            is to be manipulated. The routine may access the
+                            ChipSelectParameter field to gain sufficient
+                            context to complete the operation.
+  @param[in] PinValue       The value to be applied to the chip select line of
+                            the SPI peripheral.
+
+  @retval EFI_SUCCESS            The chip select was set as requested
+  @retval EFI_NOT_READY          Support for the chip select is not properly
+                                 initialized
+  @retval EFI_INVALID_PARAMETER  The ChipSelect value or its contents are
+                                 invalid
+
+**/
+EFI_STATUS
+EFIAPI
+PlatformSpiHcChipSelect (
+  IN CONST EFI_SPI_HC_PROTOCOL  *This,
+  IN CONST EFI_SPI_PERIPHERAL   *SpiPeripheral,
+  IN BOOLEAN                    PinValue
+  )
+{
+  EFI_STATUS              Status;
+  CHIP_SELECT_PARAMETERS  *ChipSelectParameter;
+
+  Status              = EFI_DEVICE_ERROR;
+  ChipSelectParameter = SpiPeripheral->ChipSelectParameter;
+
+  if (ChipSelectParameter->OrValue <= 1) {
+    MmioAndThenOr8 (
+      mHcAddress + FCH_SPI_MMIO_REG1D,
+      ChipSelectParameter->AndValue,
+      ChipSelectParameter->OrValue
+      );
+    Status = EFI_SUCCESS;
+  } else {
+    Status = EFI_INVALID_PARAMETER;
+  }
+
+  return Status;
+}
+
+/**
+  This function is the platform specific SPI clock function.
+  Set up the clock generator to produce the correct clock frequency, phase and
+  polarity for a SPI chip.
+
+  This routine is called at TPL_NOTIFY.
+  This routine updates the clock generator to generate the correct frequency
+  and polarity for the SPI clock.
+
+  @param[in] This           Pointer to an EFI_SPI_HC_PROTOCOL structure.
+  @param[in] SpiPeripheral  Pointer to a EFI_SPI_PERIPHERAL data structure from
+                            which the routine can access the ClockParameter,
+                            ClockPhase and ClockPolarity fields. The routine
+                            also has access to the names for the SPI bus and
+                            chip which can be used during debugging.
+  @param[in] ClockHz        Pointer to the requested clock frequency. The SPI
+                            host controller will choose a supported clock
+                            frequency which is less then or equal to this
+                            value. Specify zero to turn the clock generator
+                            off. The actual clock frequency supported by the
+                            SPI host controller will be returned.
+
+  @retval EFI_SUCCESS      The clock was set up successfully
+  @retval EFI_UNSUPPORTED  The SPI controller was not able to support the
+                           frequency requested by ClockHz
+
+**/
+EFI_STATUS
+EFIAPI
+PlatformSpiHcClock (
+  IN CONST EFI_SPI_HC_PROTOCOL  *This,
+  IN CONST EFI_SPI_PERIPHERAL   *SpiPeripheral,
+  IN UINT32                     *ClockHz
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      InternalClockHz;
+  UINT16      InternalClockValue;
+
+  Status             = EFI_SUCCESS;
+  InternalClockHz    = *ClockHz;
+  InternalClockValue = 0x00;
+
+  // this value is non-zero and less than the value in the EFI_SPI_PART then this value is used for the maximum clock frequency for the SPI part.
+  if ((SpiPeripheral->SpiPart->MaxClockHz != 0) &&
+      (SpiPeripheral->SpiPart->MaxClockHz < InternalClockHz))
+  {
+    InternalClockHz = SpiPeripheral->SpiPart->MaxClockHz;
+  }
+
+  if ((SpiPeripheral->MaxClockHz != 0) &&
+      (SpiPeripheral->MaxClockHz < InternalClockHz))
+  {
+    InternalClockHz = SpiPeripheral->MaxClockHz;
+  }
+
+  if ((SpiPeripheral->SpiPart->MinClockHz != 0) &&
+      (SpiPeripheral->SpiPart->MinClockHz > InternalClockHz))
+  {
+    Status = EFI_UNSUPPORTED;
+  }
+
+  if (!EFI_ERROR (Status)) {
+    if (InternalClockHz >= MHz (100)) {
+      InternalClockValue = 0x4;
+    } else if (InternalClockHz >= MHz (66)) {
+      InternalClockValue = 0x0;
+    } else if (InternalClockHz >= MHz (33)) {
+      InternalClockValue = 0x1;
+    } else if (InternalClockHz >= MHz (22)) {
+      InternalClockValue = 0x2;
+    } else if (InternalClockHz >= MHz (16)) {
+      InternalClockValue = 0x3;
+    } else if (InternalClockHz >= KHz (800)) {
+      InternalClockValue = 0x5;
+    } else {
+      Status = EFI_UNSUPPORTED;
+    }
+
+    if (!EFI_ERROR (Status)) {
+      // Enable UseSpi100
+      MmioOr8 (
+        mHcAddress + FCH_SPI_MMIO_REG20,
+        BIT0
+        );
+      // Set the Value for NormSpeed and FastSpeed
+      InternalClockValue = InternalClockValue << 12 | InternalClockValue << 8;
+      MmioAndThenOr16 (
+        mHcAddress + FCH_SPI_MMIO_REG22,
+        0x00FF,
+        InternalClockValue
+        );
+    }
+  }
+
+  return Status;
+}
+
+/**
+  This function is the platform specific SPI transaction function
+  Perform the SPI transaction on the SPI peripheral using the SPI host
+  controller.
+
+  This routine is called at TPL_NOTIFY.
+  This routine synchronously returns EFI_SUCCESS indicating that the
+  asynchronous SPI transaction was started. The routine then waits for
+  completion of the SPI transaction prior to returning the final transaction
+  status.
+
+  @param[in] This            Pointer to an EFI_SPI_HC_PROTOCOL structure.
+  @param[in] BusTransaction  Pointer to a EFI_SPI_BUS_ TRANSACTION containing
+                             the description of the SPI transaction to perform.
+
+  @retval EFI_SUCCESS         The transaction completed successfully
+  @retval EFI_BAD_BUFFER_SIZE The BusTransaction->WriteBytes value is invalid,
+                              or the BusTransaction->ReadinBytes value is
+                              invalid
+  @retval EFI_UNSUPPORTED     The BusTransaction-> Transaction Type is
+                              unsupported
+  @retval EFI_DEVICE_ERROR    SPI Host Controller failed transaction
+
+**/
+EFI_STATUS
+EFIAPI
+PlatformSpiHcTransaction (
+  IN CONST EFI_SPI_HC_PROTOCOL  *This,
+  IN EFI_SPI_BUS_TRANSACTION    *BusTransaction
+  )
+{
+  EFI_STATUS            Status;
+  UINT8                 Opcode;
+  UINT32                WriteBytes;
+  UINT8                 *WriteBuffer;
+  UINT32                ReadBytes;
+  UINT8                 *ReadBuffer;
+  EFI_PHYSICAL_ADDRESS  HcAddress;
+
+  WriteBytes  = BusTransaction->WriteBytes;
+  WriteBuffer = BusTransaction->WriteBuffer;
+
+  ReadBytes  = BusTransaction->ReadBytes;
+  ReadBuffer = BusTransaction->ReadBuffer;
+
+  if (  (WriteBytes > This->MaximumTransferBytes + 6)
+     || (ReadBytes > (This->MaximumTransferBytes + 6 - WriteBytes))
+     || ((WriteBytes != 0) && (WriteBuffer == NULL))
+     || ((ReadBytes != 0) && (ReadBuffer == NULL)))
+  {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Opcode = 0;
+  if (WriteBytes >= 1) {
+    Opcode = WriteBuffer[0];
+    // Skip Opcode
+    WriteBytes  -= 1;
+    WriteBuffer += 1;
+  }
+
+  Status    = EFI_SUCCESS;
+  HcAddress = mHcAddress;
+
+  Status = FchSpiControllerNotBusy ();
+  if (!EFI_ERROR (Status)) {
+    MmioWrite8 (
+      HcAddress + FCH_SPI_MMIO_REG48_TX_BYTE_COUNT,
+      (UINT8)WriteBytes
+      );
+    MmioWrite8 (
+      HcAddress + FCH_SPI_MMIO_REG4B_RX_BYTE_COUNT,
+      (UINT8)ReadBytes
+      );
+
+    // Fill in Write Data including Address
+    if (WriteBytes != 0) {
+      MmioWriteBuffer8 (
+        HcAddress + FCH_SPI_MMIO_REG80_FIFO,
+        WriteBytes,
+        WriteBuffer
+        );
+    }
+
+    // Set Opcode
+    MmioWrite8 (
+      HcAddress + FCH_SPI_MMIO_REG45_CMDCODE,
+      Opcode
+      );
+
+    // Execute the Transaction
+    Status = FchSpiExecute ();
+    if (!EFI_ERROR (Status)) {
+      if (ReadBytes != 0) {
+        MmioReadBuffer8 (
+          HcAddress
+          + FCH_SPI_MMIO_REG80_FIFO
+          + WriteBytes,
+          ReadBytes,
+          ReadBuffer
+          );
+      }
+    }
+  }
+
+  return Status;
+}

--- a/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLib.uni
+++ b/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLib.uni
@@ -1,0 +1,9 @@
+// /*****************************************************************************
+//  *
+//  * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+//  *
+//  *
+//  *  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#string STR_PROPERTIES_MODULE_NAME
+#language en-US   "AMD SPI Host controller library"

--- a/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLibDxe.c
+++ b/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLibDxe.c
@@ -1,0 +1,61 @@
+/** @file
+
+  Implementation of SpiHcPlatformLib for DXE
+
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/PcdLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Protocol/SpiHc.h>
+#include <Library/PciSegmentLib.h>
+#include <Library/SpiHcPlatformLib.h>
+#include "SpiHcInternal.h"
+#include <IndustryStandard/SpiNorFlashJedecSfdp.h>
+#include <FchRegistersCommon.h>
+
+#define SPI_HC_MAXIMUM_TRANSFER_BYTES  64
+
+// Global variables to manage the platform-dependent SPI host controller
+EFI_PHYSICAL_ADDRESS  mHcAddress;
+
+/**
+  This function reports the details of the SPI Host Controller to the SpiHc driver.
+
+  @param[out]     Attributes              The suported attributes of the SPI host controller
+  @param[out]     FrameSizeSupportMask    The suported FrameSizeSupportMask of the SPI host controller
+  @param[out]     MaximumTransferBytes    The suported MaximumTransferBytes of the SPI host controller
+
+  @retval EFI_SUCCESS             SPI_HOST_CONTROLLER_INSTANCE was allocated properly
+  @retval EFI_OUT_OF_RESOURCES    The SPI_HOST_CONTROLLER_INSTANCE could not be allocated
+**/
+EFI_STATUS
+EFIAPI
+GetPlatformSpiHcDetails (
+  OUT     UINT32  *Attributes,
+  OUT     UINT32  *FrameSizeSupportMask,
+  OUT     UINT32  *MaximumTransferBytes
+  )
+{
+  // Fill in the SPI Host Controller Protocol
+  *Attributes = HC_SUPPORTS_WRITE_THEN_READ_OPERATIONS |
+                HC_SUPPORTS_READ_ONLY_OPERATIONS |
+                HC_SUPPORTS_WRITE_ONLY_OPERATIONS;
+  *FrameSizeSupportMask = FCH_SPI_FRAME_SIZE_SUPPORT_MASK;
+  *MaximumTransferBytes = SPI_HC_MAXIMUM_TRANSFER_BYTES;
+
+  // fill in Platform specific global variables
+  mHcAddress = (
+                PciSegmentRead32 (
+                  PCI_SEGMENT_LIB_ADDRESS (0x00, FCH_LPC_BUS, FCH_LPC_DEV, FCH_LPC_FUNC, FCH_LPC_REGA0)
+                  )
+                ) & 0xFFFFFF00;
+  return EFI_SUCCESS;
+}

--- a/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLibDxe.inf
+++ b/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLibDxe.inf
@@ -1,0 +1,55 @@
+## @file
+#  SpiHcPlatformLibrary DXE_DRIVER inf
+#
+#  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION               = 0x00010019
+  BASE_NAME                 = SpiHcPlatformLibDxe
+  FILE_GUID                 = 1B53F26A-971D-4DFC-A13D-2626CFDF863D
+  MODULE_TYPE               = DXE_DRIVER
+  VERSION_STRING            = 0.1
+  PI_SPECIFICATION_VERSION  = 0x0001000A
+  LIBRARY_CLASS             = SpiHcPlatformLib
+
+[Packages]
+  AmdPlatformPkg/AmdPlatformPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  IoLib
+  MemoryAllocationLib
+  PcdLib
+  PciSegmentLib
+  TimerLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  UefiLib
+  UefiRuntimeServicesTableLib
+
+[Sources]
+  SpiHcPlatformLibDxe.c
+  SpiHcPlatformLib.c
+  SpiHcInternal.h
+  SpiHcInternal.c
+
+[Protocols]
+  gEfiSpiHcProtocolGuid
+
+[FixedPcd]
+  gAmdPlatformPkgTokenSpaceGuid.PcdAmdSpiRetryCount
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSpiNorFlashOperationDelayMicroseconds
+
+[Depex]
+  TRUE
+
+[UserExtensions.TianoCore."ExtraFiles"]
+  SpiHcPlatformLib.uni

--- a/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLibSmm.c
+++ b/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLibSmm.c
@@ -1,0 +1,104 @@
+/** @file
+
+  Implementation of SpiHcPlatformLibrary for SMM
+
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/PcdLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/MmServicesTableLib.h>
+#include <Protocol/SpiSmmHc.h>
+#include <Protocol/AmdSpiSmmHcState.h>
+#include <Protocol/MmReadyToLock.h>
+#include <Library/PciSegmentLib.h>
+#include <Library/SpiHcPlatformLib.h>
+#include <IndustryStandard/SpiNorFlashJedecSfdp.h>
+#include <FchRegistersCommon.h>
+#include "SpiHcInternal.h"
+#include "SpiHcSmmState.h"
+
+#define SPI_HC_MAXIMUM_TRANSFER_BYTES  64
+
+EFI_HANDLE  mSpiStateHandle = 0;
+
+// Global variables to manage the platform-dependent SPI host controller when in DXE or SMM
+VOID                  *mRegistration;
+EFI_PHYSICAL_ADDRESS  mHcAddress;
+
+// SMM specific global variables to manage the platform-dependent SPI host controller
+SMM_EFI_SPI_HC_STATE_PROTOCOL  mStateProtocol;
+BOOLEAN                        mSmmAlreadySavedState;
+VOID                           *mState;
+UINT32                         mStateSize;
+UINT32                         mStateRecordCount;
+
+/**
+  This function reports the details of the SPI Host Controller to the SpiHc driver.
+
+  @param[out]     Attributes              The suported attributes of the SPI host controller
+  @param[out]     FrameSizeSupportMask    The suported FrameSizeSupportMask of the SPI host controller
+  @param[out]     MaximumTransferBytes    The suported MaximumTransferBytes of the SPI host controller
+
+  @retval EFI_SUCCESS             SPI_HOST_CONTROLLER_INSTANCE was allocated properly
+  @retval EFI_OUT_OF_RESOURCES    The SPI_HOST_CONTROLLER_INSTANCE could not be allocated
+**/
+EFI_STATUS
+EFIAPI
+GetPlatformSpiHcDetails (
+  OUT     UINT32  *Attributes,
+  OUT     UINT32  *FrameSizeSupportMask,
+  OUT     UINT32  *MaximumTransferBytes
+  )
+{
+  EFI_STATUS  Status;
+
+  // Fill in the SPI Host Controller Protocol
+  *Attributes = HC_SUPPORTS_WRITE_THEN_READ_OPERATIONS |
+                HC_SUPPORTS_READ_ONLY_OPERATIONS |
+                HC_SUPPORTS_WRITE_ONLY_OPERATIONS;
+  *FrameSizeSupportMask = FCH_SPI_FRAME_SIZE_SUPPORT_MASK;
+  *MaximumTransferBytes = SPI_HC_MAXIMUM_TRANSFER_BYTES;
+
+  // Set platform specific global variables
+  mHcAddress = (
+                PciSegmentRead32 (
+                  PCI_SEGMENT_LIB_ADDRESS (0x00, FCH_LPC_BUS, FCH_LPC_DEV, FCH_LPC_FUNC, FCH_LPC_REGA0)
+                  )
+                ) & 0xFFFFFF00;
+
+  // Allocate Host Controller save state space
+  Status = AllocateState ();
+  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // Fill in the SPI HC Save State Protocol
+  mStateProtocol.SaveState         = SaveState;
+  mStateProtocol.RestoreState      = RestoreState;
+  mStateProtocol.Lock              = FchSpiLockSpiHostControllerRegisters;
+  mStateProtocol.Unlock            = FchSpiUnlockSpiHostControllerRegisters;
+  mStateProtocol.BlockOpcode       = FchSpiBlockOpcode;
+  mStateProtocol.UnblockOpcode     = FchSpiUnblockOpcode;
+  mStateProtocol.UnblockAllOpcodes = FchSpiUnblockAllOpcodes;
+
+  Status = gMmst->MmInstallProtocolInterface (
+                    &mSpiStateHandle,
+                    &gAmdSpiHcStateProtocolGuid,
+                    EFI_NATIVE_INTERFACE,
+                    &mStateProtocol
+                    );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_VERBOSE, "Error installing gAmdSpiHcStateProtocolGuid\n"));
+  }
+
+  return Status;
+}

--- a/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLibSmm.inf
+++ b/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcPlatformLibSmm.inf
@@ -1,0 +1,58 @@
+## @file
+#  SpiHcPlatformLibrary DXE_SMM_DRIVER inf
+#
+#  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION               = 0x00010019
+  BASE_NAME                 = SpiHcPlatformLibSmm
+  FILE_GUID                 = 6D856A06-B502-49D5-80D5-10A0BA4EDB4D
+  MODULE_TYPE               = DXE_SMM_DRIVER
+  VERSION_STRING            = 0.1
+  PI_SPECIFICATION_VERSION  = 0x0001000A
+  LIBRARY_CLASS             = SpiHcPlatformLib
+
+[Packages]
+  AmdPlatformPkg/AmdPlatformPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  IoLib
+  MemoryAllocationLib
+  MmServicesTableLib
+  PcdLib
+  PciSegmentLib
+  TimerLib
+  UefiDriverEntryPoint
+
+[Sources]
+  SpiHcPlatformLibSmm.c
+  SpiHcPlatformLib.c
+  SpiHcInternal.h
+  SpiHcInternal.c
+  SpiHcSmmState.h
+  SpiHcSmmState.c
+
+[Protocols]
+  gEfiSmmVariableProtocolGuid
+  gEfiSpiSmmHcProtocolGuid
+  gAmdSpiHcStateProtocolGuid
+  gEfiMmReadyToLockProtocolGuid
+
+[FixedPcd]
+  gAmdPlatformPkgTokenSpaceGuid.PcdAmdSpiRetryCount
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSpiNorFlashOperationDelayMicroseconds
+
+[Depex]
+  TRUE
+
+[UserExtensions.TianoCore."ExtraFiles"]
+  SpiHcPlatformLib.uni

--- a/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcSmmState.c
+++ b/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcSmmState.c
@@ -1,0 +1,342 @@
+/** @file
+
+  SPI HC SMM state registration function definitions
+
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Base.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/IoLib.h>
+#include <Protocol/AmdSpiSmmHcState.h>
+#include "SpiHcSmmState.h"
+#include "SpiHcInternal.h"
+
+extern EFI_PHYSICAL_ADDRESS  mHcAddress;
+extern BOOLEAN               mSmmAlreadySavedState;
+extern VOID                  *mState;
+extern UINT32                mStateSize;
+extern UINT32                mStateRecordCount;
+
+CONST SPI_HC_REGISTER_STATE  mSpiHcState[] = {
+  // {Register, Size, Count}
+  { 0x04, 0x4, 0x1 }, // SPI_RestrictedCmd
+  { 0x08, 0x4, 0x1 }, // SPI_RestrictedCmd2
+  { 0x0D, 0x1, 0x1 }, // SPI_Cntrl1[15:8]
+  { 0x0E, 0x2, 0x1 }, // SPI_Cntrl1[31:16]
+  { 0x10, 0x4, 0x1 }, // SPI_CmdValue0
+  { 0x14, 0x4, 0x1 }, // SPI_CmdValue1
+  { 0x18, 0x4, 0x1 }, // SPI_CmdValue2
+  { 0x1D, 0x1, 0x1 }, // Alt_SPI_CS
+  { 0x20, 0x1, 0x1 }, // SPI100 Enable
+  { 0x22, 0x2, 0x1 }, // SPI100 Speed Config
+  { 0x24, 0x4, 0x1 }, // SPI100 Clock Config
+  { 0x32, 0x2, 0x1 }, // SPI100 Dummy Cycle Config
+  { 0x34, 0x2, 0x1 }, // SPI100 RX Timing Config 1
+  { 0x44, 0x1, 0x1 }, // ModeByte
+  { 0x45, 0x1, 0x1 }, // CmdCode
+  { 0x48, 0x1, 0x1 }, // TxByteCount
+  { 0x4B, 0x1, 0x1 }, // RxByteCount
+  { 0x80, 0x1, 70  }, // FIFO [70:0]
+  { 0x00, 0x4, 0x1 }  // SpiCntrl0  ** Save last so restore last **
+};
+
+/**
+  Allocate the save state space and update the instance structure.
+
+  @retval EFI_SUCCESS            The Save State space was allocated
+  @retval EFI_OUT_OF_RESOURCES   The Save State space failed to allocate
+**/
+EFI_STATUS
+EFIAPI
+AllocateState (
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      NumRecords;
+  UINT32      Record;
+
+  NumRecords = sizeof (mSpiHcState) / sizeof (SPI_HC_REGISTER_STATE);
+
+  // calculate space needed
+  mStateSize = 0;
+  for (Record = 0; Record < NumRecords; Record++) {
+    mStateSize += mSpiHcState[Record].Size
+                  * mSpiHcState[Record].Count;
+  }
+
+  mStateRecordCount = NumRecords;
+  mState            = AllocateZeroPool (mStateSize);
+  if (mState == NULL) {
+    mStateRecordCount = 0;
+    Status            = EFI_OUT_OF_RESOURCES;
+  } else {
+    Status = EFI_SUCCESS;
+  }
+
+  return Status;
+}
+
+/**
+  Save the Host controller state to restore after transaction is complete.
+
+  @param[in] This           SPI host controller Preserve State Protocol;
+
+  @retval EFI_SUCCESS       Spi Execute command executed properly
+  @retval EFI_DEVICE_ERROR  Spi Execute command failed
+**/
+EFI_STATUS
+EFIAPI
+SaveState (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      NumRecords;
+  UINT32      Record;
+  UINT32      Count;
+  UINT8       *State;
+
+  Status = EFI_SUCCESS;
+
+  Status = FchSpiControllerNotBusy ();
+  if (!EFI_ERROR (Status)) {
+    State      = mState;
+    NumRecords = mStateRecordCount;
+    if (!mSmmAlreadySavedState) {
+      for (Record = 0; Record < NumRecords; Record++) {
+        switch (mSpiHcState[Record].Size) {
+          case 0x1:
+            for (Count = 0; Count < mSpiHcState[Record].Count; Count++) {
+              *(UINT8 *)State = MmioRead8 (
+                                  mHcAddress
+                                  + mSpiHcState[Record].Register
+                                  );
+              State += 1;
+            }
+
+            break;
+          case 0x2:
+            for (Count = 0; Count < mSpiHcState[Record].Count; Count++) {
+              *(UINT16 *)State = MmioRead16 (
+                                   mHcAddress
+                                   + mSpiHcState[Record].Register
+                                   );
+              State += 2;
+            }
+
+            break;
+          case 0x4:
+            for (Count = 0; Count < mSpiHcState[Record].Count; Count++) {
+              *(UINT32 *)State = MmioRead32 (
+                                   mHcAddress
+                                   + mSpiHcState[Record].Register
+                                   );
+              State += 4;
+            }
+
+            break;
+        }
+      }
+
+      mSmmAlreadySavedState = TRUE;
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Restore the Host Controller state.
+
+  @param[in] This           SPI host controller Preserve State Protocol;
+
+  @retval EFI_SUCCESS       Spi Execute command executed properly
+  @retval EFI_DEVICE_ERROR  Spi Execute command failed
+**/
+EFI_STATUS
+EFIAPI
+RestoreState (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      NumRecords;
+  UINT32      Record;
+  UINT32      Count;
+  UINT8       *State;
+
+  Status = EFI_SUCCESS;
+
+  State      = mState;
+  NumRecords = mStateRecordCount;
+  if (mSmmAlreadySavedState) {
+    for (Record = 0; Record < NumRecords; Record++) {
+      switch (mSpiHcState[Record].Size) {
+        case 0x1:
+          for (Count = 0; Count < mSpiHcState[Record].Count; Count++) {
+            MmioWrite8 (
+              mHcAddress + mSpiHcState[Record].Register,
+              *(UINT8 *)State
+              );
+            State += 1;
+          }
+
+          break;
+        case 0x2:
+          for (Count = 0; Count < mSpiHcState[Record].Count; Count++) {
+            MmioWrite16 (
+              mHcAddress + mSpiHcState[Record].Register,
+              *(UINT16 *)State
+              );
+            State += 2;
+          }
+
+          break;
+        case 0x4:
+          for (Count = 0; Count < mSpiHcState[Record].Count; Count++) {
+            MmioWrite32 (
+              mHcAddress + mSpiHcState[Record].Register,
+              *(UINT32 *)State
+              );
+            State += 4;
+          }
+
+          break;
+      }
+    }
+
+    mSmmAlreadySavedState = FALSE;
+  }
+
+  return Status;
+}
+
+/**
+  Block SPI Flash Write Enable Opcode.  This will block anything that requires
+  the Opcode equivalent to the SPI Flash Memory Write Enable Opcode.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+
+  @param[in]  This    A pointer to the SMM_EFI_SPI_HC_STATE_PROTOCOL structure.
+  @param[in]  Opcode  SPI opcode value.
+  @retval     Others  return various return values.
+**/
+EFI_STATUS
+EFIAPI
+FchSpiBlockOpcode (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This,
+  IN UINT8                                Opcode
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = InternalFchSpiBlockOpcode (mHcAddress, Opcode);
+  return Status;
+}
+
+/**
+  Un-Block SPI Flash Write Enable Opcode.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+
+  @param[in]  This    A pointer to the SMM_EFI_SPI_HC_STATE_PROTOCOL structure.
+  @param[in]  Opcode  SPI opcode value.
+  @retval     Others  Various return values.
+**/
+EFI_STATUS
+EFIAPI
+FchSpiUnblockOpcode (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This,
+  IN UINT8                                Opcode
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = InternalFchSpiUnblockOpcode (mHcAddress, Opcode);
+  return Status;
+}
+
+/**
+  Un-Block any blocked SPI Opcodes.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+
+  @param[in]  This    A pointer to the SMM_EFI_SPI_HC_STATE_PROTOCOL structure.
+  @retval     Others  return various return values.
+**/
+EFI_STATUS
+EFIAPI
+FchSpiUnblockAllOpcodes (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = InternalFchSpiUnblockAllOpcodes (mHcAddress);
+  return Status;
+}
+
+/**
+  Lock SPI host controller registers.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+
+  @param[in]  This    A pointer to the SMM_EFI_SPI_HC_STATE_PROTOCOL structure.
+  @retval     Others  return various return values.
+**/
+EFI_STATUS
+EFIAPI
+FchSpiLockSpiHostControllerRegisters (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = InternalFchSpiLockSpiHostControllerRegisters (mHcAddress);
+  return Status;
+}
+
+/**
+  Unlock SPI host controller registers.
+  This unlock function will only work in SMM.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+
+  @param[in]  This    A pointer to the SMM_EFI_SPI_HC_STATE_PROTOCOL
+  @retval     Others  Various return values
+**/
+EFI_STATUS
+EFIAPI
+FchSpiUnlockSpiHostControllerRegisters (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = InternalFchSpiUnlockSpiHostControllerRegisters (mHcAddress);
+  return Status;
+}

--- a/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcSmmState.h
+++ b/Platform/AMD/AmdPlatformPkg/Library/SpiHcPlatformLib/SpiHcSmmState.h
@@ -1,0 +1,143 @@
+/** @file
+
+  SPI HC SMM state registration function declarations
+
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SPI_HC_SMM_STATE_H_
+#define SPI_HC_SMM_STATE_H_
+
+#include <Base.h>
+#include <Uefi/UefiBaseType.h>
+#include <Protocol/AmdSpiSmmHcState.h>
+#include "SpiHcInternal.h"
+
+typedef struct {
+  UINT32    Register;
+  UINT8     Size;     // Size in Bytes
+  UINT8     Count;    // Number of contiguous registers to store
+} SPI_HC_REGISTER_STATE;
+
+/**
+  Allocate the save state space and update the instance structure
+
+  @retval EFI_SUCCESS            The Save State space was allocated
+  @retval EFI_OUT_OF_RESOURCES   The Save State space failed to allocate
+**/
+EFI_STATUS
+EFIAPI
+AllocateState (
+  );
+
+/**
+  Save the Host Controller state to restore after transaction is complete
+
+  @param[in] This           SPI host controller Preserve State Protocol;
+
+  @retval EFI_SUCCESS       Spi Execute command executed properly
+  @retval EFI_DEVICE_ERROR  Spi Execute command failed
+**/
+EFI_STATUS
+EFIAPI
+SaveState (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This
+  );
+
+/**
+  Restore the Host Controller state
+
+  @param[in] This           SPI host controller Preserve State Protocol;
+
+  @retval EFI_SUCCESS       Spi Execute command executed properly
+  @retval EFI_DEVICE_ERROR  Spi Execute command failed
+**/
+EFI_STATUS
+EFIAPI
+RestoreState (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This
+  );
+
+/**
+  Block SPI Flash Write Enable Opcode.  This will block anything that requires
+  the Opcode equivalent to the SPI Flash Memory Write Enable Opcode.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+**/
+EFI_STATUS
+EFIAPI
+FchSpiBlockOpcode (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This,
+  IN UINT8                                Opcode
+  );
+
+/**
+  Un-Block SPI Flash Write Enable Opcode.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+**/
+EFI_STATUS
+EFIAPI
+FchSpiUnblockOpcode (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This,
+  IN UINT8                                Opcode
+  );
+
+/**
+  Un-Block any blocked SPI Opcodes.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+**/
+EFI_STATUS
+EFIAPI
+FchSpiUnblockAllOpcodes (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This
+  );
+
+/**
+  Lock SPI host controller registers.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+**/
+EFI_STATUS
+EFIAPI
+FchSpiLockSpiHostControllerRegisters (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This
+  );
+
+/**
+  Unlock SPI host controller registers.  This unlock function will only work in
+  SMM.
+
+  RestrictedCmd0..3 (SPIx04[31:0]) will be locked (write protected) when
+  SPIx00[23:22] not equal 11b, so you can write SPIx00[23:22]=00b to lock them.
+  Once SPIx00[23:22] = 00b, they can only be written in SMM,
+  to clear RestrictedCmd0..3, get into SMM, write SPIx00[23:22]=11b,
+  then you can clear RestrictedCmd0..3 (SPIx04)
+**/
+EFI_STATUS
+EFIAPI
+FchSpiUnlockSpiHostControllerRegisters (
+  IN CONST SMM_EFI_SPI_HC_STATE_PROTOCOL  *This
+  );
+
+#endif // SPI_HC_SMM_STATE_H__


### PR DESCRIPTION
Implements SpiHcPlatformLib library for AMD platform. Its AMD platform specific SPI host controller library.

Cc: Abner Chang <abner.chang@amd.com>
Cc: Paul Grimes <paul.grimes@amd.com>