### PR TITLE
IntelSiliconPkg: Update Header File to Align FIT Specification 1.5

### DIFF
--- a/Silicon/Intel/IntelSiliconPkg/Include/IndustryStandard/FirmwareInterfaceTable.h
+++ b/Silicon/Intel/IntelSiliconPkg/Include/IndustryStandard/FirmwareInterfaceTable.h
@@ -1,10 +1,11 @@
 /** @file
-  FirmwareInterfaceTable (FIT) related definitions.
+  Firmware Interface Table (FIT) related definitions.
 
-  @todo update document/spec reference
-
-  Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Specification Reference:
+    - Firmware Interface Table Revision 1.5
 
 **/
 
@@ -12,12 +13,15 @@
 #define __FIRMWARE_INTERFACE_TABLE_H__
 
 //
-// FIT Entry type definitions
+// FIT entry type definitions.
 //
 #define FIT_TYPE_00_HEADER                  0x00
 #define FIT_TYPE_01_MICROCODE               0x01
 #define FIT_TYPE_02_STARTUP_ACM             0x02
+#define FIT_TYPE_03_DIAGNOSTIC_ACM          0x03
 #define FIT_TYPE_04_PROT_BOOT_POLICY        0x04
+#define FIT_TYPE_05_MMC_FIRMWARE_IMAGE      0x05
+#define FIT_TYPE_06_FIT_RESET_STATE         0x06
 #define FIT_TYPE_07_BIOS_STARTUP_MODULE     0x07
 #define FIT_TYPE_08_TPM_POLICY              0x08
 #define FIT_TYPE_09_BIOS_POLICY             0x09
@@ -26,17 +30,39 @@
 #define FIT_TYPE_0C_BOOT_POLICY_MANIFEST    0x0C
 #define FIT_TYPE_0D_FSP_BOOT_MANIFEST       0x0D
 #define FIT_TYPE_10_CSE_SECURE_BOOT         0x10
+#define FIT_TYPE_1A_VAB_PROVISIONING_TABLE  0x1A
+#define FIT_TYPE_1B_VAB_KEY_MANIFEST        0x1B
+#define FIT_TYPE_1C_VAB_IMAGE_MANIFEST      0x1C
+#define FIT_TYPE_1D_VAB_IMAGE_HASH_DESC     0x1D
+#define FIT_TYPE_2C_SACM_DEBUG              0x2C
 #define FIT_TYPE_2D_TXTSX_POLICY            0x2D
+#define FIT_TYPE_2E_GRANULAR_SCRTM_ERROR    0x2E
 #define FIT_TYPE_2F_JMP_DEBUG_POLICY        0x2F
 #define FIT_TYPE_7F_SKIP                    0x7F
 
-#define FIT_POINTER_ADDRESS                 0xFFFFFFC0 ///< Fixed address at 4G - 40h
+//
+// FIT pointer definitions.
+//
+#define FIT_POINTER_ADDRESS  0xFFFFFFC0 ///< Fixed address at 4G - 40h
 
-#define FIT_TYPE_VERSION                    0x0100
+//
+// The entire FIT table must reside within the firmware address range of
+// (4 GB to 16 MB) to (4 GB-40h).
+// If the FIT is located outside this region, the processor will invoke
+// a legacy boot process and a root of trust will not be established using FIT.
+//
+#define FIT_TABLE_LOWER_ADDRESS  (BASE_4GB - SIZE_16MB)
+#define FIT_TABLE_UPPER_ADDRESS  FIT_POINTER_ADDRESS
+
+//
+// FIT entry version definitions.
+//
+#define FIT_TYPE_VERSION         0x0100
+#define FIT_TYPE_02_VERSION_200  0x0200
 
 #define FIT_TYPE_00_SIGNATURE  SIGNATURE_64 ('_', 'F', 'I', 'T', '_', ' ', ' ', ' ')
 
-#pragma pack(1)
+#pragma pack (1)
 
 typedef struct {
   /**
@@ -66,6 +92,23 @@ typedef struct {
   UINT8  Chksum;
 } FIRMWARE_INTERFACE_TABLE_ENTRY;
 
-#pragma pack()
+typedef struct {
+  UINT64    Address;                ///< Same definition as generic FIT entry.
+  UINT8     Model             : 4;  ///< Processor model field.
+  UINT8     Family            : 4;  ///< Processor family field.
+  UINT8     ProcessorType     : 4;  ///< Processor type field.
+  UINT8     ExtModel          : 4;  ///< Processor extended model field.
+  UINT8     ModelMask         : 4;  ///< Processor model field mask.
+  UINT8     FamilyMask        : 4;  ///< Processor family field mask.
+  UINT8     ProcessorTypeMask : 4;  ///< Processor type field mask.
+  UINT8     ExtModelMask      : 4;  ///< Processor extended model field mask.
+  UINT16    Version;                ///< Version field must be 0x0200.
+  UINT8     Type              : 7;  ///< Type filed must be 0x02.
+  UINT8     C_V               : 1;  ///< C_V field must be 0x0.
+  UINT8     ExtFamily         : 4;  ///< Processor extended family field.
+  UINT8     ExtFamilyMask     : 4;  ///< Processor extended family field mask.
+} FIT_TYPE_02_VERSION_200_ENTRY;
+
+#pragma pack ()
 
 #endif


### PR DESCRIPTION
This commit includes below changes,

(1) Add the below definition for FIT entry type
    - FIT_TYPE_03_DIAGNOSTIC_ACM
    - FIT_TYPE_05_MMC_FIRMWARE_IMAGE
    - FIT_TYPE_06_FIT_RESET_STATE
    - FIT_TYPE_1A_VAB_PROVISIONING_TABLE
    - FIT_TYPE_1B_VAB_KEY_MANIFEST
    - FIT_TYPE_1C_VAB_IMAGE_MANIFEST
    - FIT_TYPE_1D_VAB_IMAGE_HASH_DESC
    - FIT_TYPE_2C_SACM_DEBUG
    - FIT_TYPE_2E_GRANULAR_SCRTM_ERROR

(2) Add the below definition to support FIT table range
    - FIT_TABLE_LOWER_ADDRESS
    - FIT_TABLE_UPPER_ADDRESS

(3) Add the below definition and structure for Type02 (Ver. 0x200) entry
    - FIT_TYPE_02_VERSION_200
    - FIT_TYPE_02_VERSION_200_ENTRY