### PR TITLE
Platform/ARM: Prepare for supporting other archs in DynamicTablesPkg

### DIFF
--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1404,7 +1404,7 @@ GetPsdInfo (
   @param [in]      This           Pointer to the Configuration Manager Protocol.
   @param [in]      CmObjectId     The Object ID of the CM object requested
   @param [in]      SearchToken    A unique token for identifying the requested
-                                  CM_ARM_PCI_INTERRUPT_MAP_INFO object.
+                                  CM_ARCH_COMMON_CPC_INFO object.
   @param [in, out] CmObject       Pointer to the Configuration Manager Object
                                   descriptor describing the requested Object.
 
@@ -1762,6 +1762,19 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjCpcInfo:
+      Status = HandleCmObjectRefByToken (
+                 This,
+                 CmObjectId,
+                 PlatformRepo->CpcInfo,
+                 sizeof (PlatformRepo->CpcInfo),
+                 ARRAY_SIZE (PlatformRepo->CpcInfo),
+                 Token,
+                 GetCpcInfo,
+                 CmObject
+                 );
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1919,19 +1932,6 @@ GetArmNameSpaceObject (
                  ARRAY_SIZE (PlatformRepo->PsdInfo),
                  Token,
                  GetPsdInfo,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjCpcInfo:
-      Status = HandleCmObjectRefByToken (
-                 This,
-                 CmObjectId,
-                 PlatformRepo->CpcInfo,
-                 sizeof (PlatformRepo->CpcInfo),
-                 ARRAY_SIZE (PlatformRepo->CpcInfo),
-                 Token,
-                 GetCpcInfo,
                  CmObject
                  );
       break;

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1658,6 +1658,26 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjConsolePortInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->SpcrSerialPort,
+                 sizeof (PlatformRepo->SpcrSerialPort),
+                 1,
+                 CmObject
+                 );
+      break;
+
+    case EArchCommonObjSerialDebugPortInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->DbgSerialPort,
+                 sizeof (PlatformRepo->DbgSerialPort),
+                 1,
+                 CmObject
+                 );
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1795,25 +1815,7 @@ GetArmNameSpaceObject (
                  CmObject
                  );
       break;
-    case EArmObjSerialConsolePortInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 &PlatformRepo->SpcrSerialPort,
-                 sizeof (PlatformRepo->SpcrSerialPort),
-                 1,
-                 CmObject
-                 );
-      break;
 
-    case EArmObjSerialDebugPortInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 &PlatformRepo->DbgSerialPort,
-                 sizeof (PlatformRepo->DbgSerialPort),
-                 1,
-                 CmObject
-                 );
-      break;
     case EArmObjGicMsiFrameInfo:
       Status = HandleCmObject (
                  CmObjectId,

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1752,6 +1752,16 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjCacheInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 PlatformRepo->CacheInfo,
+                 sizeof (PlatformRepo->CacheInfo),
+                 ARRAY_SIZE (PlatformRepo->CacheInfo),
+                 CmObject
+                 );
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1896,16 +1906,6 @@ GetArmNameSpaceObject (
                  &PlatformRepo->GicMsiFrameInfo,
                  sizeof (PlatformRepo->GicMsiFrameInfo),
                  1,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjCacheInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 PlatformRepo->CacheInfo,
-                 sizeof (PlatformRepo->CacheInfo),
-                 ARRAY_SIZE (PlatformRepo->CacheInfo),
                  CmObject
                  );
       break;

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1648,6 +1648,16 @@ GetArchCommonNameSpaceObject (
   PlatformRepo = This->PlatRepoInfo;
 
   switch (GET_CM_OBJECT_ID (CmObjectId)) {
+    case EArchCommonObjPowerManagementProfileInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->PmProfileInfo,
+                 sizeof (PlatformRepo->PmProfileInfo),
+                 1,
+                 CmObject
+                 );
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1703,15 +1713,6 @@ GetArmNameSpaceObject (
                  CmObjectId,
                  &PlatformRepo->BootArchInfo,
                  sizeof (PlatformRepo->BootArchInfo),
-                 1,
-                 CmObject
-                 );
-      break;
-    case EArmObjPowerManagementProfileInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 &PlatformRepo->PmProfileInfo,
-                 sizeof (PlatformRepo->PmProfileInfo),
                  1,
                  CmObject
                  );

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -361,7 +361,7 @@ EDKII_PLATFORM_REPOSITORY_INFO ArmJunoPlatformRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       CM_NULL_TOKEN,
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       CM_NULL_TOKEN,
       // UINT32  NoOfPrivateResources
       0,
@@ -384,7 +384,7 @@ EDKII_PLATFORM_REPOSITORY_INFO ArmJunoPlatformRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[0]), // -> Package
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       CM_NULL_TOKEN,
       // UINT32  NoOfPrivateResources
       BIG_CLUSTER_RESOURCE_COUNT,
@@ -407,7 +407,7 @@ EDKII_PLATFORM_REPOSITORY_INFO ArmJunoPlatformRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[0]), // -> Package
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       CM_NULL_TOKEN,
       // UINT32  NoOfPrivateResources
       LITTLE_CLUSTER_RESOURCE_COUNT,
@@ -430,7 +430,7 @@ EDKII_PLATFORM_REPOSITORY_INFO ArmJunoPlatformRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[1]), // -> 'big' cluster
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[0]),
       // UINT32  NoOfPrivateResources
       BIG_CORE_RESOURCE_COUNT,
@@ -452,7 +452,7 @@ EDKII_PLATFORM_REPOSITORY_INFO ArmJunoPlatformRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[1]), // -> 'big' cluster
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[1]),
       // UINT32  NoOfPrivateResources
       BIG_CORE_RESOURCE_COUNT,
@@ -475,7 +475,7 @@ EDKII_PLATFORM_REPOSITORY_INFO ArmJunoPlatformRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[2]), // -> 'LITTLE' cluster
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[2]),
       // UINT32  NoOfPrivateResources
       LITTLE_CORE_RESOURCE_COUNT,
@@ -497,7 +497,7 @@ EDKII_PLATFORM_REPOSITORY_INFO ArmJunoPlatformRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[2]), // -> 'LITTLE' cluster
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[3]),
       // UINT32  NoOfPrivateResources
       LITTLE_CORE_RESOURCE_COUNT,
@@ -519,7 +519,7 @@ EDKII_PLATFORM_REPOSITORY_INFO ArmJunoPlatformRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[2]), // -> 'LITTLE' cluster
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[4]),
       // UINT32  NoOfPrivateResources
       LITTLE_CORE_RESOURCE_COUNT,
@@ -541,7 +541,7 @@ EDKII_PLATFORM_REPOSITORY_INFO ArmJunoPlatformRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[2]), // -> 'LITTLE' cluster
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[5]),
       // UINT32  NoOfPrivateResources
       LITTLE_CORE_RESOURCE_COUNT,

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1355,7 +1355,7 @@ GetPciInterruptMapInfo (
   @param [in]      This           Pointer to the Configuration Manager Protocol.
   @param [in]      CmObjectId     The Object ID of the CM object requested
   @param [in]      SearchToken    A unique token for identifying the requested
-                                  CM_ARM_PCI_INTERRUPT_MAP_INFO object.
+                                  CM_ARCH_COMMON_PSD_INFO object.
   @param [in, out] CmObject       Pointer to the Configuration Manager Object
                                   descriptor describing the requested Object.
 
@@ -1775,6 +1775,19 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjPsdInfo:
+      Status = HandleCmObjectRefByToken (
+                 This,
+                 CmObjectId,
+                 PlatformRepo->PsdInfo,
+                 sizeof (PlatformRepo->PsdInfo),
+                 ARRAY_SIZE (PlatformRepo->PsdInfo),
+                 Token,
+                 GetPsdInfo,
+                 CmObject
+                 );
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1919,19 +1932,6 @@ GetArmNameSpaceObject (
                  &PlatformRepo->GicMsiFrameInfo,
                  sizeof (PlatformRepo->GicMsiFrameInfo),
                  1,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjPsdInfo:
-      Status = HandleCmObjectRefByToken (
-                 This,
-                 CmObjectId,
-                 PlatformRepo->PsdInfo,
-                 sizeof (PlatformRepo->PsdInfo),
-                 ARRAY_SIZE (PlatformRepo->PsdInfo),
-                 Token,
-                 GetPsdInfo,
                  CmObject
                  );
       break;

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1257,7 +1257,7 @@ GetLpiInfo (
   @param [in]      This           Pointer to the Configuration Manager Protocol.
   @param [in]      CmObjectId     The Object ID of the CM object requested
   @param [in]      SearchToken    A unique token for identifying the requested
-                                  CM_ARM_PCI_ADDRESS_MAP_INFO object.
+                                  CM_ARCH_COMMON_PCI_ADDRESS_MAP_INFO object.
   @param [in, out] CmObject       Pointer to the Configuration Manager Object
                                   descriptor describing the requested Object.
 
@@ -1703,6 +1703,19 @@ GetArchCommonNameSpaceObject (
       }
       break;
 
+    case EArchCommonObjPciAddressMapInfo:
+      Status = HandleCmObjectRefByToken (
+                 This,
+                 CmObjectId,
+                 PlatformRepo->PciAddressMapInfo,
+                 sizeof (PlatformRepo->PciAddressMapInfo),
+                 ARRAY_SIZE (PlatformRepo->PciAddressMapInfo),
+                 Token,
+                 GetPciAddressMapInfo,
+                 CmObject
+                 );
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1880,19 +1893,6 @@ GetArmNameSpaceObject (
                  0,
                  Token,
                  GetLpiInfo,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjPciAddressMapInfo:
-      Status = HandleCmObjectRefByToken (
-                 This,
-                 CmObjectId,
-                 PlatformRepo->PciAddressMapInfo,
-                 sizeof (PlatformRepo->PciAddressMapInfo),
-                 ARRAY_SIZE (PlatformRepo->PciAddressMapInfo),
-                 Token,
-                 GetPciAddressMapInfo,
                  CmObject
                  );
       break;

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1,7 +1,7 @@
 /** @file
   Configuration Manager Dxe
 
-  Copyright (c) 2017 - 2023, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2017 - 2024, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -1612,6 +1612,57 @@ GetStandardNameSpaceObject (
   return Status;
 }
 
+
+/** Return an Arch Common namespace object.
+
+  @param [in]      This        Pointer to the Configuration Manager Protocol.
+  @param [in]      CmObjectId  The Configuration Manager Object ID.
+  @param [in]      Token       An optional token identifying the object. If
+                               unused this must be CM_NULL_TOKEN.
+  @param [in, out] CmObject    Pointer to the Configuration Manager Object
+                               descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+**/
+EFI_STATUS
+EFIAPI
+GetArchCommonNameSpaceObject (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  )
+{
+  EFI_STATUS                        Status;
+  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
+
+  if ((This == NULL) || (CmObject == NULL)) {
+    ASSERT (This != NULL);
+    ASSERT (CmObject != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = EFI_NOT_FOUND;
+  PlatformRepo = This->PlatRepoInfo;
+
+  switch (GET_CM_OBJECT_ID (CmObjectId)) {
+    default: {
+      Status = EFI_NOT_FOUND;
+      DEBUG ((
+        DEBUG_INFO,
+        "INFO: Object 0x%x. Status = %r\n",
+        CmObjectId,
+        Status
+        ));
+      break;
+    }
+  } //switch
+
+  return Status;
+}
+
 /** Return an ARM namespace object.
 
   @param [in]      This        Pointer to the Configuration Manager Protocol.
@@ -1979,6 +2030,9 @@ ArmJunoPlatformGetObject (
   switch (GET_CM_NAMESPACE_ID (CmObjectId)) {
     case EObjNameSpaceStandard:
       Status = GetStandardNameSpaceObject (This, CmObjectId, Token, CmObject);
+      break;
+    case EObjNameSpaceArchCommon:
+      Status = GetArchCommonNameSpaceObject (This, CmObjectId, Token, CmObject);
       break;
     case EObjNameSpaceArm:
       Status = GetArmNameSpaceObject (This, CmObjectId, Token, CmObject);

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1742,6 +1742,16 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjProcHierarchyInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 PlatformRepo->ProcHierarchyInfo,
+                 sizeof (PlatformRepo->ProcHierarchyInfo),
+                 ARRAY_SIZE (PlatformRepo->ProcHierarchyInfo),
+                 CmObject
+                 );
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1886,16 +1896,6 @@ GetArmNameSpaceObject (
                  &PlatformRepo->GicMsiFrameInfo,
                  sizeof (PlatformRepo->GicMsiFrameInfo),
                  1,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjProcHierarchyInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 PlatformRepo->ProcHierarchyInfo,
-                 sizeof (PlatformRepo->ProcHierarchyInfo),
-                 ARRAY_SIZE (PlatformRepo->ProcHierarchyInfo),
                  CmObject
                  );
       break;

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1207,7 +1207,7 @@ GetGicCInfo (
   @param [in]      This           Pointer to the Configuration Manager Protocol.
   @param [in]      CmObjectId     The Object ID of the CM object requested
   @param [in]      SearchToken    A unique token for identifying the requested
-                                  CM_ARM_LPI_INFO object.
+                                  CM_ARCH_COMMON_LPI_INFO object.
   @param [in, out] CmObject       Pointer to the Configuration Manager Object
                                   descriptor describing the requested Object.
 
@@ -1729,6 +1729,19 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjLpiInfo:
+      Status = HandleCmObjectRefByToken (
+                 This,
+                 CmObjectId,
+                 NULL,
+                 0,
+                 0,
+                 Token,
+                 GetLpiInfo,
+                 CmObject
+                 );
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1893,19 +1906,6 @@ GetArmNameSpaceObject (
                  PlatformRepo->CacheInfo,
                  sizeof (PlatformRepo->CacheInfo),
                  ARRAY_SIZE (PlatformRepo->CacheInfo),
-                 CmObject
-                 );
-      break;
-
-    case EArmObjLpiInfo:
-      Status = HandleCmObjectRefByToken (
-                 This,
-                 CmObjectId,
-                 NULL,
-                 0,
-                 0,
-                 Token,
-                 GetLpiInfo,
                  CmObject
                  );
       break;

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1454,7 +1454,7 @@ GetCpcInfo (
   @param [in]      This           Pointer to the Configuration Manager Protocol.
   @param [in]      CmObjectId     The Object ID of the CM object requested
   @param [in]      SearchToken    A unique token for identifying the requested
-                                  CM_ARM_OBJ_REF list.
+                                  CM_ARCH_COMMON_OBJ_REF list.
   @param [in, out] CmObject       Pointer to the Configuration Manager Object
                                   descriptor describing the requested Object.
 
@@ -1678,6 +1678,16 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjCmRef:
+      Status = HandleCmObjectSearchPlatformRepo (
+                 This,
+                 CmObjectId,
+                 Token,
+                 GetCmObjRefs,
+                 CmObject
+                 );
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1842,16 +1852,6 @@ GetArmNameSpaceObject (
                  PlatformRepo->CacheInfo,
                  sizeof (PlatformRepo->CacheInfo),
                  ARRAY_SIZE (PlatformRepo->CacheInfo),
-                 CmObject
-                 );
-      break;
-
-    case EArmObjCmRef:
-      Status = HandleCmObjectSearchPlatformRepo (
-                 This,
-                 CmObjectId,
-                 Token,
-                 GetCmObjRefs,
                  CmObject
                  );
       break;

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1306,7 +1306,7 @@ GetPciAddressMapInfo (
   @param [in]      This           Pointer to the Configuration Manager Protocol.
   @param [in]      CmObjectId     The Object ID of the CM object requested
   @param [in]      SearchToken    A unique token for identifying the requested
-                                  CM_ARM_PCI_INTERRUPT_MAP_INFO object.
+                                  CM_ARCH_COMMON_PCI_INTERRUPT_MAP_INFO object.
   @param [in, out] CmObject       Pointer to the Configuration Manager Object
                                   descriptor describing the requested Object.
 
@@ -1716,6 +1716,19 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjPciInterruptMapInfo:
+      Status = HandleCmObjectRefByToken (
+                 This,
+                 CmObjectId,
+                 PlatformRepo->PciInterruptMapInfo,
+                 sizeof (PlatformRepo->PciInterruptMapInfo),
+                 ARRAY_SIZE (PlatformRepo->PciInterruptMapInfo),
+                 Token,
+                 GetPciInterruptMapInfo,
+                 CmObject
+                 );
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1893,19 +1906,6 @@ GetArmNameSpaceObject (
                  0,
                  Token,
                  GetLpiInfo,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjPciInterruptMapInfo:
-      Status = HandleCmObjectRefByToken (
-                 This,
-                 CmObjectId,
-                 PlatformRepo->PciInterruptMapInfo,
-                 sizeof (PlatformRepo->PciInterruptMapInfo),
-                 ARRAY_SIZE (PlatformRepo->PciInterruptMapInfo),
-                 Token,
-                 GetPciInterruptMapInfo,
                  CmObject
                  );
       break;

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1688,6 +1688,21 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjPciConfigSpaceInfo:
+      if (PlatformRepo->JunoRevision != JUNO_REVISION_R0) {
+        Status = HandleCmObject (
+                   CmObjectId,
+                   &PlatformRepo->PciConfigInfo,
+                   sizeof (PlatformRepo->PciConfigInfo),
+                   1,
+                   CmObject
+                   );
+      } else {
+        // No PCIe on Juno R0.
+        Status = EFI_NOT_FOUND;
+      }
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1854,21 +1869,6 @@ GetArmNameSpaceObject (
                  ARRAY_SIZE (PlatformRepo->CacheInfo),
                  CmObject
                  );
-      break;
-
-    case EArmObjPciConfigSpaceInfo:
-      if (PlatformRepo->JunoRevision != JUNO_REVISION_R0) {
-        Status = HandleCmObject (
-                   CmObjectId,
-                   &PlatformRepo->PciConfigInfo,
-                   sizeof (PlatformRepo->PciConfigInfo),
-                   1,
-                   CmObject
-                   );
-      } else {
-        // No PCIe on Juno R0.
-        Status = EFI_NOT_FOUND;
-      }
       break;
 
     case EArmObjLpiInfo:

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -301,7 +301,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARCH_COMMON_OBJ_REF                CoresLpiRef[CORES_LPI_STATE_COUNT];
 
   // Power domains
-  CM_ARM_PSD_INFO                       PsdInfo[PSD_DOMAIN_COUNT];
+  CM_ARCH_COMMON_PSD_INFO               PsdInfo[PSD_DOMAIN_COUNT];
 
   //
   // Dynamically populated fields from here.

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -274,7 +274,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARM_GIC_MSI_FRAME_INFO             GicMsiFrameInfo;
 
   // Processor topology information
-  CM_ARM_PROC_HIERARCHY_INFO            ProcHierarchyInfo[PLAT_PROC_HIERARCHY_NODE_COUNT];
+  CM_ARCH_COMMON_PROC_HIERARCHY_INFO    ProcHierarchyInfo[PLAT_PROC_HIERARCHY_NODE_COUNT];
 
   // Cache information
   CM_ARM_CACHE_INFO                     CacheInfo[PLAT_CACHE_COUNT];

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -277,7 +277,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARCH_COMMON_PROC_HIERARCHY_INFO    ProcHierarchyInfo[PLAT_PROC_HIERARCHY_NODE_COUNT];
 
   // Cache information
-  CM_ARM_CACHE_INFO                     CacheInfo[PLAT_CACHE_COUNT];
+  CM_ARCH_COMMON_CACHE_INFO             CacheInfo[PLAT_CACHE_COUNT];
 
   // 'big' cluster private resources
   CM_ARCH_COMMON_OBJ_REF                BigClusterResources[BIG_CLUSTER_RESOURCE_COUNT];

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -250,10 +250,10 @@ typedef struct PlatformRepositoryInfo {
   /** Serial port information for the
       serial port console redirection port
   */
-  CM_ARM_SERIAL_PORT_INFO               SpcrSerialPort;
+  CM_ARCH_COMMON_SERIAL_PORT_INFO       SpcrSerialPort;
 
   /// Serial port information for the DBG2 UART port
-  CM_ARM_SERIAL_PORT_INFO               DbgSerialPort;
+  CM_ARCH_COMMON_SERIAL_PORT_INFO       DbgSerialPort;
 
   /// PCI configuration space information
   CM_ARM_PCI_CONFIG_SPACE_INFO          PciConfigInfo;

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -292,7 +292,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARCH_COMMON_OBJ_REF                LittleCoreResources[LITTLE_CORE_RESOURCE_COUNT];
 
   // Low Power Idle state information (LPI) for all cores/clusters
-  CM_ARM_LPI_INFO                       LpiInfo[LPI_STATE_COUNT];
+  CM_ARCH_COMMON_LPI_INFO               LpiInfo[LPI_STATE_COUNT];
 
   // Clusters Low Power Idle state references (LPI)
   CM_ARCH_COMMON_OBJ_REF                ClustersLpiRef[CLUSTERS_LPI_STATE_COUNT];

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -259,13 +259,13 @@ typedef struct PlatformRepositoryInfo {
   CM_ARM_PCI_CONFIG_SPACE_INFO          PciConfigInfo;
 
   // PCI address-range mapping references
-  CM_ARM_OBJ_REF                        PciAddressMapRef[PCI_ADDRESS_MAP_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                PciAddressMapRef[PCI_ADDRESS_MAP_COUNT];
 
   // PCI address-range mapping information
   CM_ARM_PCI_ADDRESS_MAP_INFO           PciAddressMapInfo[PCI_ADDRESS_MAP_COUNT];
 
   // PCI device legacy interrupts mapping references
-  CM_ARM_OBJ_REF                        PciInterruptMapRef[PCI_INTERRUPT_MAP_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                PciInterruptMapRef[PCI_INTERRUPT_MAP_COUNT];
 
   // PCI device legacy interrupts mapping information
   CM_ARM_PCI_INTERRUPT_MAP_INFO         PciInterruptMapInfo[PCI_INTERRUPT_MAP_COUNT];
@@ -280,25 +280,25 @@ typedef struct PlatformRepositoryInfo {
   CM_ARM_CACHE_INFO                     CacheInfo[PLAT_CACHE_COUNT];
 
   // 'big' cluster private resources
-  CM_ARM_OBJ_REF                        BigClusterResources[BIG_CLUSTER_RESOURCE_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                BigClusterResources[BIG_CLUSTER_RESOURCE_COUNT];
 
   // 'big' core private resources
-  CM_ARM_OBJ_REF                        BigCoreResources[BIG_CORE_RESOURCE_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                BigCoreResources[BIG_CORE_RESOURCE_COUNT];
 
   // 'LITTLE' cluster private resources
-  CM_ARM_OBJ_REF                        LittleClusterResources[LITTLE_CLUSTER_RESOURCE_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                LittleClusterResources[LITTLE_CLUSTER_RESOURCE_COUNT];
 
   // 'LITTLE' core private resources
-  CM_ARM_OBJ_REF                        LittleCoreResources[LITTLE_CORE_RESOURCE_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                LittleCoreResources[LITTLE_CORE_RESOURCE_COUNT];
 
   // Low Power Idle state information (LPI) for all cores/clusters
   CM_ARM_LPI_INFO                       LpiInfo[LPI_STATE_COUNT];
 
   // Clusters Low Power Idle state references (LPI)
-  CM_ARM_OBJ_REF                        ClustersLpiRef[CLUSTERS_LPI_STATE_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                ClustersLpiRef[CLUSTERS_LPI_STATE_COUNT];
 
   // Cores Low Power Idle state references (LPI)
-  CM_ARM_OBJ_REF                        CoresLpiRef[CORES_LPI_STATE_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                CoresLpiRef[CORES_LPI_STATE_COUNT];
 
   // Power domains
   CM_ARM_PSD_INFO                       PsdInfo[PSD_DOMAIN_COUNT];

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -262,7 +262,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARCH_COMMON_OBJ_REF                PciAddressMapRef[PCI_ADDRESS_MAP_COUNT];
 
   // PCI address-range mapping information
-  CM_ARM_PCI_ADDRESS_MAP_INFO           PciAddressMapInfo[PCI_ADDRESS_MAP_COUNT];
+  CM_ARCH_COMMON_PCI_ADDRESS_MAP_INFO   PciAddressMapInfo[PCI_ADDRESS_MAP_COUNT];
 
   // PCI device legacy interrupts mapping references
   CM_ARCH_COMMON_OBJ_REF                PciInterruptMapRef[PCI_INTERRUPT_MAP_COUNT];

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -256,7 +256,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARCH_COMMON_SERIAL_PORT_INFO       DbgSerialPort;
 
   /// PCI configuration space information
-  CM_ARM_PCI_CONFIG_SPACE_INFO          PciConfigInfo;
+  CM_ARCH_COMMON_PCI_CONFIG_SPACE_INFO  PciConfigInfo;
 
   // PCI address-range mapping references
   CM_ARCH_COMMON_OBJ_REF                PciAddressMapRef[PCI_ADDRESS_MAP_COUNT];

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -227,7 +227,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARM_BOOT_ARCH_INFO                 BootArchInfo;
 
   /// Power management profile information
-  CM_ARM_POWER_MANAGEMENT_PROFILE_INFO  PmProfileInfo;
+  CM_ARCH_COMMON_POWER_MANAGEMENT_PROFILE_INFO  PmProfileInfo;
 
   /// GIC CPU interface information
   CM_ARM_GICC_INFO                      GicCInfo[PLAT_CPU_COUNT];

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -268,7 +268,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARCH_COMMON_OBJ_REF                PciInterruptMapRef[PCI_INTERRUPT_MAP_COUNT];
 
   // PCI device legacy interrupts mapping information
-  CM_ARM_PCI_INTERRUPT_MAP_INFO         PciInterruptMapInfo[PCI_INTERRUPT_MAP_COUNT];
+  CM_ARCH_COMMON_PCI_INTERRUPT_MAP_INFO PciInterruptMapInfo[PCI_INTERRUPT_MAP_COUNT];
 
   /// GIC MSI Frame information
   CM_ARM_GIC_MSI_FRAME_INFO             GicMsiFrameInfo;

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -308,7 +308,7 @@ typedef struct PlatformRepositoryInfo {
   //
 
   // Cpc info (1 for each PSD domain)
-  CM_ARM_CPC_INFO                       CpcInfo[PSD_DOMAIN_COUNT];
+  CM_ARCH_COMMON_CPC_INFO               CpcInfo[PSD_DOMAIN_COUNT];
 
   /// Juno Board Revision
   UINT32                                JunoRevision;

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -801,7 +801,17 @@ GetArchCommonNameSpaceObject (
   CommonPlatRepo = This->PlatRepoInfo->CommonPlatRepoInfo;
 
   switch (GET_CM_OBJECT_ID (CmObjectId)) {
-    default: {
+      case EArchCommonObjPowerManagementProfileInfo:
+        Status = HandleCmObject (
+                   CmObjectId,
+                   &CommonPlatRepo->PmProfileInfo,
+                   sizeof (CommonPlatRepo->PmProfileInfo),
+                   1,
+                   CmObject
+                   );
+      break;
+
+      default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
         DEBUG_INFO,
@@ -875,15 +885,6 @@ GetArmNameSpaceObject (
                    );
       break;
 #endif
-      case EArmObjPowerManagementProfileInfo:
-        Status = HandleCmObject (
-                   CmObjectId,
-                   &CommonPlatRepo->PmProfileInfo,
-                   sizeof (CommonPlatRepo->PmProfileInfo),
-                   1,
-                   CmObject
-                   );
-      break;
 
       case EArmObjGenericTimerInfo:
         Status = HandleCmObject (

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -831,6 +831,18 @@ GetArchCommonNameSpaceObject (
                    );
       break;
 
+#ifdef HEADLESS_PLATFORM
+      case EArchCommonObjFixedFeatureFlags:
+        Status = HandleCmObject (
+                   CmObjectId,
+                   &CommonPlatRepo->FixedFeatureFlags,
+                   sizeof (CommonPlatRepo->FixedFeatureFlags),
+                   1,
+                   CmObject
+                   );
+      break;
+#endif
+
       default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -893,18 +905,6 @@ GetArmNameSpaceObject (
                    CmObject
                    );
       break;
-
-#ifdef HEADLESS_PLATFORM
-      case EArmObjFixedFeatureFlags:
-        Status = HandleCmObject (
-                   CmObjectId,
-                   &CommonPlatRepo->FixedFeatureFlags,
-                   sizeof (CommonPlatRepo->FixedFeatureFlags),
-                   1,
-                   CmObject
-                   );
-      break;
-#endif
 
       case EArmObjGenericTimerInfo:
         Status = HandleCmObject (

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -811,6 +811,26 @@ GetArchCommonNameSpaceObject (
                    );
       break;
 
+      case EArchCommonObjConsolePortInfo:
+        Status = HandleCmObject (
+                   CmObjectId,
+                   &CommonPlatRepo->SpcrSerialPort,
+                   sizeof (CommonPlatRepo->SpcrSerialPort),
+                   1,
+                   CmObject
+                   );
+      break;
+
+      case EArchCommonObjSerialDebugPortInfo:
+        Status = HandleCmObject (
+                   CmObjectId,
+                   &CommonPlatRepo->DbgSerialPort,
+                   sizeof (CommonPlatRepo->DbgSerialPort),
+                   1,
+                   CmObject
+                   );
+      break;
+
       default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -957,26 +977,6 @@ GetArmNameSpaceObject (
                    CmObjectId,
                    &CommonPlatRepo->GicRedistInfo,
                    sizeof (CommonPlatRepo->GicRedistInfo),
-                   1,
-                   CmObject
-                   );
-      break;
-
-      case EArmObjSerialConsolePortInfo:
-        Status = HandleCmObject (
-                   CmObjectId,
-                   &CommonPlatRepo->SpcrSerialPort,
-                   sizeof (CommonPlatRepo->SpcrSerialPort),
-                   1,
-                   CmObject
-                   );
-      break;
-
-      case EArmObjSerialDebugPortInfo:
-        Status = HandleCmObject (
-                   CmObjectId,
-                   &CommonPlatRepo->DbgSerialPort,
-                   sizeof (CommonPlatRepo->DbgSerialPort),
                    1,
                    CmObject
                    );

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1,7 +1,7 @@
 /** @file
   Configuration Manager Dxe
 
-  Copyright (c) 2021, ARM Limited. All rights reserved.<BR>
+  Copyright (c) 2021 - 2024, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -764,6 +764,58 @@ GetStandardNameSpaceObject (
   return Status;
 }
 
+/** Return an Arch Common namespace object.
+
+  @param [in]      This        Pointer to the Configuration Manager Protocol.
+  @param [in]      CmObjectId  The Configuration Manager Object ID.
+  @param [in]      Token       An optional token identifying the object. If
+                               unused this must be CM_NULL_TOKEN.
+  @param [in, out] CmObject    Pointer to the Configuration Manager Object
+                               descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+**/
+EFI_STATUS
+EFIAPI
+GetArchCommonNameSpaceObject (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  )
+{
+  EFI_STATUS                             Status;
+  EDKII_PLATFORM_REPOSITORY_INFO         *PlatformRepo;
+  EDKII_COMMON_PLATFORM_REPOSITORY_INFO  *CommonPlatRepo;
+
+  if ((This == NULL) || (CmObject == NULL)) {
+    ASSERT (This != NULL);
+    ASSERT (CmObject != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = EFI_NOT_FOUND;
+  PlatformRepo = This->PlatRepoInfo;
+  CommonPlatRepo = This->PlatRepoInfo->CommonPlatRepoInfo;
+
+  switch (GET_CM_OBJECT_ID (CmObjectId)) {
+    default: {
+      Status = EFI_NOT_FOUND;
+      DEBUG ((
+        DEBUG_INFO,
+        "INFO: Object 0x%x. Status = %r\n",
+        CmObjectId,
+        Status
+        ));
+      break;
+    }
+  } //switch
+
+  return Status;
+}
+
 /** Return an ARM namespace object.
 
   @param [in]      This        Pointer to the Configuration Manager Protocol.
@@ -1056,6 +1108,9 @@ MorelloPlatformGetObject (
   switch (GET_CM_NAMESPACE_ID (CmObjectId)) {
     case EObjNameSpaceStandard:
       Status = GetStandardNameSpaceObject (This, CmObjectId, Token, CmObject);
+      break;
+    case EObjNameSpaceArchCommon:
+      Status = GetArchCommonNameSpaceObject (This, CmObjectId, Token, CmObject);
       break;
     case EObjNameSpaceArm:
       Status = GetArmNameSpaceObject (This, CmObjectId, Token, CmObject);

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -853,6 +853,16 @@ GetArchCommonNameSpaceObject (
                    );
       break;
 
+      case EArchCommonObjProcHierarchyInfo:
+        Status = HandleCmObject (
+                   CmObjectId,
+                   CommonPlatRepo->ProcHierarchyInfo,
+                   sizeof (CommonPlatRepo->ProcHierarchyInfo),
+                   PLAT_PROC_HIERARCHY_NODE_COUNT,
+                   CmObject
+                   );
+      break;
+
       default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -988,16 +998,6 @@ GetArmNameSpaceObject (
                    &CommonPlatRepo->GicRedistInfo,
                    sizeof (CommonPlatRepo->GicRedistInfo),
                    1,
-                   CmObject
-                   );
-      break;
-
-      case EArmObjProcHierarchyInfo:
-        Status = HandleCmObject (
-                   CmObjectId,
-                   CommonPlatRepo->ProcHierarchyInfo,
-                   sizeof (CommonPlatRepo->ProcHierarchyInfo),
-                   PLAT_PROC_HIERARCHY_NODE_COUNT,
                    CmObject
                    );
       break;

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -650,7 +650,7 @@ GetGicCInfo (
   @param [in]      This           Pointer to the Configuration Manager Protocol.
   @param [in]      CmObjectId     The Object ID of the CM object requested
   @param [in]      SearchToken    A unique token for identifying the requested
-                                  CM_ARM_OBJ_REF list.
+                                  CM_ARCH_COMMON_OBJ_REF list.
   @param [in, out] CmObject       Pointer to the Configuration Manager Object
                                   descriptor describing the requested Object.
 
@@ -843,6 +843,16 @@ GetArchCommonNameSpaceObject (
       break;
 #endif
 
+      case EArchCommonObjCmRef:
+        Status = HandleCmObjectSearchPlatformRepo (
+                   This,
+                   CmObjectId,
+                   Token,
+                   GetCmObjRefs,
+                   CmObject
+                   );
+      break;
+
       default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -998,16 +1008,6 @@ GetArmNameSpaceObject (
                    CommonPlatRepo->CacheInfo,
                    sizeof (CommonPlatRepo->CacheInfo),
                    ARRAY_SIZE (CommonPlatRepo->CacheInfo),
-                   CmObject
-                   );
-      break;
-
-      case EArmObjCmRef:
-        Status = HandleCmObjectSearchPlatformRepo (
-                   This,
-                   CmObjectId,
-                   Token,
-                   GetCmObjRefs,
                    CmObject
                    );
       break;

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -800,7 +800,12 @@ GetArchCommonNameSpaceObject (
   PlatformRepo = This->PlatRepoInfo;
   CommonPlatRepo = This->PlatRepoInfo->CommonPlatRepoInfo;
 
-  switch (GET_CM_OBJECT_ID (CmObjectId)) {
+  // Search for the FVP platform specific Arch Common namespace objects
+  Status = GetArchCommonNameSpaceObjectPlat (This, CmObjectId, Token, CmObject);
+
+  // Get the object if not found in the platform specific search
+  if (Status == EFI_NOT_FOUND) {
+    switch (GET_CM_OBJECT_ID (CmObjectId)) {
       case EArchCommonObjPowerManagementProfileInfo:
         Status = HandleCmObject (
                    CmObjectId,
@@ -809,7 +814,7 @@ GetArchCommonNameSpaceObject (
                    1,
                    CmObject
                    );
-      break;
+        break;
 
       case EArchCommonObjConsolePortInfo:
         Status = HandleCmObject (
@@ -819,7 +824,7 @@ GetArchCommonNameSpaceObject (
                    1,
                    CmObject
                    );
-      break;
+        break;
 
       case EArchCommonObjSerialDebugPortInfo:
         Status = HandleCmObject (
@@ -829,9 +834,9 @@ GetArchCommonNameSpaceObject (
                    1,
                    CmObject
                    );
-      break;
+        break;
 
-#ifdef HEADLESS_PLATFORM
+ #ifdef HEADLESS_PLATFORM
       case EArchCommonObjFixedFeatureFlags:
         Status = HandleCmObject (
                    CmObjectId,
@@ -840,8 +845,8 @@ GetArchCommonNameSpaceObject (
                    1,
                    CmObject
                    );
-      break;
-#endif
+        break;
+ #endif
 
       case EArchCommonObjCmRef:
         Status = HandleCmObjectSearchPlatformRepo (
@@ -851,7 +856,7 @@ GetArchCommonNameSpaceObject (
                    GetCmObjRefs,
                    CmObject
                    );
-      break;
+        break;
 
       case EArchCommonObjProcHierarchyInfo:
         Status = HandleCmObject (
@@ -861,7 +866,7 @@ GetArchCommonNameSpaceObject (
                    PLAT_PROC_HIERARCHY_NODE_COUNT,
                    CmObject
                    );
-      break;
+        break;
 
       case EArchCommonObjCacheInfo:
         Status = HandleCmObject (
@@ -871,19 +876,21 @@ GetArchCommonNameSpaceObject (
                    ARRAY_SIZE (CommonPlatRepo->CacheInfo),
                    CmObject
                    );
-      break;
+        break;
 
-      default: {
-      Status = EFI_NOT_FOUND;
-      DEBUG ((
-        DEBUG_INFO,
-        "INFO: Object 0x%x. Status = %r\n",
-        CmObjectId,
-        Status
-        ));
-      break;
-    }
-  } //switch
+      default:
+      {
+        Status = EFI_NOT_FOUND;
+        DEBUG ((
+          DEBUG_INFO,
+          "INFO: Object 0x%x. Status = %r\n",
+          CmObjectId,
+          Status
+          ));
+        break;
+      }
+    } // switch
+  } // if
 
   return Status;
 }

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -863,6 +863,16 @@ GetArchCommonNameSpaceObject (
                    );
       break;
 
+      case EArchCommonObjCacheInfo:
+        Status = HandleCmObject (
+                   CmObjectId,
+                   CommonPlatRepo->CacheInfo,
+                   sizeof (CommonPlatRepo->CacheInfo),
+                   ARRAY_SIZE (CommonPlatRepo->CacheInfo),
+                   CmObject
+                   );
+      break;
+
       default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -998,16 +1008,6 @@ GetArmNameSpaceObject (
                    &CommonPlatRepo->GicRedistInfo,
                    sizeof (CommonPlatRepo->GicRedistInfo),
                    1,
-                   CmObject
-                   );
-      break;
-
-      case EArmObjCacheInfo:
-        Status = HandleCmObject (
-                   CmObjectId,
-                   CommonPlatRepo->CacheInfo,
-                   sizeof (CommonPlatRepo->CacheInfo),
-                   ARRAY_SIZE (CommonPlatRepo->CacheInfo),
                    CmObject
                    );
       break;

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -172,7 +172,7 @@ EDKII_COMMON_PLATFORM_REPOSITORY_INFO CommonPlatformInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       CM_NULL_TOKEN,
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       CM_NULL_TOKEN,
       // UINT32  NoOfPrivateResources
       SOC_RESOURCE_COUNT,
@@ -194,7 +194,7 @@ EDKII_COMMON_PLATFORM_REPOSITORY_INFO CommonPlatformInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[0]), // -> Package
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       CM_NULL_TOKEN,
       // UINT32  NoOfPrivateResources
       CLUSTER_RESOURCE_COUNT,
@@ -215,7 +215,7 @@ EDKII_COMMON_PLATFORM_REPOSITORY_INFO CommonPlatformInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[0]), // -> Package
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       CM_NULL_TOKEN,
       // UINT32  NoOfPrivateResources
       CLUSTER_RESOURCE_COUNT,
@@ -236,7 +236,7 @@ EDKII_COMMON_PLATFORM_REPOSITORY_INFO CommonPlatformInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[1]), // -> 'cluster in Cluster0
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[0]),
       // UINT32  NoOfPrivateResources
       CORE_RESOURCE_COUNT,
@@ -257,7 +257,7 @@ EDKII_COMMON_PLATFORM_REPOSITORY_INFO CommonPlatformInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[1]), // -> 'cluster in Cluster0
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[1]),
       // UINT32  NoOfPrivateResources
       CORE_RESOURCE_COUNT,
@@ -278,7 +278,7 @@ EDKII_COMMON_PLATFORM_REPOSITORY_INFO CommonPlatformInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[2]), // -> 'cluster in Cluster1
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[2]),
       // UINT32  NoOfPrivateResources
       CORE_RESOURCE_COUNT,
@@ -300,7 +300,7 @@ EDKII_COMMON_PLATFORM_REPOSITORY_INFO CommonPlatformInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[2]), // -> 'cluster in Cluster1
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[3]),
       // UINT32  NoOfPrivateResources
       CORE_RESOURCE_COUNT,

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -225,7 +225,7 @@ typedef struct CommonPlatformRepositoryInfo {
 
 #ifdef HEADLESS_PLATFORM
   /// Fixed feature flag information
-  CM_ARM_FIXED_FEATURE_FLAGS            FixedFeatureFlags;
+  CM_ARCH_COMMON_FIXED_FEATURE_FLAGS    FixedFeatureFlags;
 #endif
 
   /// Power management profile information

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -267,13 +267,13 @@ typedef struct CommonPlatformRepositoryInfo {
   CM_ARM_CACHE_INFO                     CacheInfo[PLAT_CACHE_COUNT];
 
   // Cluster private resources
-  CM_ARM_OBJ_REF                        ClusterResources[CLUSTER_RESOURCE_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                ClusterResources[CLUSTER_RESOURCE_COUNT];
 
   // Core private resources
-  CM_ARM_OBJ_REF                        CoreResources[CORE_RESOURCE_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                CoreResources[CORE_RESOURCE_COUNT];
 
   // SoC Resources
-  CM_ARM_OBJ_REF                        SocResources[SOC_RESOURCE_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                SocResources[SOC_RESOURCE_COUNT];
 
 } EDKII_COMMON_PLATFORM_REPOSITORY_INFO;
 

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -261,7 +261,7 @@ typedef struct CommonPlatformRepositoryInfo {
   CM_ARCH_COMMON_SERIAL_PORT_INFO       DbgSerialPort;
 
   // Processor topology information
-  CM_ARM_PROC_HIERARCHY_INFO            ProcHierarchyInfo[PLAT_PROC_HIERARCHY_NODE_COUNT];
+  CM_ARCH_COMMON_PROC_HIERARCHY_INFO    ProcHierarchyInfo[PLAT_PROC_HIERARCHY_NODE_COUNT];
 
   // Cache information
   CM_ARM_CACHE_INFO                     CacheInfo[PLAT_CACHE_COUNT];

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -264,7 +264,7 @@ typedef struct CommonPlatformRepositoryInfo {
   CM_ARCH_COMMON_PROC_HIERARCHY_INFO    ProcHierarchyInfo[PLAT_PROC_HIERARCHY_NODE_COUNT];
 
   // Cache information
-  CM_ARM_CACHE_INFO                     CacheInfo[PLAT_CACHE_COUNT];
+  CM_ARCH_COMMON_CACHE_INFO             CacheInfo[PLAT_CACHE_COUNT];
 
   // Cluster private resources
   CM_ARCH_COMMON_OBJ_REF                ClusterResources[CLUSTER_RESOURCE_COUNT];

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2021, ARM Limited. All rights reserved.<BR>
+  Copyright (c) 2021 - 2024, ARM Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -229,7 +229,7 @@ typedef struct CommonPlatformRepositoryInfo {
 #endif
 
   /// Power management profile information
-  CM_ARM_POWER_MANAGEMENT_PROFILE_INFO  PmProfileInfo;
+  CM_ARCH_COMMON_POWER_MANAGEMENT_PROFILE_INFO  PmProfileInfo;
 
   /// GIC CPU interface information
   CM_ARM_GICC_INFO                      GicCInfo[PLAT_CPU_COUNT];

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -255,10 +255,10 @@ typedef struct CommonPlatformRepositoryInfo {
   /** Serial port information for the
       serial port console redirection port
   */
-  CM_ARM_SERIAL_PORT_INFO               SpcrSerialPort;
+  CM_ARCH_COMMON_SERIAL_PORT_INFO       SpcrSerialPort;
 
   /// Serial port information for the DBG2 UART port
-  CM_ARM_SERIAL_PORT_INFO               DbgSerialPort;
+  CM_ARCH_COMMON_SERIAL_PORT_INFO       DbgSerialPort;
 
   // Processor topology information
   CM_ARM_PROC_HIERARCHY_INFO            ProcHierarchyInfo[PLAT_PROC_HIERARCHY_NODE_COUNT];

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerFvp.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerFvp.c
@@ -1,7 +1,7 @@
 /** @file
   Configuration Manager Dxe
 
-  Copyright (c) 2021, ARM Limited. All rights reserved.<BR>
+  Copyright (c) 2021 - 2024, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -425,6 +425,48 @@ GetItsGroupInfo (
   }
 
   return EFI_NOT_FOUND;
+}
+
+/** Return platform specific arch common namespace object.
+
+  @param [in]      This        Pointer to the Configuration Manager Protocol.
+  @param [in]      CmObjectId  The Configuration Manager Object ID.
+  @param [in]      Token       An optional token identifying the object. If
+                               unused this must be CM_NULL_TOKEN.
+  @param [in, out] CmObject    Pointer to the Configuration Manager Object
+                               descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+**/
+EFI_STATUS
+EFIAPI
+GetArchCommonNameSpaceObjectPlat (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  )
+{
+  EFI_STATUS                            Status;
+  EDKII_FVP_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
+
+  if ((This == NULL) || (CmObject == NULL)) {
+    ASSERT (This != NULL);
+    ASSERT (CmObject != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = EFI_NOT_FOUND;
+  PlatformRepo = This->PlatRepoInfo->FvpPlatRepoInfo;
+
+  switch (GET_CM_OBJECT_ID (CmObjectId)) {
+      default:
+        break;
+  }
+
+  return Status;
 }
 
 /** Return platform specific ARM namespace object.

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerFvp.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerFvp.c
@@ -462,6 +462,16 @@ GetArchCommonNameSpaceObjectPlat (
   PlatformRepo = This->PlatRepoInfo->FvpPlatRepoInfo;
 
   switch (GET_CM_OBJECT_ID (CmObjectId)) {
+    case EArchCommonObjPciConfigSpaceInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 PlatformRepo->PciConfigInfo,
+                 sizeof (PlatformRepo->PciConfigInfo),
+                 1,
+                 CmObject
+                 );
+      break;
+
       default:
         break;
   }
@@ -568,16 +578,6 @@ GetArmNameSpaceObjectPlat (
                  ARRAY_SIZE (PlatformRepo->DeviceIdMapping),
                  Token,
                  GetDeviceIdMappingArray,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjPciConfigSpaceInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 PlatformRepo->PciConfigInfo,
-                 sizeof (PlatformRepo->PciConfigInfo),
-                 1,
                  CmObject
                  );
       break;

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerFvp.h
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerFvp.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2021, ARM Limited. All rights reserved.<BR>
+  Copyright (c) 2021 - 2024, ARM Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -74,6 +74,28 @@ typedef struct PlatformRepositoryInfo {
 } EDKII_PLATFORM_REPOSITORY_INFO;
 
 extern EDKII_COMMON_PLATFORM_REPOSITORY_INFO CommonPlatformInfo;
+
+/** Return platform specific arch common namespace object.
+
+  @param [in]      This        Pointer to the Configuration Manager Protocol.
+  @param [in]      CmObjectId  The Configuration Manager Object ID.
+  @param [in]      Token       An optional token identifying the object. If
+                               unused this must be CM_NULL_TOKEN.
+  @param [in, out] CmObject    Pointer to the Configuration Manager Object
+                               descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+**/
+EFI_STATUS
+EFIAPI
+GetArchCommonNameSpaceObjectPlat (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
+  );
 
 /** Return platform specific ARM namespace object.
 

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerFvp.h
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerFvp.h
@@ -56,7 +56,7 @@ typedef struct FvpPlatformRepositoryInfo {
   CM_ARM_ID_MAPPING                     DeviceIdMapping[2][2];
 
   /// PCI configuration space information
-  CM_ARM_PCI_CONFIG_SPACE_INFO          PciConfigInfo[1];
+  CM_ARCH_COMMON_PCI_CONFIG_SPACE_INFO  PciConfigInfo[1];
 
 } EDKII_FVP_PLATFORM_REPOSITORY_INFO;
 

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -341,7 +341,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       CM_NULL_TOKEN,
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       CM_NULL_TOKEN,
       // UINT32  NoOfPrivateResources
       SOC_RESOURCE_COUNT,
@@ -362,7 +362,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[0]), // -> Package
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       CM_NULL_TOKEN,
       // UINT32  NoOfPrivateResources
       CLUSTER_RESOURCE_COUNT,
@@ -383,7 +383,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[0]), // -> Package
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       CM_NULL_TOKEN,
       // UINT32  NoOfPrivateResources
       CLUSTER_RESOURCE_COUNT,
@@ -404,7 +404,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[1]), // -> 'cluster in Cluster0
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[0]),
       // UINT32  NoOfPrivateResources
       CORE_RESOURCE_COUNT,
@@ -425,7 +425,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[1]), // -> 'cluster in Cluster0
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[1]),
       // UINT32  NoOfPrivateResources
       CORE_RESOURCE_COUNT,
@@ -446,7 +446,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[2]), // -> 'cluster in Cluster1
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[2]),
       // UINT32  NoOfPrivateResources
       CORE_RESOURCE_COUNT,
@@ -467,7 +467,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[2]), // -> 'cluster in Cluster1
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[3]),
       // UINT32  NoOfPrivateResources
       CORE_RESOURCE_COUNT,
@@ -489,7 +489,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       CM_NULL_TOKEN,
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       CM_NULL_TOKEN,
       // UINT32  NoOfPrivateResources
       SOC_RESOURCE_COUNT,
@@ -510,7 +510,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[7]), // -> Package
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       CM_NULL_TOKEN,
       // UINT32  NoOfPrivateResources
       CLUSTER_RESOURCE_COUNT,
@@ -531,7 +531,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[7]), // -> Package
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       CM_NULL_TOKEN,
       // UINT32  NoOfPrivateResources
       CLUSTER_RESOURCE_COUNT,
@@ -552,7 +552,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[8]), // -> 'cluster in Cluster0
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[4]),
       // UINT32  NoOfPrivateResources
       CORE_RESOURCE_COUNT,
@@ -573,7 +573,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[8]), // -> 'cluster in Cluster0
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[5]),
       // UINT32  NoOfPrivateResources
       CORE_RESOURCE_COUNT,
@@ -594,7 +594,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[9]), // -> 'cluster in Cluster1
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[6]),
       // UINT32  NoOfPrivateResources
       CORE_RESOURCE_COUNT,
@@ -615,7 +615,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[9]), // -> 'cluster in Cluster1
-      // CM_OBJECT_TOKEN  GicCToken
+      // CM_OBJECT_TOKEN  AcpiIdObjectToken
       REFERENCE_TOKEN (GicCInfo[7]),
       // UINT32  NoOfPrivateResources
       CORE_RESOURCE_COUNT,

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1743,6 +1743,16 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjFixedFeatureFlags:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->FixedFeatureFlags,
+                 sizeof (PlatformRepo->FixedFeatureFlags),
+                 1,
+                 CmObject
+                 );
+      break;
+
       default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1833,16 +1843,6 @@ GetArmNameSpaceObject (
                  CmObjectId,
                  &PlatformRepo->BootArchInfo,
                  sizeof (PlatformRepo->BootArchInfo),
-                 1,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjFixedFeatureFlags:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 &PlatformRepo->FixedFeatureFlags,
-                 sizeof (PlatformRepo->FixedFeatureFlags),
                  1,
                  CmObject
                  );

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1557,7 +1557,7 @@ GetGicCInfo (
   @param [in]        This        Pointer to the Configuration Manager Protocol.
   @param [in]        CmObjectId  The Object ID of the CM object requested
   @param [in]        SearchToken A unique token for identifying the requested
-                                 CM_ARM_OBJ_REF list.
+                                 CM_ARCH_COMMON_OBJ_REF list.
   @param [in, out]   CmObject    Pointer to the Configuration Manager Object
                                  descriptor describing the requested Object.
 
@@ -1749,6 +1749,16 @@ GetArchCommonNameSpaceObject (
                  &PlatformRepo->FixedFeatureFlags,
                  sizeof (PlatformRepo->FixedFeatureFlags),
                  1,
+                 CmObject
+                 );
+      break;
+
+    case EArchCommonObjCmRef:
+      Status = HandleCmObjectSearchPlatformRepo (
+                 This,
+                 CmObjectId,
+                 Token,
+                 GetCmObjRefs,
                  CmObject
                  );
       break;
@@ -2009,16 +2019,6 @@ GetArmNameSpaceObject (
                  PlatformRepo->CacheInfo,
                  sizeof (PlatformRepo->CacheInfo),
                  ARRAY_SIZE (PlatformRepo->CacheInfo),
-                 CmObject
-                 );
-      break;
-
-    case EArmObjCmRef:
-      Status = HandleCmObjectSearchPlatformRepo (
-                 This,
-                 CmObjectId,
-                 Token,
-                 GetCmObjRefs,
                  CmObject
                  );
       break;

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1723,6 +1723,26 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjConsolePortInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->SpcrSerialPort,
+                 sizeof (PlatformRepo->SpcrSerialPort),
+                 1,
+                 CmObject
+                 );
+      break;
+
+    case  EArchCommonObjSerialDebugPortInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->DbgSerialPort,
+                 sizeof (PlatformRepo->DbgSerialPort),
+                 1,
+                 CmObject
+                 );
+      break;
+
       default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1900,26 +1920,6 @@ GetArmNameSpaceObject (
                  PlatformRepo->GicRedistInfo,
                  sizeof (PlatformRepo->GicRedistInfo),
                  GicRedistCount,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjSerialConsolePortInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 &PlatformRepo->SpcrSerialPort,
-                 sizeof (PlatformRepo->SpcrSerialPort),
-                 1,
-                 CmObject
-                 );
-      break;
-
-    case  EArmObjSerialDebugPortInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 &PlatformRepo->DbgSerialPort,
-                 sizeof (PlatformRepo->DbgSerialPort),
-                 1,
                  CmObject
                  );
       break;

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1,7 +1,7 @@
 /** @file
   Configuration Manager Dxe
 
-  Copyright (c) 2021 - 2024, ARM Limited. All rights reserved.<BR>
+  Copyright (c) 2021, ARM Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -1678,6 +1678,56 @@ GetStandardNameSpaceObject (
   return Status;
 }
 
+/** Return an Arch Common namespace object.
+
+  @param [in]      This        Pointer to the Configuration Manager Protocol.
+  @param [in]      CmObjectId  The Configuration Manager Object ID.
+  @param [in]      Token       An optional token identifying the object. If
+                               unused this must be CM_NULL_TOKEN.
+  @param [in, out] CmObject    Pointer to the Configuration Manager Object
+                               descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+**/
+EFI_STATUS
+EFIAPI
+GetArchCommonNameSpaceObject (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  )
+{
+  EFI_STATUS                        Status;
+  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
+
+  if ((This == NULL) || (CmObject == NULL)) {
+    ASSERT (This != NULL);
+    ASSERT (CmObject != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = EFI_NOT_FOUND;
+  PlatformRepo = This->PlatRepoInfo;
+
+  switch (GET_CM_OBJECT_ID (CmObjectId)) {
+    default: {
+      Status = EFI_NOT_FOUND;
+      DEBUG ((
+        DEBUG_INFO,
+        "INFO: Object 0x%x. Status = %r\n",
+        CmObjectId,
+        Status
+        ));
+      break;
+    }
+  } //switch
+
+  return Status;
+}
+
 /** Return an ARM namespace object.
 
   @param [in]        This        Pointer to the Configuration Manager Protocol.
@@ -2090,6 +2140,9 @@ N1sdpPlatformGetObject (
   switch (GET_CM_NAMESPACE_ID (CmObjectId)) {
     case EObjNameSpaceStandard:
       Status = GetStandardNameSpaceObject (This, CmObjectId, Token, CmObject);
+      break;
+    case EObjNameSpaceArchCommon:
+      Status = GetArchCommonNameSpaceObject (This, CmObjectId, Token, CmObject);
       break;
     case EObjNameSpaceArm:
       Status = GetArmNameSpaceObject (This, CmObjectId, Token, CmObject);

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1703,6 +1703,7 @@ GetArchCommonNameSpaceObject (
   EFI_STATUS                        Status;
   EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
   UINT32                            PciConfigInfoCount;
+  UINT32                            ProcHierarchyInfoCount;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1715,8 +1716,10 @@ GetArchCommonNameSpaceObject (
 
   if (PlatformRepo->PlatInfo->MultichipMode == 1) {
     PciConfigInfoCount = Root_pcie_max;
+    ProcHierarchyInfoCount = PLAT_PROC_HIERARCHY_NODE_COUNT * 2;
   } else {
     PciConfigInfoCount = Root_pcie_master_chip_max;
+    ProcHierarchyInfoCount = PLAT_PROC_HIERARCHY_NODE_COUNT;
   }
 
   switch (GET_CM_OBJECT_ID (CmObjectId)) {
@@ -1780,6 +1783,16 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjProcHierarchyInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 PlatformRepo->ProcHierarchyInfo,
+                 sizeof (PlatformRepo->ProcHierarchyInfo),
+                 ProcHierarchyInfoCount,
+                 CmObject
+                 );
+      break;
+
       default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1821,7 +1834,6 @@ GetArmNameSpaceObject (
   EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
   UINT32                            GicRedistCount;
   UINT32                            GicCpuCount;
-  UINT32                            ProcHierarchyInfoCount;
   UINT32                            GicItsInfoCount;
   UINT32                            ItsGroupInfoCount;
   UINT32                            ItsIdentifierArrayCount;
@@ -1842,7 +1854,6 @@ GetArmNameSpaceObject (
   if (PlatformRepo->PlatInfo->MultichipMode == 1) {
     GicRedistCount = 2;
     GicCpuCount = PLAT_CPU_COUNT * 2;
-    ProcHierarchyInfoCount = PLAT_PROC_HIERARCHY_NODE_COUNT * 2;
     GicItsInfoCount = Its_max;
     ItsGroupInfoCount = Its_max;
     ItsIdentifierArrayCount = Its_max;
@@ -1852,7 +1863,6 @@ GetArmNameSpaceObject (
   } else {
     GicRedistCount = 1;
     GicCpuCount = PLAT_CPU_COUNT;
-    ProcHierarchyInfoCount = PLAT_PROC_HIERARCHY_NODE_COUNT;
     GicItsInfoCount = Its_master_chip_max;
     ItsGroupInfoCount = Its_master_chip_max;
     ItsIdentifierArrayCount = Its_master_chip_max;
@@ -2013,16 +2023,6 @@ GetArmNameSpaceObject (
                  DeviceIdMappingCount,
                  Token,
                  GetDeviceIdMappingArray,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjProcHierarchyInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 PlatformRepo->ProcHierarchyInfo,
-                 sizeof (PlatformRepo->ProcHierarchyInfo),
-                 ProcHierarchyInfoCount,
                  CmObject
                  );
       break;

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1702,6 +1702,7 @@ GetArchCommonNameSpaceObject (
 {
   EFI_STATUS                        Status;
   EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
+  UINT32                            PciConfigInfoCount;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1711,6 +1712,12 @@ GetArchCommonNameSpaceObject (
 
   Status = EFI_NOT_FOUND;
   PlatformRepo = This->PlatRepoInfo;
+
+  if (PlatformRepo->PlatInfo->MultichipMode == 1) {
+    PciConfigInfoCount = Root_pcie_max;
+  } else {
+    PciConfigInfoCount = Root_pcie_master_chip_max;
+  }
 
   switch (GET_CM_OBJECT_ID (CmObjectId)) {
     case EArchCommonObjPowerManagementProfileInfo:
@@ -1763,6 +1770,16 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjPciConfigSpaceInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 PlatformRepo->PciConfigInfo,
+                 sizeof (PlatformRepo->PciConfigInfo),
+                 PciConfigInfoCount,
+                 CmObject
+                 );
+      break;
+
       default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -1811,7 +1828,6 @@ GetArmNameSpaceObject (
   UINT32                            SmmuV3InfoCount;
   UINT32                            DeviceIdMappingCount;
   UINT32                            RootComplexInfoCount;
-  UINT32                            PciConfigInfoCount;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1833,7 +1849,6 @@ GetArmNameSpaceObject (
     SmmuV3InfoCount = Smmuv3info_max;
     DeviceIdMappingCount = Devicemapping_max;
     RootComplexInfoCount = Root_pcie_max;
-    PciConfigInfoCount = Root_pcie_max;
   } else {
     GicRedistCount = 1;
     GicCpuCount = PLAT_CPU_COUNT;
@@ -1844,7 +1859,6 @@ GetArmNameSpaceObject (
     SmmuV3InfoCount = Smmuv3info_master_chip_max;
     DeviceIdMappingCount = Devicemapping_master_chip_max;
     RootComplexInfoCount = Root_pcie_master_chip_max;
-    PciConfigInfoCount = Root_pcie_master_chip_max;
   }
 
   switch (GET_CM_OBJECT_ID (CmObjectId)) {
@@ -2019,16 +2033,6 @@ GetArmNameSpaceObject (
                  PlatformRepo->CacheInfo,
                  sizeof (PlatformRepo->CacheInfo),
                  ARRAY_SIZE (PlatformRepo->CacheInfo),
-                 CmObject
-                 );
-      break;
-
-    case EArmObjPciConfigSpaceInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 PlatformRepo->PciConfigInfo,
-                 sizeof (PlatformRepo->PciConfigInfo),
-                 PciConfigInfoCount,
                  CmObject
                  );
       break;

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1793,6 +1793,16 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjCacheInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 PlatformRepo->CacheInfo,
+                 sizeof (PlatformRepo->CacheInfo),
+                 ARRAY_SIZE (PlatformRepo->CacheInfo),
+                 CmObject
+                 );
+      break;
+
       default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -2023,16 +2033,6 @@ GetArmNameSpaceObject (
                  DeviceIdMappingCount,
                  Token,
                  GetDeviceIdMappingArray,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjCacheInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 PlatformRepo->CacheInfo,
-                 sizeof (PlatformRepo->CacheInfo),
-                 ARRAY_SIZE (PlatformRepo->CacheInfo),
                  CmObject
                  );
       break;

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1713,7 +1713,17 @@ GetArchCommonNameSpaceObject (
   PlatformRepo = This->PlatRepoInfo;
 
   switch (GET_CM_OBJECT_ID (CmObjectId)) {
-    default: {
+    case EArchCommonObjPowerManagementProfileInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->PmProfileInfo,
+                 sizeof (PlatformRepo->PmProfileInfo),
+                 1,
+                 CmObject
+                 );
+      break;
+
+      default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
         DEBUG_INFO,
@@ -1813,16 +1823,6 @@ GetArmNameSpaceObject (
                  CmObjectId,
                  &PlatformRepo->FixedFeatureFlags,
                  sizeof (PlatformRepo->FixedFeatureFlags),
-                 1,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjPowerManagementProfileInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 &PlatformRepo->PmProfileInfo,
-                 sizeof (PlatformRepo->PmProfileInfo),
                  1,
                  CmObject
                  );

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1803,6 +1803,16 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjMemoryAffinityInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 PlatformRepo->MemAffInfo,
+                 sizeof (PlatformRepo->MemAffInfo),
+                 ARRAY_SIZE (PlatformRepo->MemAffInfo),
+                 CmObject
+                 );
+      break;
+
       default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -2033,16 +2043,6 @@ GetArmNameSpaceObject (
                  DeviceIdMappingCount,
                  Token,
                  GetDeviceIdMappingArray,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjMemoryAffinityInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 PlatformRepo->MemAffInfo,
-                 sizeof (PlatformRepo->MemAffInfo),
-                 ARRAY_SIZE (PlatformRepo->MemAffInfo),
                  CmObject
                  );
       break;

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -273,13 +273,13 @@ typedef struct PlatformRepositoryInfo {
   CM_ARM_CACHE_INFO                     CacheInfo[PLAT_CACHE_COUNT];
 
   // Cluster private resources
-  CM_ARM_OBJ_REF                        ClusterResources[CLUSTER_RESOURCE_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                ClusterResources[CLUSTER_RESOURCE_COUNT];
 
   // Core private resources
-  CM_ARM_OBJ_REF                        CoreResources[CORE_RESOURCE_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                CoreResources[CORE_RESOURCE_COUNT];
 
   // SoC Resources
-  CM_ARM_OBJ_REF                        SocResources[SOC_RESOURCE_COUNT];
+  CM_ARCH_COMMON_OBJ_REF                SocResources[SOC_RESOURCE_COUNT];
 
   /// ITS Group node
   CM_ARM_ITS_GROUP_NODE                 ItsGroupInfo[Its_max];

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -229,7 +229,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARM_BOOT_ARCH_INFO                 BootArchInfo;
 
   /// Fixed feature flag information
-  CM_ARM_FIXED_FEATURE_FLAGS            FixedFeatureFlags;
+  CM_ARCH_COMMON_FIXED_FEATURE_FLAGS    FixedFeatureFlags;
 
   /// Power management profile information
   CM_ARCH_COMMON_POWER_MANAGEMENT_PROFILE_INFO  PmProfileInfo;

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -270,7 +270,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARCH_COMMON_PROC_HIERARCHY_INFO    ProcHierarchyInfo[PLAT_PROC_HIERARCHY_NODE_COUNT * 2];
 
   // Cache information
-  CM_ARM_CACHE_INFO                     CacheInfo[PLAT_CACHE_COUNT];
+  CM_ARCH_COMMON_CACHE_INFO             CacheInfo[PLAT_CACHE_COUNT];
 
   // Cluster private resources
   CM_ARCH_COMMON_OBJ_REF                ClusterResources[CLUSTER_RESOURCE_COUNT];

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2021-2024, ARM Limited. All rights reserved.<BR>
+  Copyright (c) 2021, ARM Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -232,7 +232,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARM_FIXED_FEATURE_FLAGS            FixedFeatureFlags;
 
   /// Power management profile information
-  CM_ARM_POWER_MANAGEMENT_PROFILE_INFO  PmProfileInfo;
+  CM_ARCH_COMMON_POWER_MANAGEMENT_PROFILE_INFO  PmProfileInfo;
 
   /// GIC CPU interface information
   CM_ARM_GICC_INFO                      GicCInfo[PLAT_CPU_COUNT * 2];

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -300,7 +300,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARCH_COMMON_PCI_CONFIG_SPACE_INFO  PciConfigInfo[Root_pcie_max];
 
   /// Memory Affinity Info
-  CM_ARM_MEMORY_AFFINITY_INFO           MemAffInfo[DDR_REGION_COUNT];
+  CM_ARCH_COMMON_MEMORY_AFFINITY_INFO   MemAffInfo[DDR_REGION_COUNT];
 
   /// N1Sdp Platform Info
   NEOVERSEN1SOC_PLAT_INFO               *PlatInfo;

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -261,10 +261,10 @@ typedef struct PlatformRepositoryInfo {
   /** Serial port information for the
       serial port console redirection port
   */
-  CM_ARM_SERIAL_PORT_INFO               SpcrSerialPort;
+  CM_ARCH_COMMON_SERIAL_PORT_INFO       SpcrSerialPort;
 
   /// Serial port information for the DBG2 UART port
-  CM_ARM_SERIAL_PORT_INFO               DbgSerialPort;
+  CM_ARCH_COMMON_SERIAL_PORT_INFO       DbgSerialPort;
 
   // Processor topology information
   CM_ARM_PROC_HIERARCHY_INFO            ProcHierarchyInfo[PLAT_PROC_HIERARCHY_NODE_COUNT * 2];

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -267,7 +267,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARCH_COMMON_SERIAL_PORT_INFO       DbgSerialPort;
 
   // Processor topology information
-  CM_ARM_PROC_HIERARCHY_INFO            ProcHierarchyInfo[PLAT_PROC_HIERARCHY_NODE_COUNT * 2];
+  CM_ARCH_COMMON_PROC_HIERARCHY_INFO    ProcHierarchyInfo[PLAT_PROC_HIERARCHY_NODE_COUNT * 2];
 
   // Cache information
   CM_ARM_CACHE_INFO                     CacheInfo[PLAT_CACHE_COUNT];

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -297,7 +297,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARM_ID_MAPPING                     DeviceIdMapping[Devicemapping_max][2];
 
   /// PCI configuration space information
-  CM_ARM_PCI_CONFIG_SPACE_INFO          PciConfigInfo[Root_pcie_max];
+  CM_ARCH_COMMON_PCI_CONFIG_SPACE_INFO  PciConfigInfo[Root_pcie_max];
 
   /// Memory Affinity Info
   CM_ARM_MEMORY_AFFINITY_INFO           MemAffInfo[DDR_REGION_COUNT];

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -754,6 +754,7 @@ GetArchCommonNameSpaceObject (
 {
   EFI_STATUS                        Status;
   EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
+  UINTN                             PciConfigSpaceCount;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -763,6 +764,13 @@ GetArchCommonNameSpaceObject (
 
   Status = EFI_NOT_FOUND;
   PlatformRepo = This->PlatRepoInfo;
+
+  if ((PlatformRepo->SysId & ARM_FVP_SYS_ID_REV_MASK) ==
+       ARM_FVP_BASE_REVC_REV) {
+    PciConfigSpaceCount = 1;
+  } else {
+    PciConfigSpaceCount = 0;
+  }
 
   switch (GET_CM_OBJECT_ID (CmObjectId)) {
     case EArchCommonObjPowerManagementProfileInfo:
@@ -806,6 +814,16 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 #endif
+
+    case EArchCommonObjPciConfigSpaceInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->PciConfigInfo,
+                 sizeof (PlatformRepo->PciConfigInfo),
+                 PciConfigSpaceCount,
+                 CmObject
+                 );
+      break;
 
     default: {
       Status = EFI_NOT_FOUND;
@@ -851,7 +869,6 @@ GetArmNameSpaceObject (
   UINTN                             ItsIdentifierArrayCount;
   UINTN                             RootComplexCount;
   UINTN                             DeviceIdMappingArrayCount;
-  UINTN                             PciConfigSpaceCount;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -869,14 +886,12 @@ GetArmNameSpaceObject (
     ItsIdentifierArrayCount = ARRAY_SIZE (PlatformRepo->ItsIdentifierArray);
     RootComplexCount = 1;
     DeviceIdMappingArrayCount = ARRAY_SIZE (PlatformRepo->DeviceIdMapping);
-    PciConfigSpaceCount = 1;
   } else {
     Smmuv3Count = 0;
     ItsGroupCount = 0;
     ItsIdentifierArrayCount = 0;
     RootComplexCount = 0;
     DeviceIdMappingArrayCount = 0;
-    PciConfigSpaceCount = 0;
   }
 
   switch (GET_CM_OBJECT_ID (CmObjectId)) {
@@ -1025,16 +1040,6 @@ GetArmNameSpaceObject (
                  DeviceIdMappingArrayCount,
                  Token,
                  GetDeviceIdMappingArray,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjPciConfigSpaceInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 &PlatformRepo->PciConfigInfo,
-                 sizeof (PlatformRepo->PciConfigInfo),
-                 PciConfigSpaceCount,
                  CmObject
                  );
       break;

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -765,6 +765,16 @@ GetArchCommonNameSpaceObject (
   PlatformRepo = This->PlatRepoInfo;
 
   switch (GET_CM_OBJECT_ID (CmObjectId)) {
+    case EArchCommonObjPowerManagementProfileInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->PmProfileInfo,
+                 sizeof (PlatformRepo->PmProfileInfo),
+                 1,
+                 CmObject
+                 );
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -859,15 +869,6 @@ GetArmNameSpaceObject (
                  );
       break;
 #endif
-    case EArmObjPowerManagementProfileInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 &PlatformRepo->PmProfileInfo,
-                 sizeof (PlatformRepo->PmProfileInfo),
-                 1,
-                 CmObject
-                 );
-      break;
 
     case EArmObjGenericTimerInfo:
       Status = HandleCmObject (

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -775,6 +775,26 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+    case EArchCommonObjConsolePortInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->SpcrSerialPort,
+                 sizeof (PlatformRepo->SpcrSerialPort),
+                 1,
+                 CmObject
+                 );
+      break;
+
+    case EArchCommonObjSerialDebugPortInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->DbgSerialPort,
+                 sizeof (PlatformRepo->DbgSerialPort),
+                 1,
+                 CmObject
+                 );
+      break;
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -938,26 +958,6 @@ GetArmNameSpaceObject (
                  CmObjectId,
                  &PlatformRepo->GicRedistInfo,
                  sizeof (PlatformRepo->GicRedistInfo),
-                 1,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjSerialConsolePortInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 &PlatformRepo->SpcrSerialPort,
-                 sizeof (PlatformRepo->SpcrSerialPort),
-                 1,
-                 CmObject
-                 );
-      break;
-
-    case EArmObjSerialDebugPortInfo:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 &PlatformRepo->DbgSerialPort,
-                 sizeof (PlatformRepo->DbgSerialPort),
                  1,
                  CmObject
                  );

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1,7 +1,7 @@
 /** @file
   Configuration Manager Dxe
 
-  Copyright (c) 2017 - 2023, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2017 - 2024, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -730,6 +730,56 @@ GetStandardNameSpaceObject (
   return Status;
 }
 
+/** Return an Arch Common namespace object.
+
+  @param [in]      This        Pointer to the Configuration Manager Protocol.
+  @param [in]      CmObjectId  The Configuration Manager Object ID.
+  @param [in]      Token       An optional token identifying the object. If
+                               unused this must be CM_NULL_TOKEN.
+  @param [in, out] CmObject    Pointer to the Configuration Manager Object
+                               descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+**/
+EFI_STATUS
+EFIAPI
+GetArchCommonNameSpaceObject (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  )
+{
+  EFI_STATUS                        Status;
+  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
+
+  if ((This == NULL) || (CmObject == NULL)) {
+    ASSERT (This != NULL);
+    ASSERT (CmObject != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = EFI_NOT_FOUND;
+  PlatformRepo = This->PlatRepoInfo;
+
+  switch (GET_CM_OBJECT_ID (CmObjectId)) {
+    default: {
+      Status = EFI_NOT_FOUND;
+      DEBUG ((
+        DEBUG_INFO,
+        "INFO: Object 0x%x. Status = %r\n",
+        CmObjectId,
+        Status
+        ));
+      break;
+    }
+  } //switch
+
+  return Status;
+}
+
 /** Return an ARM namespace object.
 
   @param [in]      This        Pointer to the Configuration Manager Protocol.
@@ -1100,6 +1150,9 @@ ArmVExpressPlatformGetObject (
   switch (GET_CM_NAMESPACE_ID (CmObjectId)) {
     case EObjNameSpaceStandard:
       Status = GetStandardNameSpaceObject (This, CmObjectId, Token, CmObject);
+      break;
+    case EObjNameSpaceArchCommon:
+      Status = GetArchCommonNameSpaceObject (This, CmObjectId, Token, CmObject);
       break;
     case EObjNameSpaceArm:
       Status = GetArmNameSpaceObject (This, CmObjectId, Token, CmObject);

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -795,6 +795,18 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
+#ifdef HEADLESS_PLATFORM
+    case EArchCommonObjFixedFeatureFlags:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->FixedFeatureFlags,
+                 sizeof (PlatformRepo->FixedFeatureFlags),
+                 1,
+                 CmObject
+                 );
+      break;
+#endif
+
     default: {
       Status = EFI_NOT_FOUND;
       DEBUG ((
@@ -877,18 +889,6 @@ GetArmNameSpaceObject (
                  CmObject
                  );
       break;
-
-#ifdef HEADLESS_PLATFORM
-    case EArmObjFixedFeatureFlags:
-      Status = HandleCmObject (
-                 CmObjectId,
-                 &PlatformRepo->FixedFeatureFlags,
-                 sizeof (PlatformRepo->FixedFeatureFlags),
-                 1,
-                 CmObject
-                 );
-      break;
-#endif
 
     case EArmObjGenericTimerInfo:
       Status = HandleCmObject (

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -118,7 +118,7 @@ typedef struct PlatformRepositoryInfo {
 #endif
 
   /// Power management profile information
-  CM_ARM_POWER_MANAGEMENT_PROFILE_INFO  PmProfileInfo;
+  CM_ARCH_COMMON_POWER_MANAGEMENT_PROFILE_INFO  PmProfileInfo;
 
   /// GIC CPU interface information
   CM_ARM_GICC_INFO                      GicCInfo[PLAT_CPU_COUNT];

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -169,7 +169,7 @@ typedef struct PlatformRepositoryInfo {
   CM_ARM_ID_MAPPING                     DeviceIdMapping[2];
 
   /// PCI configuration space information
-  CM_ARM_PCI_CONFIG_SPACE_INFO          PciConfigInfo;
+  CM_ARCH_COMMON_PCI_CONFIG_SPACE_INFO  PciConfigInfo;
 
   CM_ARM_ET_INFO                        EtInfo;
 

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -114,7 +114,7 @@ typedef struct PlatformRepositoryInfo {
 
 #ifdef HEADLESS_PLATFORM
   /// Fixed feature flag information
-  CM_ARM_FIXED_FEATURE_FLAGS            FixedFeatureFlags;
+  CM_ARCH_COMMON_FIXED_FEATURE_FLAGS    FixedFeatureFlags;
 #endif
 
   /// Power management profile information

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -144,10 +144,10 @@ typedef struct PlatformRepositoryInfo {
   /** Serial port information for the
       serial port console redirection port
   */
-  CM_ARM_SERIAL_PORT_INFO               SpcrSerialPort;
+  CM_ARCH_COMMON_SERIAL_PORT_INFO       SpcrSerialPort;
 
   /// Serial port information for the DBG2 UART port
-  CM_ARM_SERIAL_PORT_INFO               DbgSerialPort;
+  CM_ARCH_COMMON_SERIAL_PORT_INFO       DbgSerialPort;
 
   /// GIC ITS information
   CM_ARM_GIC_ITS_INFO                   GicItsInfo;

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -1,0 +1,329 @@
+This branch holds all platforms actively maintained against the
+[edk2](https://github.com/tianocore/edk2) master branch.
+
+For generic information about the edk2-platforms repository, and the process
+under which _stable_ and _devel_ branches can be added for individual platforms,
+please see
+[the introduction on the about branch](https://github.com/tianocore/edk2-platforms/blob/about/Readme.md).
+
+The majority of the content in the EDK II open source project uses a
+[BSD-2-Clause Plus Patent License](License.txt).  Additional details on EDK II
+open source project code contributions can be found in the edk2 repository
+[Readme.md](https://github.com/tianocore/edk2/blob/master/ReadMe.rst).
+The EDK II Platforms open source project contains the following components that
+are covered by additional licenses:
+
+- [`Silicon/RISC-V/ProcessorPkg/Library/RiscVOpensbiLib/opensbi`](https://github.com/riscv/opensbi/blob/master/COPYING.BSD)
+
+# INDEX
+* [Overview](#overview)
+* [How To Build (Linux Environment)](#how-to-build-linux-environment)
+   * [Manual building](#manual-building)
+   * [Using uefi-tools helper scripts](#using-uefi-tools-helper-scripts)
+* [How To Build (Windows Environment)](#how-to-build-windows-environment)
+* [Supported Platforms](#supported-platforms)
+* [Maintainers](#maintainers)
+
+# Overview
+
+Platform description files can be found under `Platform/{Vendor}/{Platform}`.
+
+Many platforms require additional image processing beyond the EDK2 build.
+Any such steps should be documented (as a Readme.md), and any necessary helper
+scripts be contained, under said platform directory.
+
+Any contributions to this branch should be submitted via email to the
+edk2-devel mailing list with a subject prefix of `[platforms]`. See
+[Laszlo's excellent guide](https://github.com/tianocore/tianocore.github.io/wiki/Laszlo's-unkempt-git-guide-for-edk2-contributors-and-maintainers) for details
+on how to do this successfully.
+
+# How to build (Linux Environment)
+
+## Prerequisites
+The build tools themselves depend on Python (2) and libuuid. Most Linux systems
+will come with a Python environment installed by default, but you usually need
+to install uuid-dev (or uuid-devel, depending on distribution) manually.
+
+## If cross compiling
+If building EDK2 for a different archtecture than the build machine, you need to
+obtain an appropriate cross-compiler. X64 (x86_64) compilers also support IA32,
+but the reverse may not always be true.
+
+Target architecture | Cross compilation prefix
+--------------------|-------------------------
+AARCH64             | aarch64-linux-gnu-
+ARM                 | arm-linux-gnueabihf-
+IA32                | i?86-linux-gnu-* _or_ x86_64-linux-gnu-
+IPF                 | ia64-linux-gnu
+X64                 | x86_64-linux-gnu-
+RISCV64             | riscv64-unknown-elf-
+LOONGARCH64         | loongarch64-unknown-linux-
+
+\* i386, i486, i586 or i686
+
+### GCC
+Arm provides GCC toolchains for aarch64-linux-gnu and arm-linux-gnueabihf at
+[GNU Toolchain for the A-profile Architecture](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads)
+compiled to run on x86_64/i686 Linux and i686 Windows. Some Linux distributions
+provide their own packaged cross-toolchains.
+
+### GCC for RISC-V
+RISC-V open source community provides GCC toolchains for
+[riscv64-unknown-elf](https://github.com/riscv/riscv-gnu-toolchain)
+compiled to run on x86 Linux.
+
+### GCC for LoongArch
+Loonson open source community provides GCC toolchains for
+[loongarch64-unknown-elf](https://github.com/loongson/build-tools)
+compiled to run on x86 Linux
+
+### clang
+Clang does not require separate cross compilers, but it does need a
+target-specific binutils. These are included with any prepackaged GCC toolchain
+(see above), or can be installed or built separately.
+
+## Obtaining source code
+1. Create a new folder (directory) on your local development machine
+   for use as your workspace. This example uses `/work/git/tianocore`, modify as
+   appropriate for your needs.
+   ```
+   $ export WORKSPACE=/work/git/tianocore
+   $ mkdir -p $WORKSPACE
+   $ cd $WORKSPACE
+   ```
+
+1. Into that folder, clone:
+   1. [edk2](https://github.com/tianocore/edk2)
+   1. [edk2-platforms](https://github.com/tianocore/edk2-platforms)
+   1. [edk2-non-osi](https://github.com/tianocore/edk2-non-osi) (if building
+      platforms that need it)
+   ```
+   $ git clone https://github.com/tianocore/edk2.git
+   $ git submodule update --init
+   ...
+   $ git clone https://github.com/tianocore/edk2-platforms.git
+   $ git submodule update --init
+   ...
+   $ git clone https://github.com/tianocore/edk2-non-osi.git
+   ```
+
+1. Set up a **PACKAGES_PATH** to point to the locations of these three
+   repositories:
+
+   `$ export PACKAGES_PATH=$PWD/edk2:$PWD/edk2-platforms:$PWD/edk2-non-osi`
+
+## Manual building
+
+1. Set up the build environment (this will modify your environment variables)
+
+   `$ . edk2/edksetup.sh`
+
+   (This step _depends_ on **WORKSPACE** being set as per above.)
+1. Build BaseTools
+
+   `make -C edk2/BaseTools`
+
+   (BaseTools can currently not be built in parallel, so do not specify any `-j`
+   option, either on the command line or in a **MAKEFLAGS** environment
+   variable.)
+
+### Build options
+There are a number of options that can (or must) be specified at the point of
+building. Their default values are set in `edk2/Conf/target.txt`. If we are
+working only on a single platform, it makes sense to just update this file.
+
+target.txt option | command line | Description
+------------------|--------------|------------
+ACTIVE_PLATFORM   | `-p`         | Description file (.dsc) of platform.
+TARGET            | `-b`         | One of DEBUG, RELEASE or NOOPT.
+TARGET_ARCH       | `-a`         | Architecture to build for.
+TOOL_CHAIN_TAG    | `-t`         | Toolchain profile to use for building.
+
+There is also MAX_CONCURRENT_THREAD_NUMBER (`-n`), roughly equivalent to
+`make -j`.
+
+When specified on command line, `-b` can be repeated multiple times in order to
+build multiple targets sequentially.
+
+After a successful build, the resulting images can be found in
+`Build/{Platform Name}/{TARGET}_{TOOL_CHAIN_TAG}/FV`.
+
+### Build a platform
+The main build process _can_ run in parallel - so figure out how many threads we
+have available.
+
+```
+$ getconf _NPROCESSORS_ONLN
+8
+```
+OK, so we have 8 CPUs - let's tell the build to use a little more than that:
+```
+$ NUM_CPUS=$((`getconf _NPROCESSORS_ONLN` + 2))
+```
+For the toolchain tag, use GCC5 for gcc version 5 or later, GCC4x for
+earlier versions, or CLANG35/CLANG38 as appropriate when building with clang.
+```
+$ build -n $NUM_CPUS -a AARCH64 -t GCC5 -p Platform/ARM/JunoPkg/ArmJuno.dsc
+```
+(Note that the description file gets resolved by the build command through
+searching in all locations specified in **PACKAGES_PATH**.)
+
+#### If cross-compiling
+When cross-compiling, or building with a different version of the compiler than
+the default `gcc` or `clang`(/binutils), we additionally need to inform the
+build command which toolchain to use. We do this by setting the environment
+variable `{TOOL_CHAIN_TAG}_{TARGET_ARCH}_PREFIX` - in the case above,
+**GCC5_AARCH64_PREFIX**.
+
+So, referring to the cross compiler toolchain table above, we should prepend the `build` command line with `GCC5_AARCH64_PREFIX=aarch64-linux-gnu-`.
+
+## Using uefi-tools helper scripts
+uefi-tools is a completely unofficial set of helper-scripts developed by Linaro.
+They automate figuring out all of the manual options above, and store the paths
+to platform description files in a separate configuration file. Additionally,
+they simplify bulk-building large numbers of platforms.
+
+The (best effort) intent is to keep this configuration up to date with all
+platforms that exist in the edk2-platforms master branch.
+
+The equivalent of the manual example above would be
+```
+$ git clone https://git.linaro.org/uefi/uefi-tools.git
+...
+$ ./uefi-tools/edk2-build.sh juno
+...
+------------------------------------------------------------
+                         aarch64 Juno (AARCH64) RELEASE pass
+------------------------------------------------------------
+pass   1
+fail   0
+```
+The build finishes with a summary of which platforms/targets were built, which
+succeeded and which failed (and the total number of either).
+
+Like the `build` command itself, `edk2-build.sh` it supports specifying multiple
+targets on a single command line, but it also lets you specify multiple
+platforms (or `all` for building all known platforms). So in order to build all
+platforms described by the configuration file, for both DEBUG and RELEASE
+targets:
+```
+$ ./uefi-tools/edk2-build.sh -b DEBUG -b RELEASE
+```
+
+# How To Build (Windows Environment)
+
+(I genuinely have no idea. Please help!)
+
+
+# Supported Platforms
+
+These are the platforms currently supported by this tree - grouped by
+Processor/SoC vendor, rather than platform vendor.
+
+If there are any additional build steps beyond the generic ones listed above,
+they will be documented with the platform.
+
+## AMD
+* [Cello](Platform/LeMaker/CelloBoard)
+* [Overdrive](Platform/AMD/OverdriveBoard)
+* [Overdrive 1000](Platform/SoftIron/Overdrive1000Board)
+
+## [Ampere](Platform/Ampere/Readme.md)
+* [Mt. Jade](Platform/Ampere/JadePkg)
+
+## [ARM](Platform/ARM/Readme.md)
+* [Juno](Platform/ARM/JunoPkg)
+* [SGI family](Platform/ARM/SgiPkg)
+
+## BeagleBoard
+* [BeagleBoard](Platform/BeagleBoard/BeagleBoardPkg)
+
+## Hisilicon
+* [D03](Platform/Hisilicon/D03)
+* [D05](Platform/Hisilicon/D05)
+* [D06](Platform/Hisilicon/D06)
+* [HiKey](Platform/Hisilicon/HiKey)
+* [HiKey960](Platform/Hisilicon/HiKey960)
+
+## Intel
+### [Minimum Platforms](Platform/Intel/Readme.md)
+* [Kaby Lake](Platform/Intel/KabylakeOpenBoardPkg)
+* [Purley](Platform/Intel/PurleyOpenBoardPkg)
+* [Simics](Platform/Intel/SimicsOpenBoardPkg)
+* [Whiskey Lake](Platform/Intel/WhiskeylakeOpenBoardPkg)
+* [Comet Lake](Platform/Intel/CometlakeOpenBoardPkg)
+* [Tiger Lake](Platform/Intel/TigerlakeOpenBoardPkg)
+* [Whitley/Cedar Island](Platform/Intel/WhitleyOpenBoardPkg)
+* [Alder Lake](Platform/Intel/AlderlakeOpenBoardPkg)
+
+For more information, see the
+[EDK II Minimum Platform Specification](https://edk2-docs.gitbooks.io/edk-ii-minimum-platform-specification).
+### Other Platforms
+##### Intel&reg; Quark SoC X1000 based platforms
+* [Galileo](Platform/Intel/QuarkPlatformPkg)
+##### Minnowboard Max/Turbot based on Intel Valleyview2 SoC
+* [Minnowboard Max](Platform/Intel/Vlv2TbltDevicePkg)
+
+## Loongson
+* [LoongArchQemu](Platform/Loongson/LoongArchQemuPkg)
+
+## Marvell
+* [Armada 70x0](Platform/Marvell/Armada70x0Db)
+* [Armada 80x0](Platform/Marvell/Armada80x0Db)
+* [CN913x](Platform/Marvell/Cn913xDb)
+* [SolidRun Armada MacchiatoBin](Platform/SolidRun/Armada80x0McBin)
+
+## Raspberry Pi
+* [Pi 3](Platform/RaspberryPi/RPi3)
+* [Pi 4](Platform/RaspberryPi/RPi4)
+
+## RISC-V
+### SiFive
+* [Sifive U5 Series](Platform/SiFive/U5SeriesPkg) Refer to Platform/SiFive/U5Series/Readme.md on edk2-platform repository.
+* [Freedom U500 VC707 FPGA](Platform/SiFive/U5SeriesPkg/FreedomU500VC707Board)
+* [Freedom U540 HiFive Unleashed](Platform/SiFive/U5SeriesPkg/FreedomU540HiFiveUnleashedBoard)
+
+## Socionext
+* [SynQuacer](Platform/Socionext/DeveloperBox)
+
+## NXP
+* [LS1043aRdb](Platform/NXP/LS1043aRdbPkg)
+
+## Qemu
+* [SBSA](Platform/Qemu/SbsaQemu)
+
+# Maintainers
+
+See [Maintainers.txt](Maintainers.txt).
+
+# Submodules
+
+Submodule in EDK II Platforms is allowed but submodule chain should be avoided
+as possible as we can. Currently EDK II Platforms contains the following
+submodules
+
+- Silicon/RISC-V/ProcessorPkg/Library/RiscVOpensbiLib/opensbi
+
+To get a full, buildable EDK II repository, use following steps of git command
+
+```bash
+  git clone https://github.com/tianocore/edk2-platforms.git
+  cd edk2-platforms
+  git submodule update --init
+  cd ..
+```
+
+If there's update for submodules, use following git commands to get the latest
+submodules code.
+
+```bash
+  cd edk2-platforms
+  git pull
+  git submodule update
+```
+
+Note: When cloning submodule repos, '--recursive' option is not recommended.
+EDK II Platforms itself will not use any code/feature from submodules in above
+submodules. So using '--recursive' adds a dependency on being able to reach
+servers we do not actually want any code from, as well as needlessly
+downloading code we will not use.


### PR DESCRIPTION
The DynamicTablesPkg currently supports the Arm architecture only.
To ease the utilization of the framework by other architectures, some refactoring is necessary.

The edk2 repository will soon update the organization of the DynamicTablesPkg Configuration Manager structures.
Match this change in the edk2-platforms repository.

The NXP platform is not updated in this PR as changes have not been approved yet by its maintainers.
