### PR TITLE
Silicon/Intel: Support MM_STANDALONE for the PCH SPI Interface

### DIFF
--- a/Silicon/Intel/SimicsIch10Pkg/Spi/Smm/PchSpi.c
+++ b/Silicon/Intel/SimicsIch10Pkg/Spi/Smm/PchSpi.c
@@ -1,7 +1,7 @@
 /** @file
   PCH SPI SMM Driver implements the SPI Host Controller Compatibility Interface.
 
-  Copyright (c) 2019 Intel Corporation. All rights reserved. <BR>
+  Copyright (c) 2019 - 2024 Intel Corporation. All rights reserved. <BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -19,6 +19,10 @@ GLOBAL_REMOVE_IF_UNREFERENCED SPI_INSTANCE          *mSpiInstance;
 //
 GLOBAL_REMOVE_IF_UNREFERENCED UINT32                mSpiResvMmioAddr;
 
+EFI_STATUS
+InstallPchSpiCommon (
+  VOID
+  );
 /**
   <b>SPI Runtime SMM Module Entry Point</b>\n
   - <b>Introduction</b>\n
@@ -55,9 +59,28 @@ GLOBAL_REMOVE_IF_UNREFERENCED UINT32                mSpiResvMmioAddr;
 **/
 EFI_STATUS
 EFIAPI
-InstallPchSpi (
+InstallPchSpiSmm (
   IN EFI_HANDLE            ImageHandle,
   IN EFI_SYSTEM_TABLE      *SystemTable
+  )
+{
+  return InstallPchSpiCommon ();
+}
+
+
+EFI_STATUS
+EFIAPI
+InstallPchSpiMm (
+  IN EFI_HANDLE            ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE     *SystemTable
+  )
+{
+  return InstallPchSpiCommon ();
+}
+
+EFI_STATUS
+InstallPchSpiCommon (
+  VOID
   )
 {
   EFI_STATUS  Status;
@@ -70,7 +93,7 @@ InstallPchSpi (
   ///
   /// Allocate pool for SPI protocol instance
   ///
-  Status = gSmst->SmmAllocatePool (
+  Status = gMmst->MmAllocatePool (
                     EfiRuntimeServicesData, /// MemoryType don't care
                     sizeof (SPI_INSTANCE),
                     (VOID **) &mSpiInstance
@@ -94,14 +117,14 @@ InstallPchSpi (
   //
   // Install the SMM PCH_SPI2_PROTOCOL interface
   //
-  Status = gSmst->SmmInstallProtocolInterface (
+  Status = gMmst->MmInstallProtocolInterface (
                     &(mSpiInstance->Handle),
                     &gPchSmmSpi2ProtocolGuid,
                     EFI_NATIVE_INTERFACE,
                     &(mSpiInstance->SpiProtocol)
                     );
   if (EFI_ERROR (Status)) {
-    gSmst->SmmFreePool (mSpiInstance);
+    gMmst->MmFreePool (mSpiInstance);
     return EFI_DEVICE_ERROR;
   }
 

--- a/Silicon/Intel/SimicsIch10Pkg/Spi/Smm/PchSpi.h
+++ b/Silicon/Intel/SimicsIch10Pkg/Spi/Smm/PchSpi.h
@@ -1,7 +1,7 @@
 /** @file
   Header file for the PCH SPI SMM Driver.
 
-  Copyright (c) 2019 Intel Corporation. All rights reserved. <BR>
+  Copyright (c) 2019 - 2024 Intel Corporation. All rights reserved. <BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -15,7 +15,7 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
-#include <Library/SmmServicesTableLib.h>
+#include <Library/MmServicesTableLib.h>
 #include <PchAccess.h>
 #include <Protocol/Spi2.h>
 #include <IncludePrivate/Library/PchSpiCommonLib.h>

--- a/Silicon/Intel/SimicsIch10Pkg/Spi/Smm/PchSpiStandaloneMm.inf
+++ b/Silicon/Intel/SimicsIch10Pkg/Spi/Smm/PchSpiStandaloneMm.inf
@@ -1,7 +1,7 @@
 ## @file
 # Component description file for the SPI SMM driver.
 #
-# Copyright (c) 2019 - 2024 Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2024 Intel Corporation. All rights reserved. <BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -10,18 +10,17 @@
 [Defines]
   INF_VERSION                 = 0x00010017
   BASE_NAME                   = PchSpiSmm
-  FILE_GUID                   = 27F4917B-A707-4aad-9676-26DF168CBF0D
+  FILE_GUID                   = 28b8e210-b14d-4b3d-af3c-c73af224457e
   VERSION_STRING              = 1.0
-  MODULE_TYPE                 = DXE_SMM_DRIVER
-  PI_SPECIFICATION_VERSION    = 1.10
-  ENTRY_POINT                 = InstallPchSpiSmm
+  MODULE_TYPE                 = MM_STANDALONE
+  PI_SPECIFICATION_VERSION    = 0x00010032
+  ENTRY_POINT                 = InstallPchSpiMm
 
 
   [LibraryClasses]
   DebugLib
   IoLib
-  UefiDriverEntryPoint
-  UefiBootServicesTableLib
+  StandaloneMmDriverEntryPoint
   BaseLib
   MmServicesTableLib
   PchSpiCommonLib
@@ -41,5 +40,4 @@
 
 
 [Depex]
-  gEfiSmmBase2ProtocolGuid    #This is for SmmServicesTableLib
-  AND gEfiSmmCpuProtocolGuid  # This is for CpuSmmDisableBiosWriteProtect()
+  gEfiSmmCpuProtocolGuid  # This is for CpuSmmDisableBiosWriteProtect()


### PR DESCRIPTION
This patch Add a new PchSpiStandaloneMm.inf driver for the PCH SPI Interface support.