### PR TITLE
IntelSiliconPkg: Add missing components and build fixes

### DIFF
--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/BmDma.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/BmDma.c
@@ -464,7 +464,7 @@ IoMmuAllocateBuffer (
   if (!EFI_ERROR (Status)) {
     *HostAddress = (VOID *) (UINTN) PhysicalAddress;
 
-    VTdLogAddEvent (VTDLOG_DXE_IOMMU_ALLOC_BUFFER, (UINT64) Pages, (UINT64) (*HostAddress));
+    VTdLogAddEvent (VTDLOG_DXE_IOMMU_ALLOC_BUFFER, (UINT64) Pages, (UINT64) (UINTN) (*HostAddress));
   }
 
   DEBUG ((DEBUG_VERBOSE, "IoMmuAllocateBuffer: 0x%08x <==\n", *HostAddress));
@@ -494,7 +494,7 @@ IoMmuFreeBuffer (
 {
   DEBUG ((DEBUG_VERBOSE, "IoMmuFreeBuffer: 0x%\n", Pages));
 
-  VTdLogAddEvent (VTDLOG_DXE_IOMMU_FREE_BUFFER, Pages, (UINT64) HostAddress);
+  VTdLogAddEvent (VTDLOG_DXE_IOMMU_FREE_BUFFER, Pages, (UINT64) (UINTN) HostAddress);
 
   return gBS->FreePages ((EFI_PHYSICAL_ADDRESS) (UINTN) HostAddress, Pages);
 }

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/VtdLog.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/VtdLog.c
@@ -77,7 +77,7 @@ VTdLogAddEvent (
     Item->Data2 = Data2;
 
     Item->Header.DataSize  = sizeof (VTDLOG_EVENT_2PARAM);
-    Item->Header.LogType   = (UINT64) 1 << EventType;
+    Item->Header.LogType   = LShiftU64 (1, EventType);
     Item->Header.Timestamp = AsmReadTsc ();
   }
 }
@@ -117,11 +117,11 @@ VTdLogAddDataEvent (
     CopyMem (Item->Data, Data, DataSize);
 
     Item->Header.DataSize  = EventSize;
-    Item->Header.LogType   = (UINT64) 1 << EventType;
+    Item->Header.LogType   = LShiftU64 (1, EventType);
     Item->Header.Timestamp = AsmReadTsc ();
   }
 }
-  
+
 /**
   Get Event Items From Pei Pre-Mem Buffer
 
@@ -154,10 +154,10 @@ VTdGetEventItemsFromPeiPreMemBuffer (
       Event.Header.DataSize = sizeof (VTDLOG_EVENT_2PARAM);
       Event.Header.Timestamp = 0;
 
-      Event.Header.LogType = ((UINT64) 1) << VTDLOG_PEI_PRE_MEM_DMA_PROTECT;
+      Event.Header.LogType = LShiftU64 (1, VTDLOG_PEI_PRE_MEM_DMA_PROTECT);
       Event.Data1 = InfoBuffer[Index].BarAddress;
       Event.Data2 = InfoBuffer[Index].Mode;
-      Event.Data2 |= InfoBuffer[Index].Status<<8;
+      Event.Data2 |= LShiftU64 (InfoBuffer[Index].Status, 8);
       CallbackHandle (Context, &Event.Header);
     }
     EventCount++;
@@ -231,7 +231,7 @@ VTdGenerateStateEvent (
   Item.Data2 = Data2;
 
   Item.Header.DataSize  = sizeof (VTDLOG_EVENT_2PARAM);
-  Item.Header.LogType   = (UINT64) 1 << EventType;
+  Item.Header.LogType   = LShiftU64 (1, EventType);
   Item.Header.Timestamp = 0;
 
   if (CallbackHandle) {

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCorePei/IntelVTdCorePei.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCorePei/IntelVTdCorePei.c
@@ -111,7 +111,7 @@ VTdLogAddEvent (
     Item->Data1 = Data1;
     Item->Data2 = Data2;
     Item->Header.DataSize  = sizeof (VTDLOG_EVENT_2PARAM);
-    Item->Header.LogType   = (UINT64) (1 << EventType);
+    Item->Header.LogType   = LShiftU64 (1, EventType);
     Item->Header.Timestamp = AsmReadTsc ();
   }
 }
@@ -151,8 +151,8 @@ VTdLogAddDataEvent (
     CopyMem (Item->Data, Data, DataSize);
 
     Item->Header.DataSize  = EventSize;
-    Item->Header.LogType   = (UINT64) (1 << EventType);
-    Item->Header.Timestamp = AsmReadTsc ();    
+    Item->Header.LogType   = LShiftU64 (1, EventType);
+    Item->Header.Timestamp = AsmReadTsc ();
   }
 }
 /**
@@ -372,7 +372,7 @@ PeiIoMmuMap (
       );
   }
 
-  VTdLogAddEvent (VTDLOG_PEI_PPI_MAP, (UINT64) HostAddress, Length);
+  VTdLogAddEvent (VTDLOG_PEI_PPI_MAP, (UINT64) (UINTN) HostAddress, Length);
   return EFI_SUCCESS;
 }
 
@@ -498,7 +498,7 @@ PeiIoMmuAllocateBuffer (
 
   DEBUG ((DEBUG_INFO, "PeiIoMmuAllocateBuffer - allocate - %x\n", *HostAddress));
 
-  VTdLogAddEvent (VTDLOG_PEI_PPI_ALLOC_BUFFER, (UINT64) (*HostAddress), Length);
+  VTdLogAddEvent (VTDLOG_PEI_PPI_ALLOC_BUFFER, (UINT64) (UINTN) (*HostAddress), Length);
 
   return EFI_SUCCESS;
 }

--- a/Silicon/Intel/IntelSiliconPkg/IntelSiliconPkg.dsc
+++ b/Silicon/Intel/IntelSiliconPkg/IntelSiliconPkg.dsc
@@ -105,6 +105,8 @@
   IntelSiliconPkg/Feature/PcieSecurity/SamplePlatformDevicePolicyDxe/SamplePlatformDevicePolicyDxe.inf
   IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceSmm.inf
   IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceStandaloneMm.inf
+  IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/IntelVTdCoreDxe.inf
+  IntelSiliconPkg/Feature/VTd/IntelVTdCorePei/IntelVTdCorePei.inf
   IntelSiliconPkg/Feature/VTd/IntelVTdDxe/IntelVTdDxe.inf
   IntelSiliconPkg/Feature/VTd/IntelVTdDmarPei/IntelVTdDmarPei.inf
   IntelSiliconPkg/Feature/VTd/IntelVTdPmrPei/IntelVTdPmrPei.inf
@@ -113,8 +115,15 @@
   IntelSiliconPkg/Feature/Capsule/MicrocodeUpdateDxe/MicrocodeUpdateDxe.inf
   IntelSiliconPkg/Feature/Capsule/Library/MicrocodeFlashAccessLibNull/MicrocodeFlashAccessLibNull.inf
   IntelSiliconPkg/Feature/ShadowMicrocode/ShadowMicrocodePei.inf
+  IntelSiliconPkg/Feature/SmmAccess/Library/PeiSmmAccessLib/PeiSmmAccessLib.inf
+  IntelSiliconPkg/Feature/SmmAccess/Library/PeiSmmAccessLibSmramc/PeiSmmAccessLib.inf
+  IntelSiliconPkg/Feature/SmmAccess/SmmAccessDxe/SmmAccess.inf
+  IntelSiliconPkg/Feature/SmmControl/Library/PeiSmmControlLib/PeiSmmControlLib.inf
+  IntelSiliconPkg/Library/IntelVTdPeiDxeLib/IntelVTdPeiDxeLib.inf
+  IntelSiliconPkg/Library/IntelVTdPeiDxeLib/IntelVTdPeiDxeLibExt.inf
   IntelSiliconPkg/Library/PeiDxeSmmBootMediaLib/PeiFirmwareBootMediaLib.inf
   IntelSiliconPkg/Library/PeiDxeSmmBootMediaLib/DxeSmmFirmwareBootMediaLib.inf
+  IntelSiliconPkg/Library/PeiGetVtdPmrAlignmentLib/PeiGetVtdPmrAlignmentLib.inf
   IntelSiliconPkg/Library/DxeAslUpdateLib/DxeAslUpdateLib.inf
   IntelSiliconPkg/Library/ReportCpuHobLib/ReportCpuHobLib.inf
   IntelSiliconPkg/Library/SpiFlashCommonLibNull/SpiFlashCommonLibNull.inf


### PR DESCRIPTION
Some libraries and modules are missing from the build.

The first patch fixes compiler and linker failures. The second patch
adds the missing components to IntelSiliconPkg.dsc.

---

> Note: An attempt was made to follow the coding style used in
> the files which differs slightly from coding style used in
> edk2 such as spaces between casts.