### PR TITLE
Platform/Intel: Enable the PcdSmrrEnable

### DIFF
--- a/Platform/Intel/SimicsOpenBoardPkg/BoardX58Ich10/OpenBoardPkgPcd.dsc
+++ b/Platform/Intel/SimicsOpenBoardPkg/BoardX58Ich10/OpenBoardPkgPcd.dsc
@@ -43,7 +43,7 @@
   gUefiCpuPkgTokenSpaceGuid.PcdCpuHotPlugSupport|FALSE
   gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmEnableBspElection|FALSE
   gUefiCpuPkgTokenSpaceGuid.PcdSmmFeatureControlEnable|FALSE
-  gUefiCpuPkgTokenSpaceGuid.PcdSmrrEnable|FALSE
+  gUefiCpuPkgTokenSpaceGuid.PcdSmrrEnable|TRUE
 
   ######################################
   # Platform Configuration


### PR DESCRIPTION
This patch is to enable the PcdSmrrEnable since the simics report it has the capability to enable the smrr.