### PR TITLE
Modernise edk2-platforms (replace EFI_D_* and __FUNCTION__ with DEBUG_* and __func__)

### DIFF
--- a/Drivers/OpTee/OpteeRpmbPkg/FixupPcd.c
+++ b/Drivers/OpTee/OpteeRpmbPkg/FixupPcd.c
@@ -71,11 +71,11 @@ FixPcdMemory (
     );
 
   DEBUG ((DEBUG_INFO, "%a: Fixup PcdFlashNvStorageVariableBase64: 0x%lx\n",
-    __FUNCTION__, PcdGet64 (PcdFlashNvStorageVariableBase64)));
+    __func__, PcdGet64 (PcdFlashNvStorageVariableBase64)));
   DEBUG ((DEBUG_INFO, "%a: Fixup PcdFlashNvStorageFtwWorkingBase64: 0x%lx\n",
-    __FUNCTION__, PcdGet64 (PcdFlashNvStorageFtwWorkingBase64)));
+    __func__, PcdGet64 (PcdFlashNvStorageFtwWorkingBase64)));
   DEBUG ((DEBUG_INFO, "%a: Fixup PcdFlashNvStorageFtwSpareBase64: 0x%lx\n",
-    __FUNCTION__, PcdGet64 (PcdFlashNvStorageFtwSpareBase64)));
+    __func__, PcdGet64 (PcdFlashNvStorageFtwSpareBase64)));
 
   return Status;
 }

--- a/Drivers/OpTee/OpteeRpmbPkg/OpTeeRpmbFvb.c
+++ b/Drivers/OpTee/OpteeRpmbPkg/OpTeeRpmbFvb.c
@@ -575,14 +575,14 @@ ValidateFvHeader (
       || (FwVolHeader->Signature != EFI_FVH_SIGNATURE)
       || (FwVolHeader->FvLength  != FvLength)) {
     DEBUG ((DEBUG_INFO, "%a: No Firmware Volume header present\n",
-      __FUNCTION__));
+      __func__));
     return EFI_NOT_FOUND;
   }
 
   // Check the Firmware Volume Guid
   if (!CompareGuid (&FwVolHeader->FileSystemGuid, &gEfiSystemNvDataFvGuid)) {
     DEBUG ((DEBUG_INFO, "%a: Firmware Volume Guid non-compatible\n",
-      __FUNCTION__));
+      __func__));
     return EFI_VOLUME_CORRUPTED;
   }
 
@@ -590,7 +590,7 @@ ValidateFvHeader (
   Checksum = CalculateSum16 ((UINT16*)FwVolHeader, FwVolHeader->HeaderLength);
   if (Checksum != 0) {
     DEBUG ((DEBUG_INFO, "%a: FV checksum is invalid (Checksum:0x%X)\n",
-      __FUNCTION__, Checksum));
+      __func__, Checksum));
     return EFI_VOLUME_CORRUPTED;
   }
 
@@ -600,7 +600,7 @@ ValidateFvHeader (
   // Check the Variable Store Guid
   if (!CompareGuid (&VariableStoreHeader->Signature, &gEfiVariableGuid) &&
       !CompareGuid (&VariableStoreHeader->Signature, &gEfiAuthenticatedVariableGuid)) {
-    DEBUG ((DEBUG_INFO, "%a: Variable Store Guid non-compatible\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Variable Store Guid non-compatible\n", __func__));
     return EFI_VOLUME_CORRUPTED;
   }
 
@@ -608,7 +608,7 @@ ValidateFvHeader (
                         FwVolHeader->HeaderLength;
   if (VariableStoreHeader->Size != VariableStoreLength) {
     DEBUG ((DEBUG_INFO, "%a: Variable Store Length does not match\n",
-      __FUNCTION__));
+      __func__));
     return EFI_VOLUME_CORRUPTED;
   }
 
@@ -754,7 +754,7 @@ FvbInitialize (
   Status = ValidateFvHeader (FwVolHeader);
   if (EFI_ERROR (Status)) {
     // There is no valid header, so time to install one.
-    DEBUG ((DEBUG_INFO, "%a: The FVB Header is not valid.\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: The FVB Header is not valid.\n", __func__));
 
     // Reset memory
     SetMem64 (
@@ -762,7 +762,7 @@ FvbInitialize (
       Instance->NBlocks * Instance->BlockSize,
       ~0UL
       );
-    DEBUG ((DEBUG_INFO, "%a: Erasing Flash.\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Erasing Flash.\n", __func__));
     Status = ReadWriteRpmb (
                SP_SVC_RPMB_WRITE,
                Instance->MemBaseAddress,
@@ -776,13 +776,13 @@ FvbInitialize (
     }
     // Install all appropriate headers
     DEBUG ((DEBUG_INFO, "%a: Installing a correct one for this volume.\n",
-      __FUNCTION__));
+      __func__));
     Status = InitializeFvAndVariableStoreHeaders (Instance);
     if (EFI_ERROR (Status)) {
       return Status;
     }
   } else {
-    DEBUG ((DEBUG_INFO, "%a: Found valid FVB Header.\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Found valid FVB Header.\n", __func__));
   }
   Instance->Initialized = TRUE;
 
@@ -861,9 +861,9 @@ OpTeeRpmbFvbInit (
                     );
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG ((DEBUG_INFO, "%a: Register OP-TEE RPMB Fvb\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Register OP-TEE RPMB Fvb\n", __func__));
   DEBUG ((DEBUG_INFO, "%a: Using NV store FV in-memory copy at 0x%lx\n",
-    __FUNCTION__, PatchPcdGet64 (PcdFlashNvStorageVariableBase64)));
+    __func__, PatchPcdGet64 (PcdFlashNvStorageVariableBase64)));
 
   return Status;
 }

--- a/Drivers/OptionRomPkg/Application/BltLibSample/BltLibSample.c
+++ b/Drivers/OptionRomPkg/Application/BltLibSample/BltLibSample.c
@@ -136,7 +136,7 @@ Uint32SqRt (
        Mask = Mask >> 1
       ) {
     SqRtMask = SqRt | Mask;
-    //DEBUG ((EFI_D_INFO, "Uint32=0x%x SqRtMask=0x%x\n", Uint32, SqRtMask));
+    //DEBUG ((DEBUG_INFO, "Uint32=0x%x SqRtMask=0x%x\n", Uint32, SqRtMask));
     Squared = (UINT32) (SqRtMask * SqRtMask);
     if (Squared > Uint32) {
       continue;
@@ -196,14 +196,14 @@ TestColor (
                         10000000
                         );
   if (TriWidth > ScreenWidth) {
-    DEBUG ((EFI_D_INFO, "TriWidth at %d was too big\n", TriWidth));
+    DEBUG ((DEBUG_INFO, "TriWidth at %d was too big\n", TriWidth));
     TriWidth = ScreenWidth;
   } else if (TriHeight > ScreenHeight) {
-    DEBUG ((EFI_D_INFO, "TriHeight at %d was too big\n", TriHeight));
+    DEBUG ((DEBUG_INFO, "TriHeight at %d was too big\n", TriHeight));
     TriHeight = ScreenHeight;
   }
 
-  DEBUG ((EFI_D_INFO, "Triangle Width: %d; Height: %d\n", TriWidth, TriHeight));
+  DEBUG ((DEBUG_INFO, "Triangle Width: %d; Height: %d\n", TriWidth, TriHeight));
 
   X1 = (ScreenWidth - TriWidth) / 2;
   X3 = X1 + TriWidth - 1;

--- a/Drivers/OptionRomPkg/AtapiPassThruDxe/AtapiPassThru.c
+++ b/Drivers/OptionRomPkg/AtapiPassThruDxe/AtapiPassThru.c
@@ -3215,7 +3215,7 @@ Returns:
 
     if (StatusRegister & DWF) {
       DEBUG (
-        (EFI_D_BLKIO,
+        (DEBUG_BLKIO,
         "AtapiPassThruCheckErrorStatus()-- %02x : Error : Write Fault\n",
         StatusRegister)
         );
@@ -3223,7 +3223,7 @@ Returns:
 
     if (StatusRegister & CORR) {
       DEBUG (
-        (EFI_D_BLKIO,
+        (DEBUG_BLKIO,
         "AtapiPassThruCheckErrorStatus()-- %02x : Error : Corrected Data\n",
         StatusRegister)
         );
@@ -3235,7 +3235,7 @@ Returns:
 
       if (ErrorRegister & BBK_ERR) {
         DEBUG (
-          (EFI_D_BLKIO,
+          (DEBUG_BLKIO,
           "AtapiPassThruCheckErrorStatus()-- %02x : Error : Bad Block Detected\n",
           ErrorRegister)
           );
@@ -3243,7 +3243,7 @@ Returns:
 
       if (ErrorRegister & UNC_ERR) {
         DEBUG (
-          (EFI_D_BLKIO,
+          (DEBUG_BLKIO,
           "AtapiPassThruCheckErrorStatus()-- %02x : Error : Uncorrectable Data\n",
           ErrorRegister)
           );
@@ -3251,7 +3251,7 @@ Returns:
 
       if (ErrorRegister & MC_ERR) {
         DEBUG (
-          (EFI_D_BLKIO,
+          (DEBUG_BLKIO,
           "AtapiPassThruCheckErrorStatus()-- %02x : Error : Media Change\n",
           ErrorRegister)
           );
@@ -3259,7 +3259,7 @@ Returns:
 
       if (ErrorRegister & ABRT_ERR) {
         DEBUG (
-          (EFI_D_BLKIO,
+          (DEBUG_BLKIO,
           "AtapiPassThruCheckErrorStatus()-- %02x : Error : Abort\n",
           ErrorRegister)
           );
@@ -3267,7 +3267,7 @@ Returns:
 
       if (ErrorRegister & TK0NF_ERR) {
         DEBUG (
-          (EFI_D_BLKIO,
+          (DEBUG_BLKIO,
           "AtapiPassThruCheckErrorStatus()-- %02x : Error : Track 0 Not Found\n",
           ErrorRegister)
           );
@@ -3275,7 +3275,7 @@ Returns:
 
       if (ErrorRegister & AMNF_ERR) {
         DEBUG (
-          (EFI_D_BLKIO,
+          (DEBUG_BLKIO,
           "AtapiPassThruCheckErrorStatus()-- %02x : Error : Address Mark Not Found\n",
           ErrorRegister)
           );

--- a/Drivers/OptionRomPkg/Library/FrameBufferBltLib/FrameBufferBltLib.c
+++ b/Drivers/OptionRomPkg/Library/FrameBufferBltLib/FrameBufferBltLib.c
@@ -55,14 +55,14 @@ ConfigurePixelBitMaskFormat (
       mPixelShr[Loop] = 0;
     }
     MergedMasks = (UINT32) (MergedMasks | Masks[Loop]);
-    DEBUG ((EFI_D_INFO, "%d: shl:%d shr:%d mask:%x\n", Loop, mPixelShl[Loop], mPixelShr[Loop], Masks[Loop]));
+    DEBUG ((DEBUG_INFO, "%d: shl:%d shr:%d mask:%x\n", Loop, mPixelShl[Loop], mPixelShr[Loop], Masks[Loop]));
   }
   MergedMasks = (UINT32) (MergedMasks | Masks[3]);
 
   ASSERT (MergedMasks != 0);
   mBltLibBytesPerPixel = (UINTN) ((HighBitSet32 (MergedMasks) + 7) / 8);
 
-  DEBUG ((EFI_D_INFO, "Bytes per pixel: %d\n", mBltLibBytesPerPixel));
+  DEBUG ((DEBUG_INFO, "Bytes per pixel: %d\n", mBltLibBytesPerPixel));
 
   CopyMem (&mPixelBitMasks, BitMask, sizeof (*BitMask));
 }
@@ -245,17 +245,17 @@ BltLibVideoFill (
   // BltBuffer to Video: Source is BltBuffer, destination is Video
   //
   if (DestinationY + Height > mBltLibHeight) {
-    DEBUG ((EFI_D_INFO, "VideoFill: Past screen (Y)\n"));
+    DEBUG ((DEBUG_INFO, "VideoFill: Past screen (Y)\n"));
     return EFI_INVALID_PARAMETER;
   }
 
   if (DestinationX + Width > mBltLibWidthInPixels) {
-    DEBUG ((EFI_D_INFO, "VideoFill: Past screen (X)\n"));
+    DEBUG ((DEBUG_INFO, "VideoFill: Past screen (X)\n"));
     return EFI_INVALID_PARAMETER;
   }
 
   if (Width == 0 || Height == 0) {
-    DEBUG ((EFI_D_INFO, "VideoFill: Width or Height is 0\n"));
+    DEBUG ((DEBUG_INFO, "VideoFill: Width or Height is 0\n"));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -268,7 +268,7 @@ BltLibVideoFill (
         (((Uint32 << mPixelShl[1]) >> mPixelShr[1]) & mPixelBitMasks.GreenMask) |
         (((Uint32 << mPixelShl[2]) >> mPixelShr[2]) & mPixelBitMasks.BlueMask)
       );
-  VDEBUG ((EFI_D_INFO, "VideoFill: color=0x%x, wide-fill=0x%x\n", Uint32, WideFill));
+  VDEBUG ((DEBUG_INFO, "VideoFill: color=0x%x, wide-fill=0x%x\n", Uint32, WideFill));
 
   //
   // If the size of the pixel data evenly divides the sizeof
@@ -299,7 +299,7 @@ BltLibVideoFill (
   }
 
   if (UseWideFill && (DestinationX == 0) && (Width == mBltLibWidthInPixels)) {
-    VDEBUG ((EFI_D_INFO, "VideoFill (wide, one-shot)\n"));
+    VDEBUG ((DEBUG_INFO, "VideoFill (wide, one-shot)\n"));
     Offset = DestinationY * mBltLibWidthInPixels;
     Offset = mBltLibBytesPerPixel * Offset;
     BltMemDst = (VOID*) (mBltLibFrameBuffer + Offset);
@@ -319,7 +319,7 @@ BltLibVideoFill (
       BltMemDst = (VOID*) (mBltLibFrameBuffer + Offset);
 
       if (UseWideFill && (((UINTN) BltMemDst & 7) == 0)) {
-        VDEBUG ((EFI_D_INFO, "VideoFill (wide)\n"));
+        VDEBUG ((DEBUG_INFO, "VideoFill (wide)\n"));
         SizeInBytes = WidthInBytes;
         if (SizeInBytes >= 8) {
           SetMem64 (BltMemDst, SizeInBytes & ~7, WideFill);
@@ -329,7 +329,7 @@ BltLibVideoFill (
           CopyMem (BltMemDst, (VOID*) &WideFill, SizeInBytes);
         }
       } else {
-        VDEBUG ((EFI_D_INFO, "VideoFill (not wide)\n"));
+        VDEBUG ((DEBUG_INFO, "VideoFill (not wide)\n"));
         if (!LineBufferReady) {
           CopyMem (mBltLibLineBuffer, &WideFill, mBltLibBytesPerPixel);
           for (X = 1; X < Width; ) {

--- a/Features/Intel/Debugging/PostCodeDebugFeaturePkg/Library/PostCodeStatusCodeHandlerLib/PeiPostCodeStatusCodeHandlerLib.c
+++ b/Features/Intel/Debugging/PostCodeDebugFeaturePkg/Library/PostCodeStatusCodeHandlerLib/PeiPostCodeStatusCodeHandlerLib.c
@@ -54,7 +54,7 @@ PostCodeStatusCodeReportWorker (
 
   PostCodeValue = GetPostCodeFromStatusCode (CodeType, Value);
   if (PostCodeValue != 0) {
-    DEBUG ((EFI_D_INFO, "POSTCODE=<%02x>\n", PostCodeValue));
+    DEBUG ((DEBUG_INFO, "POSTCODE=<%02x>\n", PostCodeValue));
     PostCode (PostCodeValue);
   }
 

--- a/Features/Intel/Debugging/PostCodeDebugFeaturePkg/Library/PostCodeStatusCodeHandlerLib/RuntimeDxePostCodeStatusCodeHandlerLib.c
+++ b/Features/Intel/Debugging/PostCodeDebugFeaturePkg/Library/PostCodeStatusCodeHandlerLib/RuntimeDxePostCodeStatusCodeHandlerLib.c
@@ -58,7 +58,7 @@ PostCodeStatusCodeReportWorker (
 
   PostCodeValue = GetPostCodeFromStatusCode (CodeType, Value);
   if (PostCodeValue != 0) {
-    DEBUG ((EFI_D_INFO, "POSTCODE=<%02x>\n", PostCodeValue));
+    DEBUG ((DEBUG_INFO, "POSTCODE=<%02x>\n", PostCodeValue));
     PostCode (PostCodeValue);
   }
 

--- a/Features/Intel/Debugging/PostCodeDebugFeaturePkg/Library/PostCodeStatusCodeHandlerLib/SmmPostCodeStatusCodeHandlerLib.c
+++ b/Features/Intel/Debugging/PostCodeDebugFeaturePkg/Library/PostCodeStatusCodeHandlerLib/SmmPostCodeStatusCodeHandlerLib.c
@@ -54,7 +54,7 @@ PostCodeStatusCodeReportWorker (
 
   PostCodeValue = GetPostCodeFromStatusCode (CodeType, Value);
   if (PostCodeValue != 0) {
-    DEBUG ((EFI_D_INFO, "POSTCODE=<%02x>\n", PostCodeValue));
+    DEBUG ((DEBUG_INFO, "POSTCODE=<%02x>\n", PostCodeValue));
     PostCode (PostCodeValue);
   }
 

--- a/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Smm/SmmGenericIpmi.c
+++ b/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Smm/SmmGenericIpmi.c
@@ -79,14 +79,14 @@ Returns:
                                 &DataSize
                                 );
     if (Status == EFI_SUCCESS) {
-      DEBUG ((EFI_D_INFO, "IPMI: SendCommand success!\n"));
+      DEBUG ((DEBUG_INFO, "IPMI: SendCommand success!\n"));
       break;
     } else {
       //
       // Display message and retry.
       //
       DEBUG (
-             (DEBUG_WARN | EFI_D_INFO,
+             (DEBUG_WARN | DEBUG_INFO,
               "IPMI: Waiting for BMC (KCS 0x%x)...\n",
               IpmiInstance->IpmiIoBase)
              );

--- a/Features/Intel/PowerManagement/S3FeaturePkg/S3Dxe/S3Dxe.c
+++ b/Features/Intel/PowerManagement/S3FeaturePkg/S3Dxe/S3Dxe.c
@@ -129,7 +129,7 @@ S3DxeEntryPoint (
   ACPI_S3_MEMORY  S3MemoryInfo;
   EFI_STATUS      Status;
 
-  DEBUG ((DEBUG_INFO, "%a() Start\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a() Start\n", __func__));
 
   S3PeiMemSize = (UINTN) GetPeiMemSize ();
   S3PeiMemBase = (UINTN) AllocateAcpiNvsMemoryBelow4G (S3PeiMemSize);
@@ -150,6 +150,6 @@ S3DxeEntryPoint (
                   );
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG ((DEBUG_INFO, "%a() End\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a() End\n", __func__));
   return EFI_SUCCESS;
 }

--- a/Platform/96Boards/96BoardsI2cDxe/96BoardsI2cDxe.c
+++ b/Platform/96Boards/96BoardsI2cDxe/96BoardsI2cDxe.c
@@ -109,7 +109,7 @@ EnableI2cBusConfiguration (
                   &gEfiI2cMasterProtocolGuid, (VOID **)&I2cMaster);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: gBS->HandleProtocol() failed - %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     return Status;
   }
 
@@ -117,7 +117,7 @@ EnableI2cBusConfiguration (
   Status = I2cMaster->SetBusFrequency (I2cMaster, &BusClockHertz);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: I2cMaster->SetBusFrequency() failed - %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     return Status;
   }
 
@@ -162,7 +162,7 @@ RegisterI2cBus (
   Status = gBS->LocateHandle (ByProtocol, Guid, NULL, &BufferSize,
                   &I2cBus->I2cMasterHandle);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "%a: gBS->LocateHandle() failed - %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_INFO, "%a: gBS->LocateHandle() failed - %r\n", __func__,
       Status));
     return;
   }

--- a/Platform/96Boards/LsConnectorDxe/LsConnectorDxe.c
+++ b/Platform/96Boards/LsConnectorDxe/LsConnectorDxe.c
@@ -105,7 +105,7 @@ PublishOsDescription (
   Status = gBS->LocateProtocol (&g96BoardsMezzanineProtocolGuid, NULL,
                   (VOID **)&Mezzanine);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "%a: no mezzanine driver active\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: no mezzanine driver active\n", __func__));
     return;
   }
 
@@ -115,7 +115,7 @@ PublishOsDescription (
     Status = Mezzanine->InstallSsdtTable (Mezzanine, AcpiProtocol);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_WARN, "%a: failed to install SSDT table - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
     }
     return;
   }
@@ -133,7 +133,7 @@ PublishOsDescription (
 
   Status = Mezzanine->ApplyDeviceTreeOverlay (Mezzanine, Dtb);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_WARN, "%a: failed to apply DT overlay - %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_WARN, "%a: failed to apply DT overlay - %r\n", __func__,
       Status));
   }
 }
@@ -169,7 +169,7 @@ EntryPoint (
   Status = gRT->GetVariable (NINETY_SIX_BOARDS_CONFIG_VARIABLE_NAME,
                   &g96BoardsFormsetGuid, NULL, &BufferSize, &ConfigData);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "%a: no config data found\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: no config data found\n", __func__));
     ConfigData.MezzanineType = MEZZANINE_NONE;
   }
 
@@ -177,7 +177,7 @@ EntryPoint (
       ConfigData.MezzanineType >= MEZZANINE_MAX) {
     DEBUG ((DEBUG_WARN,
       "%a: invalid value for %s, defaulting to MEZZANINE_NONE\n",
-      __FUNCTION__, NINETY_SIX_BOARDS_CONFIG_VARIABLE_NAME));
+      __func__, NINETY_SIX_BOARDS_CONFIG_VARIABLE_NAME));
     ConfigData.MezzanineType = MEZZANINE_NONE;
     Status = EFI_INVALID_PARAMETER; // trigger setvar below
   }
@@ -194,7 +194,7 @@ EntryPoint (
 
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: gRT->SetVariable () failed - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
       return Status;
     }
   }

--- a/Platform/96Boards/Secure96Dxe/Secure96Dxe.c
+++ b/Platform/96Boards/Secure96Dxe/Secure96Dxe.c
@@ -68,7 +68,7 @@ SetOverlayFragmentTarget (
           AsciiStrLen (Target) + 1);
   if (Err) {
     DEBUG ((DEBUG_ERROR, "%a: fdt_setprop() failed - %a\n",
-      __FUNCTION__, fdt_strerror (Err)));
+      __func__, fdt_strerror (Err)));
   }
 }
 
@@ -103,7 +103,7 @@ FixupOverlay (
     if (Err) {
       DEBUG ((DEBUG_ERROR,
         "%a: fdt_setprop_u32(.., .., \"phandle\", 0x%x) failed - %a\n",
-        __FUNCTION__, GpioPhandle, fdt_strerror (Err)));
+        __func__, GpioPhandle, fdt_strerror (Err)));
     }
   }
 
@@ -171,7 +171,7 @@ ApplyDeviceTreeOverlay (
   Err = fdt_overlay_apply (Dtb, Overlay);
   if (Err) {
     DEBUG ((DEBUG_ERROR, "%a: fdt_overlay_apply() failed - %a\n",
-      __FUNCTION__, fdt_strerror (Err)));
+      __func__, fdt_strerror (Err)));
     return EFI_NOT_FOUND;
   }
 

--- a/Platform/AMD/AmdMinBoardPkg/Library/DxeBoardInitLib/DxeBoardInitLib.c
+++ b/Platform/AMD/AmdMinBoardPkg/Library/DxeBoardInitLib/DxeBoardInitLib.c
@@ -164,7 +164,7 @@ BoardInitAfterPciEnumeration (
 {
   EFI_STATUS  Status;
 
-  DEBUG ((DEBUG_INFO, "%a - ENTRY\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a - ENTRY\n", __func__));
 
   Status = ReserveLegacyVgaIoSpace ();
   DEBUG ((DEBUG_INFO, "ReserveLegacyVgaIoSpace...%r.\n", Status));

--- a/Platform/AMD/AmdMinBoardPkg/Library/DxeBoardInitLib/MadtAcpiTablePatch.c
+++ b/Platform/AMD/AmdMinBoardPkg/Library/DxeBoardInitLib/MadtAcpiTablePatch.c
@@ -132,7 +132,7 @@ MadtAcpiTablePatch (
   LocalX2ApicPtr = NULL;
   GetIoApicInfo (&NbioIoApic, &IoApicCount);
   if ((NbioIoApic == NULL) || (IoApicCount == 0)) {
-    DEBUG ((DEBUG_INFO, "%a:%d Cannot obtain NBIO IOAPIC information.\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_INFO, "%a:%d Cannot obtain NBIO IOAPIC information.\n", __func__, __LINE__));
     return EFI_SUCCESS;
   }
 

--- a/Platform/AMD/VanGoghBoard/Override/edk2/Fsp2WrapperPkg/FspWrapperNotifyDxe/FspWrapperNotifyDxe.c
+++ b/Platform/AMD/VanGoghBoard/Override/edk2/Fsp2WrapperPkg/FspWrapperNotifyDxe/FspWrapperNotifyDxe.c
@@ -386,7 +386,7 @@ OnReadyToBoot (
       FspsUpd = ((FSPS_UPD *)(UINTN)(*(UINT32 *)GET_GUID_HOB_DATA (FspsUpdHob)));
       Status  = gBS->LocateProtocol (&gEfiAcpiTableProtocolGuid, NULL, (VOID **)&AcpiTableProtocol);
       if (!EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_INFO, "%a:FSP-S UPD Ptr:%x\n", __FUNCTION__, FspsUpd));
+        DEBUG ((DEBUG_INFO, "%a:FSP-S UPD Ptr:%x\n", __func__, FspsUpd));
         UINTN  TableKey = 0;
         if (ExportedInterfaceHob->AcpiTpm2Table != 0) {
           DEBUG ((DEBUG_INFO, "TPM2 Table: %x\n", ExportedInterfaceHob->AcpiTpm2Table));

--- a/Platform/AMD/VanGoghBoard/Override/edk2/Fsp2WrapperPkg/Library/BaseFspWrapperPlatformLibSample/FspWrapperPlatformLibSample.c
+++ b/Platform/AMD/VanGoghBoard/Override/edk2/Fsp2WrapperPkg/Library/BaseFspWrapperPlatformLibSample/FspWrapperPlatformLibSample.c
@@ -112,7 +112,7 @@ UpdateFspmUpdDataForFabric (
   IN OUT VOID  *FspUpdRgnPtr
   )
 {
-  DEBUG ((DEBUG_INFO, "%a Enter\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a Enter\n", __func__));
   FSPM_UPD                         *Upd           = (FSPM_UPD *)FspUpdRgnPtr;
   EFI_PEI_READ_ONLY_VARIABLE2_PPI  *ReadVariable2 = NULL;
   EFI_STATUS                       Status         = PeiServicesLocatePpi (&gEfiPeiReadOnlyVariable2PpiGuid, 0, NULL, (VOID **)&ReadVariable2);

--- a/Platform/AMD/VanGoghBoard/VanGoghCommonPkg/FvbServices/FwBlockService.c
+++ b/Platform/AMD/VanGoghBoard/VanGoghCommonPkg/FvbServices/FwBlockService.c
@@ -345,7 +345,7 @@ FvbReadBlock (
   UINTN                 LbaLength;
   EFI_STATUS            Status;
 
-  DEBUG ((DEBUG_INFO, "Smm %a() enter\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "Smm %a() enter\n", __func__));
 
   //
   // Check for invalid conditions

--- a/Platform/AMD/VanGoghBoard/VanGoghCommonPkg/Smm/SmmAccessPei/SmmAccessPei.c
+++ b/Platform/AMD/VanGoghBoard/VanGoghCommonPkg/Smm/SmmAccessPei/SmmAccessPei.c
@@ -427,7 +427,7 @@ SmmAccessPeiEntryPoint (
   ASSERT_EFI_ERROR (Status);
 
   DEBUG (
-    (EFI_D_INFO, "SMM Base:Size %08X:%08X\n",
+    (DEBUG_INFO, "SMM Base:Size %08X:%08X\n",
      (UINTN)(SmmAccessPrivate->SmramDesc[SmmAccessPrivate->NumberRegions-1].PhysicalStart),
      (UINTN)(SmmAccessPrivate->SmramDesc[SmmAccessPrivate->NumberRegions-1].PhysicalSize)
     ));

--- a/Platform/ARM/Drivers/BootMonFs/BootMonFsEntryPoint.c
+++ b/Platform/ARM/Drivers/BootMonFs/BootMonFsEntryPoint.c
@@ -516,7 +516,7 @@ BootMonFsEntryPoint (
                     );
     ASSERT_EFI_ERROR (Status);
   } else {
-    DEBUG((EFI_D_ERROR,"Warning: No Device Paths supporting BootMonFs have been defined in the PCD.\n"));
+    DEBUG((DEBUG_ERROR,"Warning: No Device Paths supporting BootMonFs have been defined in the PCD.\n"));
   }
 
   return Status;

--- a/Platform/ARM/Drivers/BootMonFs/BootMonFsImages.c
+++ b/Platform/ARM/Drivers/BootMonFs/BootMonFsImages.c
@@ -164,7 +164,7 @@ BootMonFsDiscoverNextImage (
 
     // If we found a valid image description...
     if (BootMonFsIsImageValid (&File->HwDescription, (CurrentLba - Instance->Media->LowestAlignedLba))) {
-      DEBUG ((EFI_D_ERROR, "Found image: %a in block %d.\n",
+      DEBUG ((DEBUG_ERROR, "Found image: %a in block %d.\n",
         &(File->HwDescription.Footer.Filename),
         (UINTN)(CurrentLba - Instance->Media->LowestAlignedLba)
         ));

--- a/Platform/ARM/Drivers/FdtPlatformDxe/FdtPlatform.c
+++ b/Platform/ARM/Drivers/FdtPlatformDxe/FdtPlatform.c
@@ -68,7 +68,7 @@ InstallFdt (
                   (VOID **)&EfiDevicePathFromTextProtocol
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "InstallFdt() - Failed to locate EFI_DEVICE_PATH_FROM_TEXT_PROTOCOL protocol\n"));
+    DEBUG ((DEBUG_ERROR, "InstallFdt() - Failed to locate EFI_DEVICE_PATH_FROM_TEXT_PROTOCOL protocol\n"));
     return Status;
   }
 
@@ -94,7 +94,7 @@ InstallFdt (
   //
   if (fdt_check_header ((VOID*)(UINTN)FdtBlobBase) != 0 ||
       (UINTN)fdt_totalsize ((VOID*)(UINTN)FdtBlobBase) > FdtBlobSize) {
-    DEBUG ((EFI_D_ERROR, "InstallFdt() - loaded FDT binary image seems corrupt\n"));
+    DEBUG ((DEBUG_ERROR, "InstallFdt() - loaded FDT binary image seems corrupt\n"));
     Status = EFI_LOAD_ERROR;
     goto Error;
   }
@@ -210,7 +210,7 @@ FdtPlatformEntryPoint (
     }
     if (EFI_ERROR (Status)) {
       DEBUG ((
-        EFI_D_WARN,
+        DEBUG_WARN,
         "Unable to install \"setfdt\" EFI Shell command - %r \n",
         Status
         ));
@@ -236,7 +236,7 @@ FdtPlatformEntryPoint (
     }
     if (EFI_ERROR (Status)) {
       DEBUG ((
-        EFI_D_WARN,
+        DEBUG_WARN,
         "Unable to install \"dumpfdt\" EFI Shell command - %r \n",
         Status
         ));
@@ -322,14 +322,14 @@ RunFdtInstallation (
       Status = InstallFdt (TextDevicePath);
       if (!EFI_ERROR (Status)) {
         DEBUG ((
-          EFI_D_WARN,
+          DEBUG_WARN,
           "Installation of the FDT using the device path <%s> completed.\n",
           TextDevicePath
           ));
         goto Done;
       }
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "Installation of the FDT specified by the \"Fdt\" UEFI variable failed - %r\n",
         Status
         ));
@@ -368,13 +368,13 @@ RunFdtInstallation (
 
     Status = InstallFdt (TextDevicePath);
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_WARN, "Installation of the FDT using the device path <%s> completed.\n",
+      DEBUG ((DEBUG_WARN, "Installation of the FDT using the device path <%s> completed.\n",
         TextDevicePath
         ));
       goto Done;
     }
 
-    DEBUG ((EFI_D_WARN, "Installation of the FDT using the device path <%s> failed - %r.\n",
+    DEBUG ((DEBUG_WARN, "Installation of the FDT using the device path <%s> failed - %r.\n",
       TextDevicePath, Status
       ));
     FreePool (TextDevicePath);
@@ -389,7 +389,7 @@ Error:
 Done:
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Failed to install the FDT - %r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "Failed to install the FDT - %r.\n", Status));
     return Status;
   }
 

--- a/Platform/ARM/Drivers/FdtPlatformDxe/ShellDumpFdt.c
+++ b/Platform/ARM/Drivers/FdtPlatformDxe/ShellDumpFdt.c
@@ -104,7 +104,7 @@ DumpFdt (
     for (i = 0; i < num; i++) {
       err = fdt_get_mem_rsv (FdtBlob, i, &addr, &size);
       if (err) {
-        DEBUG ((EFI_D_ERROR, "Error (%d) : Cannot get memreserve section (%d)\n", err, i));
+        DEBUG ((DEBUG_ERROR, "Error (%d) : Cannot get memreserve section (%d)\n", err, i));
       }
       else {
         Print (L"/memreserve/ \t0x%lx \t0x%lx;\n", addr, size);

--- a/Platform/ARM/Drivers/NorFlashDxe/NorFlashDxe.c
+++ b/Platform/ARM/Drivers/NorFlashDxe/NorFlashDxe.c
@@ -349,11 +349,11 @@ NorFlashFvbInitialize (
   // Install the Default FVB header if required
   if (EFI_ERROR (Status)) {
     // There is no valid header, so time to install one.
-    DEBUG ((DEBUG_INFO, "%a: The FVB Header is not valid.\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: The FVB Header is not valid.\n", __func__));
     DEBUG ((
       DEBUG_INFO,
       "%a: Installing a correct one for this volume.\n",
-      __FUNCTION__
+      __func__
       ));
 
     // Erase all the NorFlash that is reserved for variable storage

--- a/Platform/ARM/Drivers/NorFlashDxe/NorFlashFvb.c
+++ b/Platform/ARM/Drivers/NorFlashDxe/NorFlashFvb.c
@@ -74,7 +74,7 @@ InitializeFvAndVariableStoreHeaders (
     DEBUG ((
       DEBUG_ERROR,
       "%a: NvStorageFtwWorkingBase is not contiguous with NvStorageVariableBase region\n",
-      __FUNCTION__
+      __func__
       ));
     return EFI_INVALID_PARAMETER;
   }
@@ -83,7 +83,7 @@ InitializeFvAndVariableStoreHeaders (
     DEBUG ((
       DEBUG_ERROR,
       "%a: NvStorageFtwSpareBase is not contiguous with NvStorageFtwWorkingBase region\n",
-      __FUNCTION__
+      __func__
       ));
     return EFI_INVALID_PARAMETER;
   }
@@ -93,7 +93,7 @@ InitializeFvAndVariableStoreHeaders (
     DEBUG ((
       DEBUG_ERROR,
       "%a: NvStorageVariableSize is 0x%x, should be atleast one block size\n",
-      __FUNCTION__,
+      __func__,
       NvStorageVariableSize
       ));
     return EFI_INVALID_PARAMETER;
@@ -103,7 +103,7 @@ InitializeFvAndVariableStoreHeaders (
     DEBUG ((
       DEBUG_ERROR,
       "%a: NvStorageFtwWorkingSize is 0x%x, should be atleast one block size\n",
-      __FUNCTION__,
+      __func__,
       NvStorageFtwWorkingSize
       ));
     return EFI_INVALID_PARAMETER;
@@ -113,7 +113,7 @@ InitializeFvAndVariableStoreHeaders (
     DEBUG ((
       DEBUG_ERROR,
       "%a: NvStorageFtwSpareSize is 0x%x, should be atleast one block size\n",
-      __FUNCTION__,
+      __func__,
       NvStorageFtwSpareSize
       ));
     return EFI_INVALID_PARAMETER;
@@ -124,7 +124,7 @@ InitializeFvAndVariableStoreHeaders (
       (NvStorageFtwWorkingBase % Instance->Media.BlockSize != 0) ||
       (NvStorageFtwSpareBase % Instance->Media.BlockSize != 0))
   {
-    DEBUG ((DEBUG_ERROR, "%a: NvStorage Base addresses must be aligned to block size boundaries", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: NvStorage Base addresses must be aligned to block size boundaries", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -209,7 +209,7 @@ ValidateFvHeader (
     DEBUG ((
       DEBUG_INFO,
       "%a: No Firmware Volume header present\n",
-      __FUNCTION__
+      __func__
       ));
     return EFI_NOT_FOUND;
   }
@@ -219,7 +219,7 @@ ValidateFvHeader (
     DEBUG ((
       DEBUG_INFO,
       "%a: Firmware Volume Guid non-compatible\n",
-      __FUNCTION__
+      __func__
       ));
     return EFI_NOT_FOUND;
   }
@@ -230,7 +230,7 @@ ValidateFvHeader (
     DEBUG ((
       DEBUG_INFO,
       "%a: FV checksum is invalid (Checksum:0x%X)\n",
-      __FUNCTION__,
+      __func__,
       Checksum
       ));
     return EFI_NOT_FOUND;
@@ -245,7 +245,7 @@ ValidateFvHeader (
     DEBUG ((
       DEBUG_INFO,
       "%a: Variable Store Guid non-compatible\n",
-      __FUNCTION__
+      __func__
       ));
     return EFI_NOT_FOUND;
   }
@@ -255,7 +255,7 @@ ValidateFvHeader (
     DEBUG ((
       DEBUG_INFO,
       "%a: Variable Store Length does not match\n",
-      __FUNCTION__
+      __func__
       ));
     return EFI_NOT_FOUND;
   }

--- a/Platform/ARM/Drivers/NorFlashDxe/NorFlashStandaloneMm.c
+++ b/Platform/ARM/Drivers/NorFlashDxe/NorFlashStandaloneMm.c
@@ -261,11 +261,11 @@ NorFlashFvbInitialize (
   // Install the Default FVB header if required
   if (EFI_ERROR (Status)) {
     // There is no valid header, so time to install one.
-    DEBUG ((DEBUG_INFO, "%a: The FVB Header is not valid.\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: The FVB Header is not valid.\n", __func__));
     DEBUG ((
       DEBUG_INFO,
       "%a: Installing a correct one for this volume.\n",
-      __FUNCTION__
+      __func__
       ));
 
     // Erase all the NorFlash that is reserved for variable storage

--- a/Platform/ARM/JunoPkg/Drivers/ArmJunoDxe/ArmJunoDxe.c
+++ b/Platform/ARM/JunoPkg/Drivers/ArmJunoDxe/ArmJunoDxe.c
@@ -378,7 +378,7 @@ ArmJunoEntryPoint (
   // Install dynamic Shell command to run baremetal binaries.
   Status = ShellDynCmdRunAxfInstall (ImageHandle);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "ArmJunoDxe: Failed to install ShellDynCmdRunAxf\n"));
+    DEBUG ((DEBUG_ERROR, "ArmJunoDxe: Failed to install ShellDynCmdRunAxf\n"));
   }
 
   GetJunoRevision(JunoRevision);
@@ -440,7 +440,7 @@ ArmJunoEntryPoint (
 
   if (EFI_ERROR (Status)) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "ArmJunoDxe: Setting of FDT device path in PcdFdtDevicePaths failed - %r\n", Status)
       );
     return Status;

--- a/Platform/ARM/JunoPkg/Drivers/SataSiI3132Dxe/SataSiI3132.c
+++ b/Platform/ARM/JunoPkg/Drivers/SataSiI3132Dxe/SataSiI3132.c
@@ -394,7 +394,7 @@ SataSiI3132DriverBindingStart (
                         );
   }
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SataSiI3132DriverBindingStart: failed to enable controller\n"));
+    DEBUG ((DEBUG_ERROR, "SataSiI3132DriverBindingStart: failed to enable controller\n"));
     goto CLOSE_PCIIO;
   }
 

--- a/Platform/ARM/JunoPkg/Drivers/SataSiI3132Dxe/SataSiI3132.h
+++ b/Platform/ARM/JunoPkg/Drivers/SataSiI3132Dxe/SataSiI3132.h
@@ -156,7 +156,7 @@ typedef struct _SATA_SI3132_INSTANCE {
 #define SATA_PORT_READ32(Offset, Value)  PciIo->Mem.Read (PciIo, EfiPciIoWidthUint32, 1, Offset, 1, Value)
 #define SATA_PORT_WRITE32(Offset, Value) { UINT32 Value32 = Value; PciIo->Mem.Write (PciIo, EfiPciIoWidthUint32, 1, Offset, 1, &Value32); }
 
-#define SATA_TRACE(txt)  DEBUG((EFI_D_VERBOSE, "ARM_SATA: " txt "\n"))
+#define SATA_TRACE(txt)  DEBUG((DEBUG_VERBOSE, "ARM_SATA: " txt "\n"))
 
 extern EFI_COMPONENT_NAME_PROTOCOL  gSataSiI3132ComponentName;
 extern EFI_COMPONENT_NAME2_PROTOCOL gSataSiI3132ComponentName2;

--- a/Platform/ARM/JunoPkg/Drivers/SataSiI3132Dxe/SiI3132AtaPassThru.c
+++ b/Platform/ARM/JunoPkg/Drivers/SataSiI3132Dxe/SiI3132AtaPassThru.c
@@ -249,12 +249,12 @@ SiI3132AtaPassThruCommand (
 
 
   if ((Packet->Timeout != 0) && (Timeout == 0)) {
-    DEBUG ((EFI_D_ERROR, "SiI3132AtaPassThru() Err:Timeout\n"));
+    DEBUG ((DEBUG_ERROR, "SiI3132AtaPassThru() Err:Timeout\n"));
     //ASSERT (0);
     return EFI_TIMEOUT;
   } else if (Value32 & (SII3132_PORT_INT_CMDERR << 16)) {
     SATA_PORT_READ32 (SataPort->RegBase + SII3132_PORT_CMDERROR_REG, &Error);
-    DEBUG ((EFI_D_ERROR, "SiI3132AtaPassThru() CmdErr:0x%X (SiI3132 Err:0x%X)\n", Value32, Error));
+    DEBUG ((DEBUG_ERROR, "SiI3132AtaPassThru() CmdErr:0x%X (SiI3132 Err:0x%X)\n", Value32, Error));
     ASSERT (0);
     return EFI_DEVICE_ERROR;
   } else if (Value32 & (SII3132_PORT_INT_CMDCOMPL << 16)) {
@@ -343,7 +343,7 @@ SiI3132AtaPassThru (
   }
   SataPort = SataDevice->Port;
 
-  DEBUG ((EFI_D_INFO, "SiI3132AtaPassThru(%d,%d) : AtaCmd:0x%X Prot:%d\n", Port, PortMultiplierPort,
+  DEBUG ((DEBUG_INFO, "SiI3132AtaPassThru(%d,%d) : AtaCmd:0x%X Prot:%d\n", Port, PortMultiplierPort,
          Packet->Acb->AtaCommand, Packet->Protocol));
 
   return SiI3132AtaPassThruCommand (SataSiI3132Instance, SataPort, PortMultiplierPort, Packet, Event);

--- a/Platform/ARM/JunoPkg/Library/JunoPciHostBridgeLib/JunoPciHostBridgeLib.c
+++ b/Platform/ARM/JunoPkg/Library/JunoPciHostBridgeLib/JunoPciHostBridgeLib.c
@@ -161,22 +161,22 @@ PciHostBridgeResourceConflict (
 {
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *Descriptor;
   UINTN                             RootBridgeIndex;
-  DEBUG ((EFI_D_ERROR, "PciHostBridge: Resource conflict happens!\n"));
+  DEBUG ((DEBUG_ERROR, "PciHostBridge: Resource conflict happens!\n"));
 
   RootBridgeIndex = 0;
   Descriptor = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *) Configuration;
   while (Descriptor->Desc == ACPI_ADDRESS_SPACE_DESCRIPTOR) {
-    DEBUG ((EFI_D_ERROR, "RootBridge[%d]:\n", RootBridgeIndex++));
+    DEBUG ((DEBUG_ERROR, "RootBridge[%d]:\n", RootBridgeIndex++));
     for (; Descriptor->Desc == ACPI_ADDRESS_SPACE_DESCRIPTOR; Descriptor++) {
       ASSERT (Descriptor->ResType <
               ARRAY_SIZE (mPciHostBridgeLibAcpiAddressSpaceTypeStr)
               );
-      DEBUG ((EFI_D_ERROR, " %s: Length/Alignment = 0x%lx / 0x%lx\n",
+      DEBUG ((DEBUG_ERROR, " %s: Length/Alignment = 0x%lx / 0x%lx\n",
               mPciHostBridgeLibAcpiAddressSpaceTypeStr[Descriptor->ResType],
               Descriptor->AddrLen, Descriptor->AddrRangeMax
               ));
       if (Descriptor->ResType == ACPI_ADDRESS_SPACE_TYPE_MEM) {
-        DEBUG ((EFI_D_ERROR, "     Granularity/SpecificFlag = %ld / %02x%s\n",
+        DEBUG ((DEBUG_ERROR, "     Granularity/SpecificFlag = %ld / %02x%s\n",
                 Descriptor->AddrSpaceGranularity, Descriptor->SpecificFlag,
                 ((Descriptor->SpecificFlag &
                   EFI_ACPI_MEMORY_RESOURCE_SPECIFIC_FLAG_CACHEABLE_PREFETCHABLE

--- a/Platform/ARM/JunoPkg/Library/JunoPciHostBridgeLib/XPressRich3.c
+++ b/Platform/ARM/JunoPkg/Library/JunoPciHostBridgeLib/XPressRich3.c
@@ -42,7 +42,7 @@ SetTranslationAddressEntry (
   // Ensure the size is a power of two. Restriction form the AXI Translation logic
   // Othwerwise we increase the translation size
   if (TranslationSize != (1ULL << Log2Size)) {
-    DEBUG ((EFI_D_WARN, "PCI: The size 0x%lX of the region 0x%lx has been increased to "
+    DEBUG ((DEBUG_WARN, "PCI: The size 0x%lX of the region 0x%lx has been increased to "
                         "be a power of two for the AXI translation table.\n",
                         TranslationSize, SourceAddress));
     Log2Size++;
@@ -148,7 +148,7 @@ HWPciRbInit (
 
   // Check for reset
   if (!(Value & PCIE_CONTROL_RST_STS_RCPHYPLL_OUT)) {
-    DEBUG ((EFI_D_ERROR, "PCIe failed to come out of reset: %x.\n", Value));
+    DEBUG ((DEBUG_ERROR, "PCIe failed to come out of reset: %x.\n", Value));
     return EFI_NOT_READY;
   }
 
@@ -166,7 +166,7 @@ HWPciRbInit (
 
   // Check for link up
   if (!(Value & LINK_UP)) {
-    DEBUG ((EFI_D_ERROR, "PCIe link not up: %x.\n", Value));
+    DEBUG ((DEBUG_ERROR, "PCIe link not up: %x.\n", Value));
     return EFI_NOT_READY;
   }
 

--- a/Platform/ARM/JunoPkg/Library/JunoPciHostBridgeLib/XPressRich3.h
+++ b/Platform/ARM/JunoPkg/Library/JunoPciHostBridgeLib/XPressRich3.h
@@ -22,7 +22,7 @@
 #define PCI_MEM64_BASE      FixedPcdGet64 (PcdPciMmio64Base)
 #define PCI_MEM64_SIZE      FixedPcdGet64 (PcdPciMmio64Size)
 
-#define PCI_TRACE(txt)  DEBUG((EFI_D_VERBOSE, "ARM_PCI: " txt "\n"))
+#define PCI_TRACE(txt)  DEBUG((DEBUG_VERBOSE, "ARM_PCI: " txt "\n"))
 
 #define PCIE_ROOTPORT_WRITE32(Add, Val) { UINT32 Value = (UINT32)(Val); CpuIo->Mem.Write (CpuIo,EfiCpuIoWidthUint32,(UINT64)(PcdGet64 (PcdPcieRootPortBaseAddress)+(Add)),1,&Value); }
 #define PCIE_ROOTPORT_READ32(Add, Val) { CpuIo->Mem.Read (CpuIo,EfiCpuIoWidthUint32,(UINT64)(PcdGet64 (PcdPcieRootPortBaseAddress)+(Add)),1,&Val); }

--- a/Platform/ARM/Library/ArmShellCmdRunAxf/ElfLoader.c
+++ b/Platform/ARM/Library/ArmShellCmdRunAxf/ElfLoader.c
@@ -99,13 +99,13 @@ ElfCheckHeader (
     }
 
     if (Hdr32->e_flags != 0) {
-      DEBUG ((EFI_D_INFO, "Warning: Wrong processor-specific flags, expected 0.\n"));
+      DEBUG ((DEBUG_INFO, "Warning: Wrong processor-specific flags, expected 0.\n"));
     }
 
-    DEBUG ((EFI_D_INFO, "Entry point addr: 0x%lx\n", Hdr32->e_entry));
-    DEBUG ((EFI_D_INFO, "Start of program headers: 0x%lx\n", Hdr32->e_phoff));
-    DEBUG ((EFI_D_INFO, "Size of 1 program header: %d\n", Hdr32->e_phentsize));
-    DEBUG ((EFI_D_INFO, "Number of program headers: %d\n", Hdr32->e_phnum));
+    DEBUG ((DEBUG_INFO, "Entry point addr: 0x%lx\n", Hdr32->e_entry));
+    DEBUG ((DEBUG_INFO, "Start of program headers: 0x%lx\n", Hdr32->e_phoff));
+    DEBUG ((DEBUG_INFO, "Size of 1 program header: %d\n", Hdr32->e_phentsize));
+    DEBUG ((DEBUG_INFO, "Number of program headers: %d\n", Hdr32->e_phnum));
   } else if (Hdr32->e_ident[EI_CLASS] == ELFCLASS64) {
       Elf64_Ehdr *Hdr64 = (Elf64_Ehdr*)Buf;
 
@@ -115,13 +115,13 @@ ElfCheckHeader (
     }
 
     if (Hdr64->e_flags != 0) {
-      DEBUG ((EFI_D_INFO, "Warning: Wrong processor-specific flags, expected 0.\n"));
+      DEBUG ((DEBUG_INFO, "Warning: Wrong processor-specific flags, expected 0.\n"));
     }
 
-    DEBUG ((EFI_D_INFO, "Entry point addr: 0x%lx\n", Hdr64->e_entry));
-    DEBUG ((EFI_D_INFO, "Start of program headers: 0x%lx\n", Hdr64->e_phoff));
-    DEBUG ((EFI_D_INFO, "Size of 1 program header: %d\n", Hdr64->e_phentsize));
-    DEBUG ((EFI_D_INFO, "Number of program headers: %d\n", Hdr64->e_phnum));
+    DEBUG ((DEBUG_INFO, "Entry point addr: 0x%lx\n", Hdr64->e_entry));
+    DEBUG ((DEBUG_INFO, "Start of program headers: 0x%lx\n", Hdr64->e_phoff));
+    DEBUG ((DEBUG_INFO, "Size of 1 program header: %d\n", Hdr64->e_phentsize));
+    DEBUG ((DEBUG_INFO, "Number of program headers: %d\n", Hdr64->e_phnum));
   } else {
     ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_RUNAXF_ELFWRONGCLASS), gRunAxfHiiHandle);
     return EFI_INVALID_PARAMETER;
@@ -177,7 +177,7 @@ ElfLoadSegment (
 
   // Load the segment in memory.
   if (ProgramHdr->p_filesz != 0) {
-    DEBUG ((EFI_D_INFO, "Loading segment from 0x%lx to 0x%lx (size = %ld)\n",
+    DEBUG ((DEBUG_INFO, "Loading segment from 0x%lx to 0x%lx (size = %ld)\n",
                  FileSegment, MemSegment, ProgramHdr->p_filesz));
 
     LoadNode = AllocateRuntimeZeroPool (sizeof (RUNAXF_LOAD_LIST));
@@ -192,7 +192,7 @@ ElfLoadSegment (
 
   ExtraZeroes = ((UINTN)MemSegment + ProgramHdr->p_filesz);
   ExtraZeroesCount = ProgramHdr->p_memsz - ProgramHdr->p_filesz;
-  DEBUG ((EFI_D_INFO, "Completing segment with %d zero bytes.\n", ExtraZeroesCount));
+  DEBUG ((DEBUG_INFO, "Completing segment with %d zero bytes.\n", ExtraZeroesCount));
   if (ExtraZeroesCount > 0) {
     // Extra Node to add the Zeroes.
     LoadNode = AllocateRuntimeZeroPool (sizeof (RUNAXF_LOAD_LIST));
@@ -297,7 +297,7 @@ ElfLoadFile (
   ASSERT (LoadList   != NULL);
 
   ProgramHdr = (UINT8*)ElfImage + ElfHdr->e_phoff;
-  DEBUG ((EFI_D_INFO, "ELF program header entry : 0x%lx\n", ProgramHdr));
+  DEBUG ((DEBUG_INFO, "ELF program header entry : 0x%lx\n", ProgramHdr));
 
   ImageSize = 0;
 

--- a/Platform/ARM/Library/ArmShellCmdRunAxf/RunAxf.c
+++ b/Platform/ARM/Library/ArmShellCmdRunAxf/RunAxf.c
@@ -200,7 +200,7 @@ ShellDynCmdRunAxfHandler (
           TmpChar16 = StrStr (TmpFileName, L".");
           if (TmpChar16 != NULL) {
             *TmpChar16 = '\0';
-            DEBUG((EFI_D_ERROR, "Trying to open file: %s\n", TmpFileName));
+            DEBUG((DEBUG_ERROR, "Trying to open file: %s\n", TmpFileName));
             Status = ShellOpenFileByName (TmpFileName, &FileHandle,
                                           EFI_FILE_MODE_READ, 0);
           }
@@ -288,7 +288,7 @@ ShellDynCmdRunAxfHandler (
     // have access to UEFI functions.
     Status = ShutdownUefiBootServices ();
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR,"Can not shutdown UEFI boot services. Status=0x%X\n",
+      DEBUG ((DEBUG_ERROR,"Can not shutdown UEFI boot services. Status=0x%X\n",
               Status));
     } else {
       // Process linked list. Copy data to Memory.

--- a/Platform/ARM/Morello/Drivers/PlatformDxe/PlatformDxeFvp.c
+++ b/Platform/ARM/Morello/Drivers/PlatformDxe/PlatformDxeFvp.c
@@ -45,7 +45,7 @@ ArmMorelloEntryPoint (
                     );
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "Couldn't find the RAM Disk protocol %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
       return Status;
     }
 
@@ -58,7 +58,7 @@ ArmMorelloEntryPoint (
                         );
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to register RAM Disk - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
     }
   }
 

--- a/Platform/ARM/Morello/Drivers/PlatformDxe/VirtioDevices.c
+++ b/Platform/ARM/Morello/Drivers/PlatformDxe/VirtioDevices.c
@@ -91,7 +91,7 @@ InitVirtioDevices (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to install EFI_DEVICE_PATH protocol "
         "for Virtio Block device (Status = %r)\n",
-        __FUNCTION__, Status));
+        __func__, Status));
     } else {
       // Declare the Virtio BlockIo device
       Status = VirtioMmioInstallDevice (
@@ -100,7 +100,7 @@ InitVirtioDevices (
                  );
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "%a: Unable to find Virtio Block MMIO device "
-          "(Status = %r)\n", __FUNCTION__, Status));
+          "(Status = %r)\n", __func__, Status));
         gBS->UninstallProtocolInterface (
                mVirtIoBlkController,
                &gEfiDevicePathProtocolGuid,
@@ -108,7 +108,7 @@ InitVirtioDevices (
                );
       } else {
         DEBUG ((DEBUG_INIT, "%a: Installed Virtio Block device\n",
-          __FUNCTION__));
+          __func__));
       }
     }
   }
@@ -125,7 +125,7 @@ InitVirtioDevices (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to install EFI_DEVICE_PATH protocol "
         "for Virtio Net (Status = %r)\n",
-        __FUNCTION__, Status));
+        __func__, Status));
     } else {
       // Declare the Virtio Net device
       Status = VirtioMmioInstallDevice (
@@ -134,14 +134,14 @@ InitVirtioDevices (
                  );
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "%a: Unable to find Virtio Block MMIO device "
-          "(Status == %r)\n", __FUNCTION__, Status));
+          "(Status == %r)\n", __func__, Status));
         gBS->UninstallProtocolInterface (
                mVirtIoNetController,
                &gEfiDevicePathProtocolGuid,
                &mVirtioNetDevicePath
                );
       } else {
-        DEBUG ((DEBUG_INIT, "%a: Installed Virtio Net\n", __FUNCTION__));
+        DEBUG ((DEBUG_INIT, "%a: Installed Virtio Net\n", __func__));
       }
     }
   }

--- a/Platform/ARM/N1Sdp/Drivers/PlatformDxe/PlatformDxe.c
+++ b/Platform/ARM/N1Sdp/Drivers/PlatformDxe/PlatformDxe.c
@@ -44,7 +44,7 @@ ArmN1SdpEntryPoint (
       DEBUG ((
         DEBUG_ERROR,
         "%a: Couldn't find the RAM Disk protocol - %r\n",
-        __FUNCTION__,
+        __func__,
         Status
         ));
       return Status;
@@ -60,7 +60,7 @@ ArmN1SdpEntryPoint (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR, "%a: Failed to register RAM Disk - %r\n",
-        __FUNCTION__,
+        __func__,
         Status
         ));
     }

--- a/Platform/ARM/SgiPkg/Drivers/PlatformDxe/PlatformDxe.c
+++ b/Platform/ARM/SgiPkg/Drivers/PlatformDxe/PlatformDxe.c
@@ -91,7 +91,7 @@ ArmSgiPkgEntryPoint (
 
   Status = LocateAndInstallAcpiFromFv (&gArmSgiAcpiTablesGuid);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to install ACPI tables\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to install ACPI tables\n", __func__));
     return Status;
   }
 

--- a/Platform/ARM/SgiPkg/Drivers/PlatformDxe/VirtioDevices.c
+++ b/Platform/ARM/SgiPkg/Drivers/PlatformDxe/VirtioDevices.c
@@ -89,14 +89,14 @@ InitVirtioDevices (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to install EFI_DEVICE_PATH protocol "
         "for Virtio Block device (Status = %r)\n",
-        __FUNCTION__, Status));
+        __func__, Status));
     } else {
       // Declare the Virtio BlockIo device
       Status = VirtioMmioInstallDevice (FixedPcdGet32 (PcdVirtioBlkBaseAddress),
                  mVirtIoBlkController);
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "%a: Unable to find Virtio Block MMIO device "
-          "(Status == %r)\n", __FUNCTION__, Status));
+          "(Status == %r)\n", __func__, Status));
         gBS->UninstallProtocolInterface (
                mVirtIoBlkController,
                &gEfiDevicePathProtocolGuid,
@@ -104,7 +104,7 @@ InitVirtioDevices (
              );
       } else {
         DEBUG ((DEBUG_INIT, "%a: Installed Virtio Block device\n",
-          __FUNCTION__));
+          __func__));
       }
     }
   }
@@ -118,7 +118,7 @@ InitVirtioDevices (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to install EFI_DEVICE_PATH protocol "
         "for Virtio Network device (Status = %r)\n",
-        __FUNCTION__, Status));
+        __func__, Status));
     } else {
       // Declare the Virtio Net device
       Status = VirtioMmioInstallDevice (FixedPcdGet32 (PcdVirtioNetBaseAddress),
@@ -126,7 +126,7 @@ InitVirtioDevices (
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "%a: Unable to find Virtio Network MMIO device "
           "(Status == %r)\n",
-          __FUNCTION__, Status));
+          __func__, Status));
         gBS->UninstallProtocolInterface (
                mVirtIoNetController,
                &gEfiDevicePathProtocolGuid,
@@ -134,7 +134,7 @@ InitVirtioDevices (
             );
       } else {
         DEBUG ((DEBUG_INIT, "%a: Installed Virtio Network device\n",
-          __FUNCTION__));
+          __func__));
       }
     }
   }

--- a/Platform/ARM/VExpressPkg/Drivers/ArmVExpressDxe/ArmFvpDxe.c
+++ b/Platform/ARM/VExpressPkg/Drivers/ArmVExpressDxe/ArmFvpDxe.c
@@ -167,13 +167,13 @@ ArmFvpInitialise (
   // Declare the Virtio BlockIo device
   Status = VirtioMmioInstallDevice (ARM_FVP_BASE_VIRTIO_BLOCK_BASE, ImageHandle);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "ArmFvpDxe: Failed to install Virtio block device\n"));
+    DEBUG ((DEBUG_ERROR, "ArmFvpDxe: Failed to install Virtio block device\n"));
   }
 
   // Install dynamic Shell command to run baremetal binaries.
   Status = ShellDynCmdRunAxfInstall (ImageHandle);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "ArmFvpDxe: Failed to install ShellDynCmdRunAxf\n"));
+    DEBUG ((DEBUG_ERROR, "ArmFvpDxe: Failed to install ShellDynCmdRunAxf\n"));
   }
 
   // If FVP RevC - Configure SMMUv3 to set NS transactions in bypass mode.

--- a/Platform/ARM/VExpressPkg/Drivers/ArmVExpressDxe/ArmHwDxe.c
+++ b/Platform/ARM/VExpressPkg/Drivers/ArmVExpressDxe/ArmHwDxe.c
@@ -25,7 +25,7 @@ ArmHwInitialise (
   // Install dynamic Shell command to run baremetal binaries.
   Status = ShellDynCmdRunAxfInstall (ImageHandle);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "ArmHwDxe: Failed to install ShellDynCmdRunAxf\n"));
+    DEBUG ((DEBUG_ERROR, "ArmHwDxe: Failed to install ShellDynCmdRunAxf\n"));
   }
 
   return Status;

--- a/Platform/ARM/VExpressPkg/Drivers/ArmVExpressFastBootDxe/ArmVExpressFastBoot.c
+++ b/Platform/ARM/VExpressPkg/Drivers/ArmVExpressFastBootDxe/ArmVExpressFastBoot.c
@@ -98,7 +98,7 @@ ReadPartitionEntries (
   // Check there is a GPT on the media
   if (GptHeader->Header.Signature != EFI_PTAB_HEADER_ID ||
       GptHeader->MyLBA != 1) {
-    DEBUG ((EFI_D_ERROR,
+    DEBUG ((DEBUG_ERROR,
       "Fastboot platform: No GPT on flash. "
       "Fastboot on Versatile Express does not support MBR.\n"
       ));
@@ -177,7 +177,7 @@ ArmFastbootPlatformInit (
   FlashDevicePathDup = FlashDevicePath;
   Status = gBS->LocateDevicePath (&gEfiBlockIoProtocolGuid, &FlashDevicePathDup, &FlashHandle);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Warning: Couldn't locate Android NVM device (status: %r)\n", Status));
+    DEBUG ((DEBUG_ERROR, "Warning: Couldn't locate Android NVM device (status: %r)\n", Status));
     // Failing to locate partitions should not prevent to do other Android FastBoot actions
     return EFI_SUCCESS;
   }
@@ -191,14 +191,14 @@ ArmFastbootPlatformInit (
                   EFI_OPEN_PROTOCOL_GET_PROTOCOL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fastboot platform: Couldn't open Android NVM device (status: %r)\n", Status));
+    DEBUG ((DEBUG_ERROR, "Fastboot platform: Couldn't open Android NVM device (status: %r)\n", Status));
     return EFI_DEVICE_ERROR;
   }
 
   // Read the GPT partition entry array into memory so we can get the partition names
   Status = ReadPartitionEntries (FlashBlockIo, &PartitionEntries);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Warning: Failed to read partitions from Android NVM device (status: %r)\n", Status));
+    DEBUG ((DEBUG_ERROR, "Warning: Failed to read partitions from Android NVM device (status: %r)\n", Status));
     // Failing to locate partitions should not prevent to do other Android FastBoot actions
     return EFI_SUCCESS;
   }
@@ -277,7 +277,7 @@ ArmFastbootPlatformInit (
       // Print a debug message if the partition label is empty or looks like
       // garbage.
       if (!IS_ALPHA (Entry->PartitionName[0])) {
-        DEBUG ((EFI_D_ERROR,
+        DEBUG ((DEBUG_ERROR,
           "Warning: Partition %d doesn't seem to have a GPT partition label. "
           "You won't be able to flash it with Fastboot.\n",
           PartitionNode->PartitionNumber
@@ -362,15 +362,15 @@ ArmFastbootPlatformFlashPartition (
                   EFI_OPEN_PROTOCOL_GET_PROTOCOL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fastboot platform: couldn't open Block IO for flash: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Fastboot platform: couldn't open Block IO for flash: %r\n", Status));
     return EFI_NOT_FOUND;
   }
 
   // Check image will fit on device
   PartitionSize = (BlockIo->Media->LastBlock + 1) * BlockIo->Media->BlockSize;
   if (PartitionSize < Size) {
-    DEBUG ((EFI_D_ERROR, "Partition not big enough.\n"));
-    DEBUG ((EFI_D_ERROR, "Partition Size:\t%d\nImage Size:\t%d\n", PartitionSize, Size));
+    DEBUG ((DEBUG_ERROR, "Partition not big enough.\n"));
+    DEBUG ((DEBUG_ERROR, "Partition Size:\t%d\nImage Size:\t%d\n", PartitionSize, Size));
 
     return EFI_VOLUME_FULL;
   }
@@ -477,10 +477,10 @@ ArmFastbootPlatformOemCommand (
   AsciiStrToUnicodeStrS (Command, CommandUnicode, ARRAY_SIZE (CommandUnicode));
 
   if (AsciiStrCmp (Command, "Demonstrate") == 0) {
-    DEBUG ((EFI_D_ERROR, "ARM OEM Fastboot command 'Demonstrate' received.\n"));
+    DEBUG ((DEBUG_ERROR, "ARM OEM Fastboot command 'Demonstrate' received.\n"));
     return EFI_SUCCESS;
   } else {
-    DEBUG ((EFI_D_ERROR,
+    DEBUG ((DEBUG_ERROR,
       "VExpress: Unrecognised Fastboot OEM command: %s\n",
       CommandUnicode
       ));

--- a/Platform/ARM/VExpressPkg/Drivers/Lan9118Dxe/Lan9118Dxe.c
+++ b/Platform/ARM/VExpressPkg/Drivers/Lan9118Dxe/Lan9118Dxe.c
@@ -144,7 +144,7 @@ Lan9118DxeEntry (
   // Power up the device so we can find the MAC address
   Status = Lan9118Initialize (Snp);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "LAN9118: Error initialising hardware\n"));
+    DEBUG ((DEBUG_ERROR, "LAN9118: Error initialising hardware\n"));
     return EFI_DEVICE_ERROR;
   }
 
@@ -275,11 +275,11 @@ SnpInitialize (
 
   // First check that driver has not already been initialized
   if (Snp->Mode->State == EfiSimpleNetworkInitialized) {
-    DEBUG ((EFI_D_WARN, "LAN9118 Driver already initialized\n"));
+    DEBUG ((DEBUG_WARN, "LAN9118 Driver already initialized\n"));
     return EFI_SUCCESS;
   } else
   if (Snp->Mode->State == EfiSimpleNetworkStopped) {
-    DEBUG ((EFI_D_WARN, "LAN9118 Driver not started\n"));
+    DEBUG ((DEBUG_WARN, "LAN9118 Driver not started\n"));
     return EFI_NOT_STARTED;
   }
 
@@ -287,14 +287,14 @@ SnpInitialize (
   Status = PhySoftReset (PHY_RESET_PMT, Snp);
   if (EFI_ERROR (Status)) {
     Snp->Mode->State = EfiSimpleNetworkStopped;
-    DEBUG ((EFI_D_WARN, "Warning: Link not ready after TimeOut. Check ethernet cable\n"));
+    DEBUG ((DEBUG_WARN, "Warning: Link not ready after TimeOut. Check ethernet cable\n"));
     return EFI_NOT_STARTED;
   }
 
   // Initiate a software reset
   Status = SoftReset (0, Snp);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_WARN, "Soft Reset Failed: Hardware Error\n"));
+    DEBUG ((DEBUG_WARN, "Soft Reset Failed: Hardware Error\n"));
     return EFI_DEVICE_ERROR;
   }
 
@@ -343,7 +343,7 @@ SnpInitialize (
   // Do auto-negotiation if supported
   Status = AutoNegotiate (AUTO_NEGOTIATE_ADVERTISE_ALL, Snp);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_WARN, "LAN9118: Auto Negotiation failed.\n"));
+    DEBUG ((DEBUG_WARN, "LAN9118: Auto Negotiation failed.\n"));
   }
 
   // Configure flow control depending on speed capabilities
@@ -394,10 +394,10 @@ SnpReset (
 
   // First check that driver has not already been initialized
   if (Snp->Mode->State == EfiSimpleNetworkStarted) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver not yet initialized\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver not yet initialized\n"));
     return EFI_DEVICE_ERROR;
   } else if (Snp->Mode->State == EfiSimpleNetworkStopped) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver not started\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver not started\n"));
     return EFI_NOT_STARTED;
   }
 
@@ -417,7 +417,7 @@ SnpReset (
 
   Status = SoftReset (ResetFlags, Snp);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_WARN, "Warning: Soft Reset Failed: Hardware Error\n"));
+    DEBUG ((DEBUG_WARN, "Warning: Soft Reset Failed: Hardware Error\n"));
     return EFI_DEVICE_ERROR;
   }
 
@@ -476,10 +476,10 @@ SnpShutdown (
 
   // First check that driver has not already been initialized
   if (Snp->Mode->State == EfiSimpleNetworkStarted) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver not yet initialized\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver not yet initialized\n"));
     return EFI_DEVICE_ERROR;
   } else if (Snp->Mode->State == EfiSimpleNetworkStopped) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver not started\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver not started\n"));
     return EFI_NOT_STARTED;
   }
 
@@ -492,7 +492,7 @@ SnpShutdown (
   // Initiate a software reset
   Status = SoftReset (0, Snp);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_WARN, "Warning: Soft Reset Failed: Hardware Error\n"));
+    DEBUG ((DEBUG_WARN, "Warning: Soft Reset Failed: Hardware Error\n"));
     return Status;
   }
 
@@ -572,10 +572,10 @@ SnpReceiveFilters (
 
   // Check that driver was started and initialised
   if (Mode->State == EfiSimpleNetworkStarted) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver not initialized\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver not initialized\n"));
     return EFI_DEVICE_ERROR;
   } else if (Mode->State == EfiSimpleNetworkStopped) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver in stopped state\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver in stopped state\n"));
     return EFI_NOT_STARTED;
   }
 
@@ -748,10 +748,10 @@ SnpStationAddress (
 
   // Check that driver was started and initialised
   if (Snp->Mode->State == EfiSimpleNetworkStarted) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver not initialized\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver not initialized\n"));
     return EFI_DEVICE_ERROR;
   } else if (Snp->Mode->State == EfiSimpleNetworkStopped) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver in stopped state\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver in stopped state\n"));
     return EFI_NOT_STARTED;
   }
 
@@ -765,7 +765,7 @@ SnpStationAddress (
       New = (EFI_MAC_ADDRESS *) PermAddr;
       Lan9118SetMacAddress ((EFI_MAC_ADDRESS *) PermAddr, Snp);
     } else {
-      DEBUG ((EFI_D_ERROR, "LAN9118: Warning: No valid MAC address in EEPROM, using fallback\n"));
+      DEBUG ((DEBUG_ERROR, "LAN9118: Warning: No valid MAC address in EEPROM, using fallback\n"));
       New = (EFI_MAC_ADDRESS*) (FixedPcdGet64 (PcdLan9118DefaultMacAddress));
     }
   } else {
@@ -826,10 +826,10 @@ SnpStatistics (
 
   // Check that driver was started and initialised
   if (Snp->Mode->State == EfiSimpleNetworkStarted) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver not initialized\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver not initialized\n"));
     return EFI_DEVICE_ERROR;
   } else if (Snp->Mode->State == EfiSimpleNetworkStopped) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver in stopped state\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver in stopped state\n"));
     return EFI_NOT_STARTED;
   }
 
@@ -890,10 +890,10 @@ SnpMcastIptoMac (
 
   // Check that driver was started and initialised
   if (Snp->Mode->State == EfiSimpleNetworkStarted) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver not initialized\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver not initialized\n"));
     return EFI_DEVICE_ERROR;
   } else if (Snp->Mode->State == EfiSimpleNetworkStopped) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver in stopped state\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver in stopped state\n"));
     return EFI_NOT_STARTED;
   }
 
@@ -982,10 +982,10 @@ SnpGetStatus (
 
   // Check that driver was started and initialised
   if (Snp->Mode->State == EfiSimpleNetworkStarted) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver not initialized\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver not initialized\n"));
     return EFI_DEVICE_ERROR;
   } else if (Snp->Mode->State == EfiSimpleNetworkStopped) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver in stopped state\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver in stopped state\n"));
     return EFI_NOT_STARTED;
   }
 
@@ -1033,24 +1033,24 @@ SnpGetStatus (
     PacketTag = TxStatus >> 16;
     TxStatus = TxStatus & 0xFFFF;
     if ((TxStatus & TXSTATUS_ES) && (TxStatus != (TXSTATUS_ES | TXSTATUS_NO_CA))) {
-      DEBUG ((EFI_D_ERROR, "LAN9118: There was an error transmitting. TxStatus=0x%08x:", TxStatus));
+      DEBUG ((DEBUG_ERROR, "LAN9118: There was an error transmitting. TxStatus=0x%08x:", TxStatus));
       if (TxStatus & TXSTATUS_NO_CA) {
-        DEBUG ((EFI_D_ERROR, "- No carrier\n"));
+        DEBUG ((DEBUG_ERROR, "- No carrier\n"));
       }
       if (TxStatus & TXSTATUS_DEF) {
-        DEBUG ((EFI_D_ERROR, "- Packet tx was deferred\n"));
+        DEBUG ((DEBUG_ERROR, "- Packet tx was deferred\n"));
       }
       if (TxStatus & TXSTATUS_EDEF) {
-        DEBUG ((EFI_D_ERROR, "- Tx ended because of excessive deferral\n"));
+        DEBUG ((DEBUG_ERROR, "- Tx ended because of excessive deferral\n"));
       }
       if (TxStatus & TXSTATUS_ECOLL) {
-        DEBUG ((EFI_D_ERROR, "- Tx ended because of Excessive Collisions\n"));
+        DEBUG ((DEBUG_ERROR, "- Tx ended because of Excessive Collisions\n"));
       }
       if (TxStatus & TXSTATUS_LCOLL) {
-        DEBUG ((EFI_D_ERROR, "- Packet Tx aborted after coll window of 64 bytes\n"));
+        DEBUG ((DEBUG_ERROR, "- Packet Tx aborted after coll window of 64 bytes\n"));
       }
       if (TxStatus & TXSTATUS_LOST_CA) {
-        DEBUG ((EFI_D_ERROR, "- Lost carrier during Tx\n"));
+        DEBUG ((DEBUG_ERROR, "- Lost carrier during Tx\n"));
       }
       return EFI_DEVICE_ERROR;
     } else if (TxBuff != NULL) {
@@ -1064,12 +1064,12 @@ SnpGetStatus (
   // Check for a TX Error interrupt
   Interrupts = Lan9118MmioRead32 (LAN9118_INT_STS);
   if (Interrupts & INSTS_TXE) {
-    DEBUG ((EFI_D_ERROR, "LAN9118: Transmitter error. Restarting..."));
+    DEBUG ((DEBUG_ERROR, "LAN9118: Transmitter error. Restarting..."));
 
     // Software reset, the TXE interrupt is cleared by the reset.
     Status = SoftReset (0, Snp);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "\n\tSoft Reset Failed: Hardware Error\n"));
+      DEBUG ((DEBUG_ERROR, "\n\tSoft Reset Failed: Hardware Error\n"));
       return EFI_DEVICE_ERROR;
     }
 
@@ -1146,10 +1146,10 @@ SnpTransmit (
 
   // Check that driver was started and initialised
   if (Snp->Mode->State == EfiSimpleNetworkStarted) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver not initialized\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver not initialized\n"));
     return EFI_DEVICE_ERROR;
   } else if (Snp->Mode->State == EfiSimpleNetworkStopped) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver in stopped state\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver in stopped state\n"));
     return EFI_NOT_STARTED;
   }
 
@@ -1284,7 +1284,7 @@ SnpTransmit (
 
 #if defined(EVAL_PERFORMANCE)
   EndClock = GetPerformanceCounter ();
-  DEBUG ((EFI_D_ERROR, "Time processing: %d counts @ %d Hz\n", StartClock - EndClock,Perf));
+  DEBUG ((DEBUG_ERROR, "Time processing: %d counts @ %d Hz\n", StartClock - EndClock,Perf));
 #endif
 
   LanDriver->Stats.TxGoodFrames += 1;
@@ -1338,10 +1338,10 @@ SnpReceive (
 
   // Check that driver was started and initialised
   if (Snp->Mode->State == EfiSimpleNetworkStarted) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver not initialized\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver not initialized\n"));
     return EFI_DEVICE_ERROR;
   } else if (Snp->Mode->State == EfiSimpleNetworkStopped) {
-    DEBUG ((EFI_D_WARN, "Warning: LAN9118 Driver in stopped state\n"));
+    DEBUG ((DEBUG_WARN, "Warning: LAN9118 Driver in stopped state\n"));
     return EFI_NOT_STARTED;
   }
 
@@ -1387,13 +1387,13 @@ SnpReceive (
       (RxFifoStatus & RXSTATUS_LE) ||
       (RxFifoStatus & RXSTATUS_DB))
   {
-    DEBUG ((EFI_D_WARN, "Warning: There was an error on frame reception.\n"));
+    DEBUG ((DEBUG_WARN, "Warning: There was an error on frame reception.\n"));
     return EFI_DEVICE_ERROR;
   }
 
   // Check if we got a CRC error
   if (RxFifoStatus & RXSTATUS_CRC_ERROR) {
-    DEBUG ((EFI_D_WARN, "Warning: Crc Error\n"));
+    DEBUG ((DEBUG_WARN, "Warning: Crc Error\n"));
     LanDriver->Stats.RxCrcErrorFrames += 1;
     LanDriver->Stats.RxDroppedFrames += 1;
     return EFI_DEVICE_ERROR;
@@ -1401,7 +1401,7 @@ SnpReceive (
 
   // Check if we got a runt frame
   if (RxFifoStatus & RXSTATUS_RUNT) {
-    DEBUG ((EFI_D_WARN, "Warning: Runt Frame\n"));
+    DEBUG ((DEBUG_WARN, "Warning: Runt Frame\n"));
     LanDriver->Stats.RxUndersizeFrames += 1;
     LanDriver->Stats.RxDroppedFrames += 1;
     return EFI_DEVICE_ERROR;
@@ -1409,7 +1409,7 @@ SnpReceive (
 
   // Check filtering status for this packet
   if (RxFifoStatus & RXSTATUS_FILT_FAIL) {
-    DEBUG ((EFI_D_WARN, "Warning: Frame Failed Filtering\n"));
+    DEBUG ((DEBUG_WARN, "Warning: Frame Failed Filtering\n"));
     // fast forward?
   }
 
@@ -1502,12 +1502,12 @@ SnpReceive (
 
   // Check for Rx errors (worst possible error)
   if (Lan9118MmioRead32 (LAN9118_INT_STS) & INSTS_RXE) {
-    DEBUG ((EFI_D_WARN, "Warning: Receiver Error. Restarting...\n"));
+    DEBUG ((DEBUG_WARN, "Warning: Receiver Error. Restarting...\n"));
 
     // Software reset, the RXE interrupt is cleared by the reset.
     Status = SoftReset (0, Snp);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Error: Soft Reset Failed: Hardware Error.\n"));
+      DEBUG ((DEBUG_ERROR, "Error: Soft Reset Failed: Hardware Error.\n"));
       return EFI_DEVICE_ERROR;
     }
 
@@ -1530,7 +1530,7 @@ SnpReceive (
 
 #if defined(EVAL_PERFORMANCE)
   UINT64 EndClock = GetPerformanceCounter ();
-  DEBUG ((EFI_D_ERROR, "Receive Time processing: %d counts @ %d Hz\n", StartClock - EndClock,Perf));
+  DEBUG ((DEBUG_ERROR, "Receive Time processing: %d counts @ %d Hz\n", StartClock - EndClock,Perf));
 #endif
 
   LanDriver->Stats.RxGoodFrames += 1;

--- a/Platform/ARM/VExpressPkg/Drivers/Lan9118Dxe/Lan9118DxeUtil.c
+++ b/Platform/ARM/VExpressPkg/Drivers/Lan9118Dxe/Lan9118DxeUtil.c
@@ -291,7 +291,7 @@ IndirectEEPROMRead32 (
 
   // Check that operation didn't time out
   if (Lan9118MmioRead32 (LAN9118_E2P_CMD) & E2P_EPC_TIMEOUT) {
-    DEBUG ((EFI_D_ERROR, "EEPROM Operation Timed out: Read command on index %x\n",Index));
+    DEBUG ((DEBUG_ERROR, "EEPROM Operation Timed out: Read command on index %x\n",Index));
     return 0;
   }
 
@@ -338,7 +338,7 @@ IndirectEEPROMWrite32 (
 
   // Check that operation didn't time out
   if (Lan9118MmioRead32 (LAN9118_E2P_CMD) & E2P_EPC_TIMEOUT) {
-    DEBUG ((EFI_D_ERROR, "EEPROM Operation Timed out: Write command at memloc 0x%x, with value 0x%x\n",Index, Value));
+    DEBUG ((DEBUG_ERROR, "EEPROM Operation Timed out: Write command at memloc 0x%x, with value 0x%x\n",Index, Value));
     return 0;
   }
 
@@ -432,14 +432,14 @@ Lan9118Initialize (
   // Check if a MAC address was loaded from EEPROM, and if it was, set it as the
   // current address.
   if ((Lan9118MmioRead32 (LAN9118_E2P_CMD) & E2P_EPC_MAC_ADDRESS_LOADED) == 0) {
-    DEBUG ((EFI_D_ERROR, "Warning: There was an error detecting EEPROM or loading the MAC Address.\n"));
+    DEBUG ((DEBUG_ERROR, "Warning: There was an error detecting EEPROM or loading the MAC Address.\n"));
 
     // If we had an address before (set by StationAddress), continue to use it
     if (CompareMem (&Snp->Mode->CurrentAddress, &mZeroMac, NET_ETHER_ADDR_LEN)) {
       Lan9118SetMacAddress (&Snp->Mode->CurrentAddress, Snp);
     } else {
       // If there are no cached addresses, then fall back to a default
-      DEBUG ((EFI_D_WARN, "Warning: using driver-default MAC address\n"));
+      DEBUG ((DEBUG_WARN, "Warning: using driver-default MAC address\n"));
       DefaultMacAddress = FixedPcdGet64 (PcdLan9118DefaultMacAddress);
       Lan9118SetMacAddress((EFI_MAC_ADDRESS *) &DefaultMacAddress, Snp);
       CopyMem (&Snp->Mode->CurrentAddress, &DefaultMacAddress, NET_ETHER_ADDR_LEN);
@@ -620,7 +620,7 @@ AutoNegotiate (
   // First check that auto-negotiation is supported
   PhyStatus = IndirectPHYRead32 (PHY_INDEX_BASIC_STATUS);
   if ((PhyStatus & PHYSTS_AUTO_CAP) == 0) {
-    DEBUG ((EFI_D_ERROR, "Auto-negotiation not supported.\n"));
+    DEBUG ((DEBUG_ERROR, "Auto-negotiation not supported.\n"));
     return EFI_DEVICE_ERROR;
   }
 
@@ -632,7 +632,7 @@ AutoNegotiate (
       gBS->Stall (LAN9118_STALL);
       Retries--;
       if (!Retries) {
-        DEBUG ((EFI_D_ERROR, "Link timeout in auto-negotiation.\n"));
+        DEBUG ((DEBUG_ERROR, "Link timeout in auto-negotiation.\n"));
         return EFI_TIMEOUT;
       }
     }

--- a/Platform/ARM/VExpressPkg/Drivers/PL180MciDxe/PL180Mci.c
+++ b/Platform/ARM/VExpressPkg/Drivers/PL180MciDxe/PL180Mci.c
@@ -171,10 +171,10 @@ MciSendCommand (
     MmioWrite32 (MCI_CLEAR_STATUS_REG, MCI_STATUS_CMD_ERROR);
 
     if ((Status & MCI_STATUS_CMD_START_BIT_ERROR)) {
-      DEBUG ((EFI_D_ERROR, "MciSendCommand(CmdIndex:%d) Start bit Error! Response:0x%X Status:0x%x\n", (Cmd & 0x3F), MmioRead32 (MCI_RESPONSE0_REG), Status));
+      DEBUG ((DEBUG_ERROR, "MciSendCommand(CmdIndex:%d) Start bit Error! Response:0x%X Status:0x%x\n", (Cmd & 0x3F), MmioRead32 (MCI_RESPONSE0_REG), Status));
       RetVal = EFI_NO_RESPONSE;
     } else if ((Status & MCI_STATUS_CMD_CMDTIMEOUT)) {
-      //DEBUG ((EFI_D_ERROR, "MciSendCommand(CmdIndex:%d) TIMEOUT! Response:0x%X Status:0x%x\n", (Cmd & 0x3F), MmioRead32 (MCI_RESPONSE0_REG), Status));
+      //DEBUG ((DEBUG_ERROR, "MciSendCommand(CmdIndex:%d) TIMEOUT! Response:0x%X Status:0x%x\n", (Cmd & 0x3F), MmioRead32 (MCI_RESPONSE0_REG), Status));
       RetVal = EFI_TIMEOUT;
     } else if ((!(MmcCmd & MMC_CMD_NO_CRC_RESPONSE)) && (Status & MCI_STATUS_CMD_CMDCRCFAIL)) {
       // The CMD1 and response type R3 do not contain CRC. We should ignore the CRC failed Status.
@@ -272,15 +272,15 @@ MciReadBlockData (
     } else {
       //Check for error conditions and timeouts
       if (Status & MCI_STATUS_CMD_DATATIMEOUT) {
-        DEBUG ((EFI_D_ERROR, "MciReadBlockData(): TIMEOUT! Response:0x%X Status:0x%x\n", MmioRead32 (MCI_RESPONSE0_REG), Status));
+        DEBUG ((DEBUG_ERROR, "MciReadBlockData(): TIMEOUT! Response:0x%X Status:0x%x\n", MmioRead32 (MCI_RESPONSE0_REG), Status));
         RetVal = EFI_TIMEOUT;
         break;
       } else if (Status & MCI_STATUS_CMD_DATACRCFAIL) {
-        DEBUG ((EFI_D_ERROR, "MciReadBlockData(): CRC Error! Response:0x%X Status:0x%x\n", MmioRead32 (MCI_RESPONSE0_REG), Status));
+        DEBUG ((DEBUG_ERROR, "MciReadBlockData(): CRC Error! Response:0x%X Status:0x%x\n", MmioRead32 (MCI_RESPONSE0_REG), Status));
         RetVal = EFI_CRC_ERROR;
         break;
       } else if (Status & MCI_STATUS_CMD_START_BIT_ERROR) {
-        DEBUG ((EFI_D_ERROR, "MciReadBlockData(): Start-bit Error! Response:0x%X Status:0x%x\n", MmioRead32 (MCI_RESPONSE0_REG), Status));
+        DEBUG ((DEBUG_ERROR, "MciReadBlockData(): Start-bit Error! Response:0x%X Status:0x%x\n", MmioRead32 (MCI_RESPONSE0_REG), Status));
         RetVal = EFI_NO_RESPONSE;
         break;
       }
@@ -358,15 +358,15 @@ MciWriteBlockData (
     } else {
       // Check for error conditions and timeouts
       if (Status & MCI_STATUS_CMD_DATATIMEOUT) {
-        DEBUG ((EFI_D_ERROR, "MciWriteBlockData(): TIMEOUT! Response:0x%X Status:0x%x\n", MmioRead32 (MCI_RESPONSE0_REG), Status));
+        DEBUG ((DEBUG_ERROR, "MciWriteBlockData(): TIMEOUT! Response:0x%X Status:0x%x\n", MmioRead32 (MCI_RESPONSE0_REG), Status));
         RetVal = EFI_TIMEOUT;
         goto Exit;
       } else if (Status & MCI_STATUS_CMD_DATACRCFAIL) {
-        DEBUG ((EFI_D_ERROR, "MciWriteBlockData(): CRC Error! Response:0x%X Status:0x%x\n", MmioRead32 (MCI_RESPONSE0_REG), Status));
+        DEBUG ((DEBUG_ERROR, "MciWriteBlockData(): CRC Error! Response:0x%X Status:0x%x\n", MmioRead32 (MCI_RESPONSE0_REG), Status));
         RetVal = EFI_CRC_ERROR;
         goto Exit;
       } else if (Status & MCI_STATUS_CMD_TX_UNDERRUN) {
-        DEBUG ((EFI_D_ERROR, "MciWriteBlockData(): TX buffer Underrun! Response:0x%X Status:0x%x, Number of bytes written 0x%x\n",MmioRead32(MCI_RESPONSE0_REG),Status, Loop));
+        DEBUG ((DEBUG_ERROR, "MciWriteBlockData(): TX buffer Underrun! Response:0x%X Status:0x%x, Number of bytes written 0x%x\n",MmioRead32(MCI_RESPONSE0_REG),Status, Loop));
         RetVal = EFI_BUFFER_TOO_SMALL;
         ASSERT(0);
         goto Exit;
@@ -396,7 +396,7 @@ MciWriteBlockData (
   MmioWrite32 (MCI_CLEAR_STATUS_REG, MCI_CLR_ALL_STATUS);
 
   if (Timer == 0) {
-    DEBUG ((EFI_D_ERROR, "MciWriteBlockData(): Data End timeout Number of words written 0x%x\n", Loop));
+    DEBUG ((DEBUG_ERROR, "MciWriteBlockData(): Data End timeout Number of words written 0x%x\n", Loop));
     RetVal = EFI_TIMEOUT;
   }
 
@@ -537,7 +537,7 @@ PL180MciDxeInitialize (
   EFI_STATUS    Status;
   EFI_HANDLE    Handle;
 
-  DEBUG ((EFI_D_WARN, "Probing ID registers at 0x%lx for a PL180\n",
+  DEBUG ((DEBUG_WARN, "Probing ID registers at 0x%lx for a PL180\n",
     MCI_PERIPH_ID_REG0));
 
   // Check if this is a PL180
@@ -549,7 +549,7 @@ PL180MciDxeInitialize (
       MmioRead8 (MCI_PCELL_ID_REG2)  != MCI_PCELL_ID2  ||
       MmioRead8 (MCI_PCELL_ID_REG3)  != MCI_PCELL_ID3) {
 
-    DEBUG ((EFI_D_WARN, "Probing ID registers at 0x%lx for a PL180"
+    DEBUG ((DEBUG_WARN, "Probing ID registers at 0x%lx for a PL180"
       " failed\n", MCI_PERIPH_ID_REG0));
     return EFI_NOT_FOUND;
   }

--- a/Platform/ARM/VExpressPkg/Drivers/PL180MciDxe/PL180Mci.h
+++ b/Platform/ARM/VExpressPkg/Drivers/PL180MciDxe/PL180Mci.h
@@ -146,7 +146,7 @@
 #define MCI_CPSM_LONG_PENDING           BIT9
 #define MCI_CPSM_ENABLE                 BIT10
 
-#define MCI_TRACE(txt)                  DEBUG ((EFI_D_BLKIO, "ARM_MCI: " txt "\n"))
+#define MCI_TRACE(txt)                  DEBUG ((DEBUG_BLKIO, "ARM_MCI: " txt "\n"))
 
 EFI_STATUS
 EFIAPI

--- a/Platform/Ampere/JadePkg/Drivers/AcpiPlatformDxe/AcpiApei.c
+++ b/Platform/Ampere/JadePkg/Drivers/AcpiPlatformDxe/AcpiApei.c
@@ -34,13 +34,13 @@ AcpiApeiUninstallTable (
    */
   Status = gBS->LocateProtocol (&gEfiAcpiTableProtocolGuid, NULL, (VOID **)&AcpiTableProtocol);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a:%d: Unable to locate ACPI table protocol\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "%a:%d: Unable to locate ACPI table protocol\n", __func__, __LINE__));
     return;
   }
 
   Status = gBS->LocateProtocol (&gEfiAcpiSdtProtocolGuid, NULL, (VOID **)&AcpiTableSdtProtocol);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a:%d: Unable to locate ACPI table support protocol\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "%a:%d: Unable to locate ACPI table support protocol\n", __func__, __LINE__));
     return;
   }
 
@@ -56,7 +56,7 @@ AcpiApeiUninstallTable (
              &TableKey
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a:%d Unable to get ACPI table\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "%a:%d Unable to get ACPI table\n", __func__, __LINE__));
     return;
   }
 
@@ -65,7 +65,7 @@ AcpiApeiUninstallTable (
    */
   Status = AcpiTableProtocol->UninstallAcpiTable (AcpiTableProtocol, TableKey);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a:%d: Unable to uninstall table\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "%a:%d: Unable to uninstall table\n", __func__, __LINE__));
   }
 }
 
@@ -102,7 +102,7 @@ AdjustBERTRegionLen (
              &TableKey
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a:%d Unable to get ACPI BERT table\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "%a:%d Unable to get ACPI BERT table\n", __func__, __LINE__));
     return;
   }
 
@@ -401,7 +401,7 @@ AcpiApeiHestUpdateTable1P (
              &TableKey
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a:%d Unable to get ACPI HEST table\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "%a:%d Unable to get ACPI HEST table\n", __func__, __LINE__));
     return;
   }
 

--- a/Platform/Ampere/JadePkg/Drivers/AcpiPlatformDxe/AcpiPcct.c
+++ b/Platform/Ampere/JadePkg/Drivers/AcpiPlatformDxe/AcpiPcct.c
@@ -242,7 +242,7 @@ PcctAdvertiseSharedMemoryAddress (
 
   Status = MailboxMsgSetPccSharedMem (Socket, Doorbell, TRUE, (UINT64)PccSharedMemoryRegion);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to send mailbox message!\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to send mailbox message!\n", __func__));
     ASSERT_EFI_ERROR (Status);
     return Status;
   }
@@ -253,7 +253,7 @@ PcctAdvertiseSharedMemoryAddress (
   Timeout = PCC_COMMAND_POLL_COUNT;
   while (PccSharedMemoryRegion->Status.CommandComplete != 1) {
     if (--Timeout <= 0) {
-      DEBUG ((DEBUG_ERROR, "%a - Timeout occurred when polling the PCC Status Complete\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a - Timeout occurred when polling the PCC Status Complete\n", __func__));
       return EFI_TIMEOUT;
     }
     MicroSecondDelay (PCC_COMMAND_POLL_INTERVAL_US);

--- a/Platform/Ampere/JadePkg/Drivers/AcpiPlatformDxe/AcpiPlatformDxe.c
+++ b/Platform/Ampere/JadePkg/Drivers/AcpiPlatformDxe/AcpiPlatformDxe.c
@@ -57,7 +57,7 @@ AcpiNotificationEvent (
     Rsdp->RsdtAddress = 0;
   }
 
-  DEBUG ((DEBUG_INFO, "[%a:%d]-\n", __FUNCTION__, __LINE__));
+  DEBUG ((DEBUG_INFO, "[%a:%d]-\n", __func__, __LINE__));
 }
 
 VOID

--- a/Platform/Ampere/JadePkg/Drivers/PciPlatformDxe/PciPlatformDxe.c
+++ b/Platform/Ampere/JadePkg/Drivers/PciPlatformDxe/PciPlatformDxe.c
@@ -120,7 +120,7 @@ PhaseNotify (
                     (VOID **)&RootBridgeDevPath
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a %d: Failed to locate RootBridge DevicePath\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "%a %d: Failed to locate RootBridge DevicePath\n", __func__, __LINE__));
       break;
     }
 

--- a/Platform/Ampere/JadePkg/Drivers/SmbiosMemInfoDxe/SmbiosMemInfoDxe.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosMemInfoDxe/SmbiosMemInfoDxe.c
@@ -538,7 +538,7 @@ InstallMemStructures (
                        (EFI_SMBIOS_TABLE_HEADER *)Table
                        );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: adding SMBIOS type 16 socket %d failed\n", __FUNCTION__, Index));
+      DEBUG ((DEBUG_ERROR, "%a: adding SMBIOS type 16 socket %d failed\n", __func__, Index));
       FreePool (Table);
       // stop adding rather than continuing
       return Status;
@@ -611,7 +611,7 @@ InstallMemStructures (
         DEBUG ((
           DEBUG_ERROR,
           "%a: adding SMBIOS type 17 Socket %d Slot %d failed\n",
-          __FUNCTION__,
+          __func__,
           Index,
           SlotIndex
           ));
@@ -656,7 +656,7 @@ InstallMemStructures (
         DEBUG ((
           DEBUG_ERROR,
           "%a: adding SMBIOS type 19 Socket %d MemRegion %d failed\n",
-          __FUNCTION__,
+          __func__,
           Index,
           MemRegionIndex
           ));

--- a/Platform/Ampere/JadePkg/Library/PCF85063RealTimeClockLib/PCF85063.c
+++ b/Platform/Ampere/JadePkg/Library/PCF85063RealTimeClockLib/PCF85063.c
@@ -82,7 +82,7 @@ RtcI2cWaitAccess (
   }
 
   if (Timeout <= 0) {
-    DEBUG ((DEBUG_ERROR, "%a: Timeout while waiting access RTC\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Timeout while waiting access RTC\n", __func__));
     return EFI_TIMEOUT;
   }
 
@@ -293,7 +293,7 @@ PlatformInitialize (
     DEBUG ((
       DEBUG_ERROR,
       "%a:%d I2cSetupRuntime() failed - %r \n",
-      __FUNCTION__,
+      __func__,
       __LINE__,
       Status
       ));
@@ -306,7 +306,7 @@ PlatformInitialize (
     DEBUG ((
       DEBUG_ERROR,
       "%a:%d GpioSetupRuntime() failed - %r \n",
-      __FUNCTION__,
+      __func__,
       __LINE__,
       Status
       ));

--- a/Platform/BeagleBoard/BeagleBoardPkg/Library/MemoryInitPeiLib/MemoryInitPeiLib.c
+++ b/Platform/BeagleBoard/BeagleBoardPkg/Library/MemoryInitPeiLib/MemoryInitPeiLib.c
@@ -35,7 +35,7 @@ InitMmu (
   //      DRAM (even at the top of DRAM as it is the first permanent memory allocation)
   Status = ArmConfigureMmu (MemoryTable, &TranslationTableBase, &TranslationTableSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Error: Failed to enable MMU\n"));
+    DEBUG ((DEBUG_ERROR, "Error: Failed to enable MMU\n"));
   }
 }
 

--- a/Platform/Hisilicon/D03/Drivers/OemNicConfig2PHi1610/OemNicConfig2P.c
+++ b/Platform/Hisilicon/D03/Drivers/OemNicConfig2PHi1610/OemNicConfig2P.c
@@ -111,7 +111,7 @@ EFI_STATUS OemGetMacE2prom(IN UINT32 Port, OUT UINT8 *pucAddr)
     Status = I2CInit(0, EEPROM_I2C_PORT, Normal);
     if (EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Call I2CInit failed! p1=0x%x.\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Call I2CInit failed! p1=0x%x.\n", __func__, __LINE__, Status));
         return Status;
     }
 
@@ -142,7 +142,7 @@ EFI_STATUS OemGetMacE2prom(IN UINT32 Port, OUT UINT8 *pucAddr)
     }
     if (EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Call I2cRead failed! p1=0x%x.\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Call I2cRead failed! p1=0x%x.\n", __func__, __LINE__, Status));
         return Status;
     }
 
@@ -177,7 +177,7 @@ EFI_STATUS OemSetMacE2prom(IN UINT32 Port, IN UINT8 *pucAddr)
     Status = I2CInit(0, EEPROM_I2C_PORT, Normal);
     if (EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Call I2CInit failed! p1=0x%x.\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Call I2CInit failed! p1=0x%x.\n", __func__, __LINE__, Status));
         return Status;
     }
 
@@ -208,7 +208,7 @@ EFI_STATUS OemSetMacE2prom(IN UINT32 Port, IN UINT8 *pucAddr)
     }
     if (EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Call I2cWrite failed! p1=0x%x.\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Call I2cWrite failed! p1=0x%x.\n", __func__, __LINE__, Status));
         return Status;
     }
     return EFI_SUCCESS;
@@ -224,14 +224,14 @@ EFIAPI OemGetMac2P (
 
     if (NULL == Mac)
     {
-      DEBUG((DEBUG_ERROR, "[%a]:[%dL] Mac buffer is null!\n", __FUNCTION__, __LINE__));
+      DEBUG((DEBUG_ERROR, "[%a]:[%dL] Mac buffer is null!\n", __func__, __LINE__));
       return EFI_INVALID_PARAMETER;
     }
 
     Status = OemGetMacE2prom(Port, Mac->Addr);
     if ((EFI_ERROR(Status)))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Get mac failed!\n", __FUNCTION__, __LINE__));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Get mac failed!\n", __func__, __LINE__));
 
         Mac->Addr[0] = 0x00;
         Mac->Addr[1] = 0x18;
@@ -255,14 +255,14 @@ EFIAPI OemSetMac2P (
 
   if (NULL == Mac)
   {
-    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Mac buffer is null!\n", __FUNCTION__, __LINE__));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Mac buffer is null!\n", __func__, __LINE__));
     return EFI_INVALID_PARAMETER;
   }
 
   Status = OemSetMacE2prom(Port, Mac->Addr);
   if ((EFI_ERROR(Status)))
   {
-      DEBUG((DEBUG_ERROR, "[%a]:[%dL] Set mac failed!\n", __FUNCTION__, __LINE__));
+      DEBUG((DEBUG_ERROR, "[%a]:[%dL] Set mac failed!\n", __func__, __LINE__));
       return Status;
   }
 
@@ -334,7 +334,7 @@ OemNicConfigEntry (
 
   if(EFI_ERROR(Status))
   {
-    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Install Protocol failed %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Install Protocol failed %r\n", __func__, __LINE__, Status));
     return Status;
   }
 
@@ -347,7 +347,7 @@ OemNicConfigEntry (
 
   if(EFI_ERROR(Status))
   {
-    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Install Protocol failed %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Install Protocol failed %r\n", __func__, __LINE__, Status));
     return Status;
   }
 

--- a/Platform/Hisilicon/D03/Drivers/OemNicConfig2PHi1610/OemNicConfig2P.c
+++ b/Platform/Hisilicon/D03/Drivers/OemNicConfig2PHi1610/OemNicConfig2P.c
@@ -111,7 +111,7 @@ EFI_STATUS OemGetMacE2prom(IN UINT32 Port, OUT UINT8 *pucAddr)
     Status = I2CInit(0, EEPROM_I2C_PORT, Normal);
     if (EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Call I2CInit failed! p1=0x%x.\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Call I2CInit failed! p1=0x%x.\n", __FUNCTION__, __LINE__, Status));
         return Status;
     }
 
@@ -142,7 +142,7 @@ EFI_STATUS OemGetMacE2prom(IN UINT32 Port, OUT UINT8 *pucAddr)
     }
     if (EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Call I2cRead failed! p1=0x%x.\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Call I2cRead failed! p1=0x%x.\n", __FUNCTION__, __LINE__, Status));
         return Status;
     }
 
@@ -177,7 +177,7 @@ EFI_STATUS OemSetMacE2prom(IN UINT32 Port, IN UINT8 *pucAddr)
     Status = I2CInit(0, EEPROM_I2C_PORT, Normal);
     if (EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Call I2CInit failed! p1=0x%x.\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Call I2CInit failed! p1=0x%x.\n", __FUNCTION__, __LINE__, Status));
         return Status;
     }
 
@@ -208,7 +208,7 @@ EFI_STATUS OemSetMacE2prom(IN UINT32 Port, IN UINT8 *pucAddr)
     }
     if (EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Call I2cWrite failed! p1=0x%x.\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Call I2cWrite failed! p1=0x%x.\n", __FUNCTION__, __LINE__, Status));
         return Status;
     }
     return EFI_SUCCESS;
@@ -224,14 +224,14 @@ EFIAPI OemGetMac2P (
 
     if (NULL == Mac)
     {
-      DEBUG((EFI_D_ERROR, "[%a]:[%dL] Mac buffer is null!\n", __FUNCTION__, __LINE__));
+      DEBUG((DEBUG_ERROR, "[%a]:[%dL] Mac buffer is null!\n", __FUNCTION__, __LINE__));
       return EFI_INVALID_PARAMETER;
     }
 
     Status = OemGetMacE2prom(Port, Mac->Addr);
     if ((EFI_ERROR(Status)))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Get mac failed!\n", __FUNCTION__, __LINE__));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Get mac failed!\n", __FUNCTION__, __LINE__));
 
         Mac->Addr[0] = 0x00;
         Mac->Addr[1] = 0x18;
@@ -255,14 +255,14 @@ EFIAPI OemSetMac2P (
 
   if (NULL == Mac)
   {
-    DEBUG((EFI_D_ERROR, "[%a]:[%dL] Mac buffer is null!\n", __FUNCTION__, __LINE__));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Mac buffer is null!\n", __FUNCTION__, __LINE__));
     return EFI_INVALID_PARAMETER;
   }
 
   Status = OemSetMacE2prom(Port, Mac->Addr);
   if ((EFI_ERROR(Status)))
   {
-      DEBUG((EFI_D_ERROR, "[%a]:[%dL] Set mac failed!\n", __FUNCTION__, __LINE__));
+      DEBUG((DEBUG_ERROR, "[%a]:[%dL] Set mac failed!\n", __FUNCTION__, __LINE__));
       return Status;
   }
 
@@ -334,7 +334,7 @@ OemNicConfigEntry (
 
   if(EFI_ERROR(Status))
   {
-    DEBUG((EFI_D_ERROR, "[%a]:[%dL] Install Protocol failed %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Install Protocol failed %r\n", __FUNCTION__, __LINE__, Status));
     return Status;
   }
 
@@ -347,7 +347,7 @@ OemNicConfigEntry (
 
   if(EFI_ERROR(Status))
   {
-    DEBUG((EFI_D_ERROR, "[%a]:[%dL] Install Protocol failed %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Install Protocol failed %r\n", __FUNCTION__, __LINE__, Status));
     return Status;
   }
 

--- a/Platform/Hisilicon/D03/EarlyConfigPeim/EarlyConfigPeimD03.c
+++ b/Platform/Hisilicon/D03/EarlyConfigPeim/EarlyConfigPeimD03.c
@@ -89,22 +89,22 @@ EarlyConfigEntry (
   IN CONST EFI_PEI_SERVICES     **PeiServices
   )
 {
-    DEBUG((EFI_D_INFO,"SMMU CONFIG........."));
+    DEBUG((DEBUG_INFO,"SMMU CONFIG........."));
     (VOID)SmmuConfigForOS();
-    DEBUG((EFI_D_INFO,"Done\n"));
+    DEBUG((DEBUG_INFO,"Done\n"));
 
 
-    DEBUG((EFI_D_INFO,"AP CONFIG........."));
+    DEBUG((DEBUG_INFO,"AP CONFIG........."));
     (VOID)QResetAp();
-    DEBUG((EFI_D_INFO,"Done\n"));
+    DEBUG((DEBUG_INFO,"Done\n"));
 
-    DEBUG((EFI_D_INFO,"MN CONFIG........."));
+    DEBUG((DEBUG_INFO,"MN CONFIG........."));
     (VOID)MN_CONFIG();
-    DEBUG((EFI_D_INFO,"Done\n"));
+    DEBUG((DEBUG_INFO,"Done\n"));
 
     if(OemIsMpBoot())
     {
-        DEBUG((EFI_D_INFO,"Event Broadcast CONFIG........."));
+        DEBUG((DEBUG_INFO,"Event Broadcast CONFIG........."));
         //EVENT broadcast
         MmioWrite32 (MDIO_SUBCTRL_BASE + SC_BROADCAST_EN_REG, SC_BROADCAST_EN_REG_VALUE);
         MmioWrite32 (MDIO_SUBCTRL_BASE + SC_BROADCAST_SCL1_ADDR0_REG, SC_BROADCAST_SCLx_ADDRx_REG_VALUE1);
@@ -138,10 +138,10 @@ EarlyConfigEntry (
         MmioWrite32 (S1_BASE + PERI_SUBCTRL_BASE + SC_BROADCAST_SCL3_ADDR0_REG, SC_BROADCAST_SCLx_ADDRx_REG_VALUE1);
         MmioWrite32 (S1_BASE + PERI_SUBCTRL_BASE + SC_BROADCAST_SCL3_ADDR1_REG, SC_BROADCAST_SCLx_ADDRx_REG_VALUE0);
 
-        DEBUG((EFI_D_INFO,"Done\n"));
+        DEBUG((DEBUG_INFO,"Done\n"));
     }
 
-    DEBUG((EFI_D_INFO,"PCIE RAM Address CONFIG........."));
+    DEBUG((DEBUG_INFO,"PCIE RAM Address CONFIG........."));
 
     if(OemIsMpBoot())
     {
@@ -161,13 +161,13 @@ EarlyConfigEntry (
         MmioWrite32 (PCIE2_SUBCTRL_BASE + PCIE_SUBCTRL_SC_DISPATCH_DAW_ARRAY6_REG, PCIE_SUBCTRL_SC_DISPATCH_DAW_ARRAY6_REG_VALUE0);
     }
 
-    DEBUG((EFI_D_INFO,"Done\n"));
+    DEBUG((DEBUG_INFO,"Done\n"));
 
     MmioWrite32(ALG_BASE + SC_ITS_M3_INT_MUX_SEL_REG, SC_ITS_M3_INT_MUX_SEL_REG_VALUE);
 
-    DEBUG((EFI_D_INFO,"Timer CONFIG........."));
+    DEBUG((DEBUG_INFO,"Timer CONFIG........."));
     PlatformTimerStart ();
-    DEBUG((EFI_D_INFO,"Done\n"));
+    DEBUG((DEBUG_INFO,"Done\n"));
 
     return EFI_SUCCESS;
 }

--- a/Platform/Hisilicon/D03/Library/DS3231RealTimeClockLib/DS3231RealTimeClockLib.c
+++ b/Platform/Hisilicon/D03/Library/DS3231RealTimeClockLib/DS3231RealTimeClockLib.c
@@ -444,7 +444,7 @@ LibRtcInitialize (
       Status = LibSetTime(&EfiTime);
       if (EFI_ERROR(Status))
       {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Status : %r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n", __FUNCTION__, __LINE__, Status));
       }
   }
 

--- a/Platform/Hisilicon/D03/Library/DS3231RealTimeClockLib/DS3231RealTimeClockLib.c
+++ b/Platform/Hisilicon/D03/Library/DS3231RealTimeClockLib/DS3231RealTimeClockLib.c
@@ -444,7 +444,7 @@ LibRtcInitialize (
       Status = LibSetTime(&EfiTime);
       if (EFI_ERROR(Status))
       {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n", __func__, __LINE__, Status));
       }
   }
 

--- a/Platform/Hisilicon/D03/Library/FdtUpdateLib/FdtUpdateLib.c
+++ b/Platform/Hisilicon/D03/Library/FdtUpdateLib/FdtUpdateLib.c
@@ -98,14 +98,14 @@ GetMacAddress (UINT32 Port)
     Status = gBS->LocateProtocol(&gHisiBoardNicProtocolGuid, NULL, (VOID **)&OemNic);
     if(EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] LocateProtocol failed %r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] LocateProtocol failed %r\n", __FUNCTION__, __LINE__, Status));
         return Status;
     }
 
     Status = OemNic->GetMac(&Mac, Port);
     if(EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] GetMac failed %r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] GetMac failed %r\n", __FUNCTION__, __LINE__, Status));
         return Status;
     }
 
@@ -115,7 +115,7 @@ GetMacAddress (UINT32 Port)
     gMacAddress[0].data3=Mac.Addr[3];
     gMacAddress[0].data4=Mac.Addr[4];
     gMacAddress[0].data5=Mac.Addr[5];
-    DEBUG((EFI_D_INFO, "Port%d:0x%x 0x%x 0x%x 0x%x 0x%x 0x%x\n",
+    DEBUG((DEBUG_INFO, "Port%d:0x%x 0x%x 0x%x 0x%x 0x%x 0x%x\n",
         Port,gMacAddress[0].data0,gMacAddress[0].data1,gMacAddress[0].data2,
         gMacAddress[0].data3,gMacAddress[0].data4,gMacAddress[0].data5));
 
@@ -138,7 +138,7 @@ DelPhyhandleUpdateMacAddress(IN VOID* Fdt)
     node = fdt_subnode_offset(Fdt, 0, "soc");
     if (node < 0)
     {
-        DEBUG ((EFI_D_ERROR, "can not find soc root node\n"));
+        DEBUG ((DEBUG_ERROR, "can not find soc root node\n"));
         return EFI_INVALID_PARAMETER;
     }
     else
@@ -152,8 +152,8 @@ DelPhyhandleUpdateMacAddress(IN VOID* Fdt)
 
                 if (ethernetnode < 0)
                 {
-                    DEBUG ((EFI_D_WARN, "Can not find ethernet@%d node\n",port));
-                    DEBUG ((EFI_D_WARN, "Suppose port %d is not enabled.\n", port));
+                    DEBUG ((DEBUG_WARN, "Can not find ethernet@%d node\n",port));
+                    DEBUG ((DEBUG_WARN, "Suppose port %d is not enabled.\n", port));
                     continue;
                 }
                 m_prop = fdt_get_property_w(Fdt, ethernetnode, "local-mac-address", &m_oldlen);
@@ -162,13 +162,13 @@ DelPhyhandleUpdateMacAddress(IN VOID* Fdt)
                     Error = fdt_delprop(Fdt, ethernetnode, "local-mac-address");
                     if (Error)
                     {
-                        DEBUG ((EFI_D_ERROR, "ERROR:fdt_delprop() Local-mac-address: %a\n", fdt_strerror (Error)));
+                        DEBUG ((DEBUG_ERROR, "ERROR:fdt_delprop() Local-mac-address: %a\n", fdt_strerror (Error)));
                         Status = EFI_INVALID_PARAMETER;
                     }
                     Error = fdt_setprop(Fdt, ethernetnode, "local-mac-address",gMacAddress,sizeof(MAC_ADDRESS));
                     if (Error)
                     {
-                        DEBUG ((EFI_D_ERROR, "ERROR:fdt_setprop():local-mac-address %a\n", fdt_strerror (Error)));
+                        DEBUG ((DEBUG_ERROR, "ERROR:fdt_setprop():local-mac-address %a\n", fdt_strerror (Error)));
                         Status = EFI_INVALID_PARAMETER;
                     }
                 }
@@ -250,7 +250,7 @@ GetMemoryNode(VOID* Fdt)
 
         if(node < 0)
         {
-          DEBUG((EFI_D_ERROR, "[%a]:[%dL] fdt add subnode error\n", __FUNCTION__, __LINE__));
+          DEBUG((DEBUG_ERROR, "[%a]:[%dL] fdt add subnode error\n", __FUNCTION__, __LINE__));
 
           return node;
         }
@@ -264,7 +264,7 @@ GetMemoryNode(VOID* Fdt)
 
         if (Error)
         {
-            DEBUG ((EFI_D_ERROR, "ERROR:fdt_delprop(): %a\n", fdt_strerror (Error)));
+            DEBUG ((DEBUG_ERROR, "ERROR:fdt_delprop(): %a\n", fdt_strerror (Error)));
             node = -1;
             return node;
         }
@@ -299,7 +299,7 @@ EFI_STATUS UpdateMemoryNode(VOID* Fdt)
     node = GetMemoryNode(Fdt);
     if (node < 0)
     {
-        DEBUG((EFI_D_ERROR, "Can not find memory node\n"));
+        DEBUG((DEBUG_ERROR, "Can not find memory node\n"));
         return EFI_NOT_FOUND;
     }
     MemoryMap = NULL;
@@ -322,14 +322,14 @@ EFI_STATUS UpdateMemoryNode(VOID* Fdt)
 
         if (EFI_ERROR(Status))
         {
-            DEBUG ((EFI_D_ERROR, "FdtUpdateLib GetMemoryMap Error\n"));
+            DEBUG ((DEBUG_ERROR, "FdtUpdateLib GetMemoryMap Error\n"));
             FreePages (MemoryMap, Pages0);
             return Status;
         }
     }
     else
     {
-        DEBUG ((EFI_D_ERROR, "FdtUpdateLib GetmemoryMap Status: %r\n",Status));
+        DEBUG ((DEBUG_ERROR, "FdtUpdateLib GetmemoryMap Status: %r\n",Status));
         return EFI_ABORTED;
     }
 
@@ -388,7 +388,7 @@ EFI_STATUS UpdateMemoryNode(VOID* Fdt)
     FreePages (MemoryMap, Pages0);
     if (Error)
     {
-        DEBUG ((EFI_D_ERROR, "ERROR:fdt_setprop(): %a\n", fdt_strerror (Error)));
+        DEBUG ((DEBUG_ERROR, "ERROR:fdt_setprop(): %a\n", fdt_strerror (Error)));
         Status = EFI_INVALID_PARAMETER;
         return Status;
     }
@@ -421,7 +421,7 @@ EFI_STATUS EFIFdtUpdate(UINTN FdtFileAddr)
     Error = fdt_check_header ((VOID*)(FdtFileAddr));
     if (0 != Error)
     {
-        DEBUG ((EFI_D_ERROR,"ERROR: Device Tree header not valid (%a)\n", fdt_strerror(Error)));
+        DEBUG ((DEBUG_ERROR,"ERROR: Device Tree header not valid (%a)\n", fdt_strerror(Error)));
         return EFI_INVALID_PARAMETER;
     }
 
@@ -438,7 +438,7 @@ EFI_STATUS EFIFdtUpdate(UINTN FdtFileAddr)
 
     Error = fdt_open_into(Fdt,(VOID*)(UINTN)(NewFdtBlobBase), (NewFdtBlobSize));
     if (Error) {
-        DEBUG ((EFI_D_ERROR, "ERROR:fdt_open_into(): %a\n", fdt_strerror (Error)));
+        DEBUG ((DEBUG_ERROR, "ERROR:fdt_open_into(): %a\n", fdt_strerror (Error)));
         Status = EFI_INVALID_PARAMETER;
         goto EXIT;
     }
@@ -447,7 +447,7 @@ EFI_STATUS EFIFdtUpdate(UINTN FdtFileAddr)
     Status = DelPhyhandleUpdateMacAddress(Fdt);
     if (EFI_ERROR (Status))
     {
-        DEBUG ((EFI_D_ERROR, "DelPhyhandleUpdateMacAddress fail:\n"));
+        DEBUG ((DEBUG_ERROR, "DelPhyhandleUpdateMacAddress fail:\n"));
         Status = EFI_SUCCESS;
     }
 
@@ -459,14 +459,14 @@ EFI_STATUS EFIFdtUpdate(UINTN FdtFileAddr)
     Status = UpdateMemoryNode(Fdt);
     if (EFI_ERROR (Status))
     {
-        DEBUG ((EFI_D_ERROR, "UpdateMemoryNode Error\n"));
+        DEBUG ((DEBUG_ERROR, "UpdateMemoryNode Error\n"));
         goto EXIT;
     }
 
     UpdateNumaStatus = UpdateNumaNode(Fdt);
     if (EFI_ERROR (UpdateNumaStatus))
     {
-        DEBUG ((EFI_D_ERROR, "Update NumaNode fail\n"));
+        DEBUG ((DEBUG_ERROR, "Update NumaNode fail\n"));
     }
 
     gBS->CopyMem(((VOID*)(UINTN)(FdtFileAddr)),((VOID*)(UINTN)(NewFdtBlobBase)),NewFdtBlobSize);

--- a/Platform/Hisilicon/D03/Library/FdtUpdateLib/FdtUpdateLib.c
+++ b/Platform/Hisilicon/D03/Library/FdtUpdateLib/FdtUpdateLib.c
@@ -98,14 +98,14 @@ GetMacAddress (UINT32 Port)
     Status = gBS->LocateProtocol(&gHisiBoardNicProtocolGuid, NULL, (VOID **)&OemNic);
     if(EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] LocateProtocol failed %r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] LocateProtocol failed %r\n", __func__, __LINE__, Status));
         return Status;
     }
 
     Status = OemNic->GetMac(&Mac, Port);
     if(EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] GetMac failed %r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] GetMac failed %r\n", __func__, __LINE__, Status));
         return Status;
     }
 
@@ -192,7 +192,7 @@ UpdateRefClk (IN VOID* Fdt)
 
   ArmArchTimerReadReg (CntFrq, &ArchTimerFreq);
   if (!ArchTimerFreq) {
-    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Get timer frequency failed!\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Get timer frequency failed!\n", __func__, __LINE__));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -210,7 +210,7 @@ UpdateRefClk (IN VOID* Fdt)
 
   m_prop = fdt_get_property_w(Fdt, node, Property, &m_oldlen);
   if(!m_prop) {
-    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Can't find property %a\n", __FUNCTION__, __LINE__, Property));
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Can't find property %a\n", __func__, __LINE__, Property));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -250,7 +250,7 @@ GetMemoryNode(VOID* Fdt)
 
         if(node < 0)
         {
-          DEBUG((DEBUG_ERROR, "[%a]:[%dL] fdt add subnode error\n", __FUNCTION__, __LINE__));
+          DEBUG((DEBUG_ERROR, "[%a]:[%dL] fdt add subnode error\n", __func__, __LINE__));
 
           return node;
         }

--- a/Platform/Hisilicon/D03/Library/HisiOemMiscLib2P/BoardFeature2PHi1610.c
+++ b/Platform/Hisilicon/D03/Library/HisiOemMiscLib2P/BoardFeature2PHi1610.c
@@ -71,7 +71,7 @@ SERDES_PARAM gSerdesParam1 = {
 EFI_STATUS OemGetSerdesParam (SERDES_PARAM *ParamA, SERDES_PARAM *ParamB, UINT32 SocketId)
 {
   if (ParamA == NULL) {
-    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Param == NULL!\n", __FUNCTION__, __LINE__));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Param == NULL!\n", __func__, __LINE__));
     return EFI_INVALID_PARAMETER;
   }
 

--- a/Platform/Hisilicon/D03/Library/HisiOemMiscLib2P/BoardFeature2PHi1610.c
+++ b/Platform/Hisilicon/D03/Library/HisiOemMiscLib2P/BoardFeature2PHi1610.c
@@ -71,7 +71,7 @@ SERDES_PARAM gSerdesParam1 = {
 EFI_STATUS OemGetSerdesParam (SERDES_PARAM *ParamA, SERDES_PARAM *ParamB, UINT32 SocketId)
 {
   if (ParamA == NULL) {
-    DEBUG((EFI_D_ERROR, "[%a]:[%dL] Param == NULL!\n", __FUNCTION__, __LINE__));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Param == NULL!\n", __FUNCTION__, __LINE__));
     return EFI_INVALID_PARAMETER;
   }
 

--- a/Platform/Hisilicon/D03/Library/HisiOemMiscLib2P/OemMiscLib2PHi1610.c
+++ b/Platform/Hisilicon/D03/Library/HisiOemMiscLib2P/OemMiscLib2PHi1610.c
@@ -103,7 +103,7 @@ UINTN OemGetDimmSlot(UINTN Socket, UINTN Channel)
 VOID OemPostEndIndicator (VOID)
 {
 
-     DEBUG((EFI_D_ERROR,"M3 release reset CONFIG........."));
+     DEBUG((DEBUG_ERROR,"M3 release reset CONFIG........."));
 
      MmioWrite32(0xd0002180, 0x3);
      MmioWrite32(0xd0002194, 0xa4);
@@ -117,7 +117,7 @@ VOID OemPostEndIndicator (VOID)
      MmioWrite32(0xd0003108, 0x1);
 
      MicroSecondDelay(500000);
-     DEBUG((EFI_D_ERROR,"Done\n"));
+     DEBUG((DEBUG_ERROR,"Done\n"));
 
 }
 

--- a/Platform/Hisilicon/D05/Library/HisiOemMiscLibD05/BoardFeatureD05.c
+++ b/Platform/Hisilicon/D05/Library/HisiOemMiscLibD05/BoardFeatureD05.c
@@ -87,7 +87,7 @@ OemGetSerdesParam (
  )
 {
   if (ParamA == NULL || ParamB == NULL) {
-    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Param == NULL!\n", __FUNCTION__, __LINE__));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Param == NULL!\n", __func__, __LINE__));
     return EFI_INVALID_PARAMETER;
   }
 

--- a/Platform/Hisilicon/D06/Drivers/OemNicConfig2PHi1620/OemNicConfig2P.c
+++ b/Platform/Hisilicon/D06/Drivers/OemNicConfig2PHi1620/OemNicConfig2P.c
@@ -56,7 +56,7 @@ OemNicConfigEntry (
 
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Install Protocol failed %r\n",
-        __FUNCTION__, __LINE__, Status));
+        __func__, __LINE__, Status));
     return Status;
   }
 

--- a/Platform/Hisilicon/D06/Library/HisiOemMiscLibD06/BoardFeatureD06.c
+++ b/Platform/Hisilicon/D06/Library/HisiOemMiscLibD06/BoardFeatureD06.c
@@ -89,10 +89,10 @@ OemGetSerdesParam (
  )
 {
   if (NULL == ParamA) {
-    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Param == NULL!\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Param == NULL!\n", __func__, __LINE__));
     return EFI_INVALID_PARAMETER;
   } if (NULL == ParamB) {
-    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Param == NULL!\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Param == NULL!\n", __func__, __LINE__));
     return EFI_INVALID_PARAMETER;
   }
 

--- a/Platform/Hisilicon/D06/Library/OemNicLib/OemNicLib.c
+++ b/Platform/Hisilicon/D06/Library/OemNicLib/OemNicLib.c
@@ -129,7 +129,7 @@ OemGetMacE2prom(
   if (EFI_ERROR (Status))
   {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Call I2CInit failed! p1=0x%x.\n",
-            __FUNCTION__, __LINE__, Status));
+            __func__, __LINE__, Status));
     return Status;
   }
 
@@ -160,7 +160,7 @@ OemGetMacE2prom(
   }
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Call I2cRead failed! p1=0x%x.\n",
-            __FUNCTION__, __LINE__, Status));
+            __func__, __LINE__, Status));
     return Status;
   }
 
@@ -209,7 +209,7 @@ OemSetMacE2prom (
   Status = I2CInit (0, EEPROM_I2C_PORT, Normal);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Call I2CInit failed! p1=0x%x.\n",
-           __FUNCTION__, __LINE__, Status));
+           __func__, __LINE__, Status));
     return Status;
   }
 
@@ -245,7 +245,7 @@ OemSetMacE2prom (
   }
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Call I2cWrite failed! p1=0x%x.\n",
-            __FUNCTION__, __LINE__, Status));
+            __func__, __LINE__, Status));
     return Status;
   }
   return EFI_SUCCESS;
@@ -262,7 +262,7 @@ OemGetMac (
 
   if (Mac == NULL) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Mac buffer is null!\n",
-            __FUNCTION__, __LINE__));
+            __func__, __LINE__));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -270,7 +270,7 @@ OemGetMac (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "[%a]:[%dL] Cannot get MAC from EEPROM, Status: %r; using default MAC.\n",
-      __FUNCTION__, __LINE__, Status));
+      __func__, __LINE__, Status));
 
     Mac->Addr[0] = 0xFF;
     Mac->Addr[1] = 0xFF;
@@ -295,13 +295,13 @@ OemSetMac (
 
   if (Mac == NULL) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Mac buffer is null!\n",
-            __FUNCTION__, __LINE__));
+            __func__, __LINE__));
     return EFI_INVALID_PARAMETER;
   }
 
   Status = OemSetMacE2prom (Port, Mac->Addr);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Set mac failed!\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Set mac failed!\n", __func__, __LINE__));
     return Status;
   }
 

--- a/Platform/Hisilicon/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/Platform/Hisilicon/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -123,7 +123,7 @@ ConstructRootBridge (
 
   DevicePath = AllocateCopyPool(sizeof mEfiPciRootBridgeDevicePath, &mEfiPciRootBridgeDevicePath);
   if (DevicePath == NULL) {
-    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] AllocatePool failed!\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] AllocatePool failed!\n", __func__, __LINE__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -182,7 +182,7 @@ PciHostBridgeGetRootBridges (
 
   Bridges = AllocatePool (RootBridgeCount * sizeof *Bridges);
   if (Bridges == NULL) {
-    DEBUG ((DEBUG_ERROR, "[%a:%d] - AllocatePool failed!\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "[%a:%d] - AllocatePool failed!\n", __func__, __LINE__));
     return NULL;
   }
 

--- a/Platform/Intel/BoardModulePkg/BoardBdsHookDxe/BoardBdsHookDxe.c
+++ b/Platform/Intel/BoardModulePkg/BoardBdsHookDxe/BoardBdsHookDxe.c
@@ -41,7 +41,7 @@ BdsHookDxeEntryPoint (
   EFI_STATUS  Status;
   VOID        *Registration;
 
-  DEBUG ((DEBUG_INFO, "%a starts\n", __FUNCTION__ ));
+  DEBUG ((DEBUG_INFO, "%a starts\n", __func__ ));
 
   //
   // Create event to set proper video resolution and text mode for internal shell.

--- a/Platform/Intel/BoardModulePkg/Library/BiosIdLib/PeiBiosIdLib.c
+++ b/Platform/Intel/BoardModulePkg/Library/BiosIdLib/PeiBiosIdLib.c
@@ -104,6 +104,6 @@ GetBiosId (
     Instance++;
   }
 
-  DEBUG ((EFI_D_ERROR, "PEI get BIOS ID failed: %r\n", EFI_NOT_FOUND));
+  DEBUG ((DEBUG_ERROR, "PEI get BIOS ID failed: %r\n", EFI_NOT_FOUND));
   return EFI_NOT_FOUND;
 }

--- a/Platform/Intel/KabylakeOpenBoardPkg/AspireVn7Dash572G/FspWrapper/Library/PeiSiliconPolicyUpdateLibFsp/PeiBoardPolicyUpdate.c
+++ b/Platform/Intel/KabylakeOpenBoardPkg/AspireVn7Dash572G/FspWrapper/Library/PeiSiliconPolicyUpdateLibFsp/PeiBoardPolicyUpdate.c
@@ -49,7 +49,7 @@ PeiFspBoardPolicyUpdatePreMem (
   IN OUT FSPM_UPD    *FspmUpd
   )
 {
-  DEBUG ((DEBUG_INFO, "%a() Start\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a() Start\n", __func__));
 
   // BUGBUG: Preserve FSP defaults - PeiSiliconPolicyInitLibFsp ultimately overrides to 0.
   // Drop when https://edk2.groups.io/g/devel/message/79391 is merged
@@ -71,7 +71,7 @@ PeiFspBoardPolicyUpdatePreMem (
   /* PCIe config */
   FspmUpd->FspmConfig.PcieRpEnableMask = 0x341;  // Ports 1, 7, 9 and 10
 
-  DEBUG ((DEBUG_INFO, "%a() End\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a() End\n", __func__));
   return EFI_SUCCESS;
 }
 
@@ -92,7 +92,7 @@ PeiFspBoardPolicyUpdate (
 {
   INTN  Index;
 
-  DEBUG ((DEBUG_INFO, "%a() Start\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a() Start\n", __func__));
 
   // FIXME/NB: This is insecure and not production-ready!
   // TODO: Configure SPI lockdown by variable on FrontPage?
@@ -281,6 +281,6 @@ PeiFspBoardPolicyUpdate (
   /* GbE config */
   FspsUpd->FspsConfig.PchLanEnable = 0;
 
-  DEBUG ((DEBUG_INFO, "%a() End\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a() End\n", __func__));
   return EFI_SUCCESS;
 }

--- a/Platform/Intel/KabylakeOpenBoardPkg/AspireVn7Dash572G/Library/BoardAcpiLib/SmmAspireVn7Dash572GAcpiEnableLib.c
+++ b/Platform/Intel/KabylakeOpenBoardPkg/AspireVn7Dash572G/Library/BoardAcpiLib/SmmAspireVn7Dash572GAcpiEnableLib.c
@@ -24,13 +24,13 @@ AspireVn7Dash572GBoardEnableAcpi (
    *   Further reversing will be performed */
   Status = SendEcCommand (0xE9);  /* Vendor implements using ACPI "CMDB" register" */
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a(): SendEcCommand(0xE9) failed!\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a(): SendEcCommand(0xE9) failed!\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
   Status = SendEcData (0x81);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a(): SendEcData(0x81) failed!\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a(): SendEcData(0x81) failed!\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -52,13 +52,13 @@ AspireVn7Dash572GBoardDisableAcpi (
    *   Further reversing will be performed */
   Status = SendEcCommand (0xE9);  /* Vendor implements using ACPI "CMDB" register" */
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a(): SendEcCommand(0xE9) failed!\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a(): SendEcCommand(0xE9) failed!\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
   Status = SendEcData (0x80);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a(): SendEcData(0x80) failed!\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a(): SendEcData(0x80) failed!\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 

--- a/Platform/Intel/KabylakeOpenBoardPkg/AspireVn7Dash572G/Library/BoardEcLib/EcCommands.c
+++ b/Platform/Intel/KabylakeOpenBoardPkg/AspireVn7Dash572G/Library/BoardEcLib/EcCommands.c
@@ -61,19 +61,19 @@ EcCmd90Read (
 
   Status = SendEcCommand (0x90);
   if (EFI_ERROR (Status)) {
-    DEBUG((DEBUG_ERROR, "%a(): SendEcCommand(0x90) failed!\n", __FUNCTION__));
+    DEBUG((DEBUG_ERROR, "%a(): SendEcCommand(0x90) failed!\n", __func__));
     return Status;
   }
 
   Status = SendEcData (Address);
   if (EFI_ERROR (Status)) {
-    DEBUG((DEBUG_ERROR, "%a(): SendEcData(Address) failed!\n", __FUNCTION__));
+    DEBUG((DEBUG_ERROR, "%a(): SendEcData(Address) failed!\n", __func__));
     return Status;
   }
 
   Status = ReceiveEcData (Data);
   if (EFI_ERROR (Status)) {
-    DEBUG((DEBUG_ERROR, "%a(): ReceiveEcData(Data) failed!\n", __FUNCTION__));
+    DEBUG((DEBUG_ERROR, "%a(): ReceiveEcData(Data) failed!\n", __func__));
     return Status;
   }
   return EFI_SUCCESS;
@@ -99,19 +99,19 @@ EcCmd91Write (
 
   Status = SendEcCommand (0x91);
   if (EFI_ERROR (Status)) {
-    DEBUG((DEBUG_ERROR, "%a(): SendEcCommand(0x91) failed!\n", __FUNCTION__));
+    DEBUG((DEBUG_ERROR, "%a(): SendEcCommand(0x91) failed!\n", __func__));
     return Status;
   }
 
   Status = SendEcData (Address);
   if (EFI_ERROR (Status)) {
-    DEBUG((DEBUG_ERROR, "%a(): SendEcData(Address) failed!\n", __FUNCTION__));
+    DEBUG((DEBUG_ERROR, "%a(): SendEcData(Address) failed!\n", __func__));
     return Status;
   }
 
   Status = SendEcData (Data);
   if (EFI_ERROR (Status)) {
-    DEBUG((DEBUG_ERROR, "%a(): SendEcData(Data) failed!\n", __FUNCTION__));
+    DEBUG((DEBUG_ERROR, "%a(): SendEcData(Data) failed!\n", __func__));
     return Status;
   }
   return EFI_SUCCESS;
@@ -140,13 +140,13 @@ EcCmd94Query (
 
   Status = SendEcCommand (0x94);
   if (EFI_ERROR (Status)) {
-    DEBUG((DEBUG_ERROR, "%a(): SendEcCommand(0x94) failed!\n", __FUNCTION__));
+    DEBUG((DEBUG_ERROR, "%a(): SendEcCommand(0x94) failed!\n", __func__));
     return Status;
   }
 
   Status = ReceiveEcData (Data);
   if (EFI_ERROR (Status)) {
-    DEBUG((DEBUG_ERROR, "%a(): ReceiveEcData(Data) failed!\n", __FUNCTION__));
+    DEBUG((DEBUG_ERROR, "%a(): ReceiveEcData(Data) failed!\n", __func__));
     return Status;
   }
   return EFI_SUCCESS;

--- a/Platform/Intel/KabylakeOpenBoardPkg/AspireVn7Dash572G/Library/BoardInitLib/PeiBoardInitPreMemLib.c
+++ b/Platform/Intel/KabylakeOpenBoardPkg/AspireVn7Dash572G/Library/BoardInitLib/PeiBoardInitPreMemLib.c
@@ -40,7 +40,7 @@ BoardDetect (
   VOID
   )
 {
-  DEBUG ((DEBUG_INFO, "%a(): Deferred until LPC programming is complete\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a(): Deferred until LPC programming is complete\n", __func__));
   return EFI_SUCCESS;
 }
 

--- a/Platform/Intel/MinPlatformPkg/Acpi/AcpiTables/AcpiPlatform.c
+++ b/Platform/Intel/MinPlatformPkg/Acpi/AcpiTables/AcpiPlatform.c
@@ -1472,7 +1472,7 @@ IsAcpiTableChange (
   Xsdt           = NULL;
   FacsPtr        = NULL;
 
-  DEBUG ((DEBUG_INFO, "%a() - Start\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a() - Start\n", __func__));
 
   Status = EfiGetSystemConfigurationTable (&gEfiAcpiTableGuid, (VOID **)&Rsdp);
   if (EFI_ERROR (Status) || (Rsdp == NULL)) {
@@ -1527,7 +1527,7 @@ IsAcpiTableChange (
   DEBUG ((DEBUG_INFO, "HardwareSignature = %x and Status = %r\n", FacsPtr->HardwareSignature, Status));
 
   FreePool (TableCrcRecord);
-  DEBUG ((DEBUG_INFO, "%a() - End\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a() - End\n", __func__));
 }
 
 VOID

--- a/Platform/Intel/MinPlatformPkg/Bds/Library/DxePlatformBootManagerLib/BdsPlatform.c
+++ b/Platform/Intel/MinPlatformPkg/Bds/Library/DxePlatformBootManagerLib/BdsPlatform.c
@@ -106,7 +106,7 @@ BdsSignalEventBeforeConsoleAfterTrustedConsole (
   EFI_STATUS    Status;
   EFI_EVENT     BdsConsoleEvent;
 
-  DEBUG ((DEBUG_INFO, "%a \n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a \n", __func__));
 
   Status = CreateBdsEvent (
              TPL_CALLBACK,
@@ -137,7 +137,7 @@ BdsSignalEventBeforeConsoleBeforeEndOfDxe (
   EFI_STATUS    Status;
   EFI_EVENT     BdsConsoleEvent;
 
-  DEBUG ((DEBUG_INFO, "%a \n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a \n", __func__));
 
   Status = CreateBdsEvent (
              TPL_CALLBACK,
@@ -167,7 +167,7 @@ BdsSignalEventAfterConsoleReadyBeforeBootOption (
   EFI_STATUS    Status;
   EFI_EVENT     BdsConsoleEvent;
 
-  DEBUG ((DEBUG_INFO, "%a \n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a \n", __func__));
 
   Status = CreateBdsEvent (
              TPL_CALLBACK,

--- a/Platform/Intel/MinPlatformPkg/Bds/Library/DxePlatformBootManagerLib/BdsPlatform.c
+++ b/Platform/Intel/MinPlatformPkg/Bds/Library/DxePlatformBootManagerLib/BdsPlatform.c
@@ -196,7 +196,7 @@ PlatformBootManagerBeforeConsole (
   )
 {
 
-  DEBUG ((EFI_D_INFO, "PlatformBootManagerBeforeConsole\n"));
+  DEBUG ((DEBUG_INFO, "PlatformBootManagerBeforeConsole\n"));
 
   //
   // Trusted console can be added in a PciEnumComplete callback
@@ -242,7 +242,7 @@ PlatformBootManagerAfterConsole (
   VOID
   )
 {
-  DEBUG ((EFI_D_INFO, "PlatformBootManagerAfterConsole\n"));
+  DEBUG ((DEBUG_INFO, "PlatformBootManagerAfterConsole\n"));
 
   BdsSignalEventAfterConsoleReadyBeforeBootOption ();
 }

--- a/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/ExternalDeviceDmaProtection.c
+++ b/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/ExternalDeviceDmaProtection.c
@@ -27,7 +27,7 @@ CheckExternalDeviceDmaProtection (
   }
   Result = TRUE;
 
-  DEBUG ((EFI_D_INFO, "  External Device DMA Protection \n"));
+  DEBUG ((DEBUG_INFO, "  External Device DMA Protection \n"));
 
   //
   // ALL PASS

--- a/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/FirmwareTrustConfigurationCryptoStrength.c
+++ b/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/FirmwareTrustConfigurationCryptoStrength.c
@@ -27,7 +27,7 @@ CheckFirmwareTrustContinuationCryptoStrength (
   }
 
   Result = TRUE;
-  DEBUG ((EFI_D_INFO, "  Firmware Trust Continuation Crypto Strength\n"));
+  DEBUG ((DEBUG_INFO, "  Firmware Trust Continuation Crypto Strength\n"));
 
   //
   // ALL PASS

--- a/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/FirmwareVersionRollbackProtection.c
+++ b/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/FirmwareVersionRollbackProtection.c
@@ -28,7 +28,7 @@ CheckFirmwareVersionRollbackProtection (
 
   Result = TRUE;
 
-  DEBUG ((EFI_D_INFO, "  Firmware Version Rollback Protection\n"));
+  DEBUG ((DEBUG_INFO, "  Firmware Version Rollback Protection\n"));
 
   //
   // ALL PASS

--- a/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/HstiIbvPlatformDxe.c
+++ b/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/HstiIbvPlatformDxe.c
@@ -103,22 +103,22 @@ UpdateData (
   IN UINT32                   Role
   )
 {
-  DEBUG ((EFI_D_INFO, "2.0 Firmware Trust Continuation Crypto Strength\n"));
+  DEBUG ((DEBUG_INFO, "2.0 Firmware Trust Continuation Crypto Strength\n"));
   CheckFirmwareTrustContinuationCryptoStrength (Role);
 
-  DEBUG ((EFI_D_INFO, "2.1 No Test Key Verification\n"));
+  DEBUG ((DEBUG_INFO, "2.1 No Test Key Verification\n"));
   CheckNoTestKeyVerification (Role);
 
-  DEBUG ((EFI_D_INFO, "2.2 Firmware Version Rollback Protection\n"));
+  DEBUG ((DEBUG_INFO, "2.2 Firmware Version Rollback Protection\n"));
   CheckFirmwareVersionRollbackProtection (Role);
 
-  DEBUG ((EFI_D_INFO, "2.3 SecureBoot Bypass Checking\n"));
+  DEBUG ((DEBUG_INFO, "2.3 SecureBoot Bypass Checking\n"));
   CheckSecureBootBypass (Role);
 
-  DEBUG ((EFI_D_INFO, "2.4 External Device DMA Protection\n"));
+  DEBUG ((DEBUG_INFO, "2.4 External Device DMA Protection\n"));
   CheckExternalDeviceDmaProtection (Role);
 
-  DEBUG ((EFI_D_INFO, "2.5 MOR Support\n"));
+  DEBUG ((DEBUG_INFO, "2.5 MOR Support\n"));
   CheckMorSupport (Role);
 }
 
@@ -139,42 +139,42 @@ DumpHsti (
   CHAR16                         ErrorChar;
 
   Hsti = HstiData;
-  DEBUG ((EFI_D_INFO, "HSTI\n"));
-  DEBUG ((EFI_D_INFO, "  Version                     - 0x%08x\n", Hsti->Version));
-  DEBUG ((EFI_D_INFO, "  Role                        - 0x%08x\n", Hsti->Role));
-  DEBUG ((EFI_D_INFO, "  ImplementationID            - %S\n", Hsti->ImplementationID));
-  DEBUG ((EFI_D_INFO, "  SecurityFeaturesSize        - 0x%08x\n", Hsti->SecurityFeaturesSize));
+  DEBUG ((DEBUG_INFO, "HSTI\n"));
+  DEBUG ((DEBUG_INFO, "  Version                     - 0x%08x\n", Hsti->Version));
+  DEBUG ((DEBUG_INFO, "  Role                        - 0x%08x\n", Hsti->Role));
+  DEBUG ((DEBUG_INFO, "  ImplementationID            - %S\n", Hsti->ImplementationID));
+  DEBUG ((DEBUG_INFO, "  SecurityFeaturesSize        - 0x%08x\n", Hsti->SecurityFeaturesSize));
 
   SecurityFeatures = (UINT8 *)(Hsti + 1);
-  DEBUG ((EFI_D_INFO, "  SecurityFeaturesRequired    - "));
+  DEBUG ((DEBUG_INFO, "  SecurityFeaturesRequired    - "));
   for (Index = 0; Index < Hsti->SecurityFeaturesSize; Index++) {
-    DEBUG ((EFI_D_INFO, "%02x ", SecurityFeatures[Index]));
+    DEBUG ((DEBUG_INFO, "%02x ", SecurityFeatures[Index]));
   }
-  DEBUG ((EFI_D_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "\n"));
 
   SecurityFeatures = (UINT8 *)(SecurityFeatures + Hsti->SecurityFeaturesSize);
-  DEBUG ((EFI_D_INFO, "  SecurityFeaturesImplemented - "));
+  DEBUG ((DEBUG_INFO, "  SecurityFeaturesImplemented - "));
   for (Index = 0; Index < Hsti->SecurityFeaturesSize; Index++) {
-    DEBUG ((EFI_D_INFO, "%02x ", SecurityFeatures[Index]));
+    DEBUG ((DEBUG_INFO, "%02x ", SecurityFeatures[Index]));
   }
-  DEBUG ((EFI_D_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "\n"));
 
   SecurityFeatures = (UINT8 *)(SecurityFeatures + Hsti->SecurityFeaturesSize);
-  DEBUG ((EFI_D_INFO, "  SecurityFeaturesVerified    - "));
+  DEBUG ((DEBUG_INFO, "  SecurityFeaturesVerified    - "));
   for (Index = 0; Index < Hsti->SecurityFeaturesSize; Index++) {
-    DEBUG ((EFI_D_INFO, "%02x ", SecurityFeatures[Index]));
+    DEBUG ((DEBUG_INFO, "%02x ", SecurityFeatures[Index]));
   }
-  DEBUG ((EFI_D_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "\n"));
 
   ErrorString = (CHAR16 *)(SecurityFeatures + Hsti->SecurityFeaturesSize);
-  DEBUG ((EFI_D_INFO, "  ErrorString                 - \""));
+  DEBUG ((DEBUG_INFO, "  ErrorString                 - \""));
   CopyMem (&ErrorChar, ErrorString, sizeof(ErrorChar));
   for (; ErrorChar != 0;) {
-    DEBUG ((EFI_D_INFO, "%c", ErrorChar));
+    DEBUG ((DEBUG_INFO, "%c", ErrorChar));
     ErrorString++;
     CopyMem (&ErrorChar, ErrorString, sizeof(ErrorChar));
   }
-  DEBUG ((EFI_D_INFO, "\"\n"));
+  DEBUG ((DEBUG_INFO, "\"\n"));
 }
 
 /**
@@ -191,7 +191,7 @@ DumpData (
 
   Status = HstiLibGetTable (Role, NULL, &Hsti, &HstiSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "HSTI (Role - 0x%08x) not found!\n", Role));
+    DEBUG ((DEBUG_ERROR, "HSTI (Role - 0x%08x) not found!\n", Role));
     return ;
   }
 

--- a/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/MorSupport.c
+++ b/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/MorSupport.c
@@ -28,7 +28,7 @@ CheckMorSupport (
 
   Result = TRUE;
 
-  DEBUG ((EFI_D_INFO, "  MOR Strength\n"));
+  DEBUG ((DEBUG_INFO, "  MOR Strength\n"));
 
   //
   // ALL PASS

--- a/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/NoTestKeyVerification.c
+++ b/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/NoTestKeyVerification.c
@@ -27,7 +27,7 @@ CheckNoTestKeyVerification (
   }
 
   Result = TRUE;
-  DEBUG ((EFI_D_INFO, "  No Test Key Verification \n"));
+  DEBUG ((DEBUG_INFO, "  No Test Key Verification \n"));
 
   //
   // Get db and check Microsoft Test Key

--- a/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/SecureBootBypass.c
+++ b/Platform/Intel/MinPlatformPkg/Hsti/HstiIbvPlatformDxe/SecureBootBypass.c
@@ -27,7 +27,7 @@ CheckSecureBootBypass (
   }
 
   Result = TRUE;
-  DEBUG ((EFI_D_INFO, "  Secure Boot Bypass\n"));
+  DEBUG ((DEBUG_INFO, "  Secure Boot Bypass\n"));
 
   //
   // ALL PASS

--- a/Platform/Intel/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
+++ b/Platform/Intel/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
@@ -272,27 +272,27 @@ GetPlatformMemorySize (
   // Accumulate maximum amount of memory needed
   //
 
-  DEBUG((EFI_D_ERROR, "PEI_MIN_MEMORY_SIZE:%dKB \n", DivU64x32(*MemorySize,1024)));
-  DEBUG((EFI_D_ERROR, "IndexNumber:%d MemoryDataNumber%d \n", IndexNumber,DataSize/ sizeof (EFI_MEMORY_TYPE_INFORMATION)));
+  DEBUG((DEBUG_ERROR, "PEI_MIN_MEMORY_SIZE:%dKB \n", DivU64x32(*MemorySize,1024)));
+  DEBUG((DEBUG_ERROR, "IndexNumber:%d MemoryDataNumber%d \n", IndexNumber,DataSize/ sizeof (EFI_MEMORY_TYPE_INFORMATION)));
   if (EFI_ERROR (Status)) {
     //
     // Start with minimum memory
     //
     for (Index = 0; Index < IndexNumber; Index++) {
-      DEBUG((EFI_D_ERROR, "Index[%d].Type = %d .NumberOfPages=0x%x\n", Index,mDefaultMemoryTypeInformation[Index].Type,mDefaultMemoryTypeInformation[Index].NumberOfPages));
+      DEBUG((DEBUG_ERROR, "Index[%d].Type = %d .NumberOfPages=0x%x\n", Index,mDefaultMemoryTypeInformation[Index].Type,mDefaultMemoryTypeInformation[Index].NumberOfPages));
       *MemorySize += mDefaultMemoryTypeInformation[Index].NumberOfPages * EFI_PAGE_SIZE;
     }
-    DEBUG((EFI_D_ERROR, "No memory type,  Total platform memory:%dKB \n", DivU64x32(*MemorySize,1024)));
+    DEBUG((DEBUG_ERROR, "No memory type,  Total platform memory:%dKB \n", DivU64x32(*MemorySize,1024)));
   } else {
     //
     // Start with at least 0x200 pages of memory for the DXE Core and the DXE Stack
     //
     for (Index = 0; Index < IndexNumber; Index++) {
-      DEBUG((EFI_D_ERROR, "Index[%d].Type = %d .NumberOfPages=0x%x\n", Index,MemoryData[Index].Type,MemoryData[Index].NumberOfPages));
+      DEBUG((DEBUG_ERROR, "Index[%d].Type = %d .NumberOfPages=0x%x\n", Index,MemoryData[Index].Type,MemoryData[Index].NumberOfPages));
       *MemorySize += MemoryData[Index].NumberOfPages * EFI_PAGE_SIZE;
 
     }
-    DEBUG((EFI_D_ERROR, "has memory type,  Total platform memory:%dKB \n", DivU64x32(*MemorySize,1024)));
+    DEBUG((DEBUG_ERROR, "has memory type,  Total platform memory:%dKB \n", DivU64x32(*MemorySize,1024)));
   }
 
   return EFI_SUCCESS;

--- a/Platform/Intel/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckMemoryAttribute.c
+++ b/Platform/Intel/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckMemoryAttribute.c
@@ -147,7 +147,7 @@ TestPointCheckImageMemoryAttribute (
 
   PdbPointer = PeCoffLoaderGetPdbPointer (ImageAddress);
   if (PdbPointer != NULL) {
-    DEBUG ((EFI_D_INFO, "  Image - %a\n", PdbPointer));
+    DEBUG ((DEBUG_INFO, "  Image - %a\n", PdbPointer));
   }
 
   //
@@ -161,7 +161,7 @@ TestPointCheckImageMemoryAttribute (
 
   Hdr.Pe32 = (EFI_IMAGE_NT_HEADERS32 *)((UINT8 *) (UINTN) ImageAddress + PeCoffHeaderOffset);
   if (Hdr.Pe32->Signature != EFI_IMAGE_NT_SIGNATURE) {
-    DEBUG ((EFI_D_INFO, "Hdr.Pe32->Signature invalid - 0x%x\n", Hdr.Pe32->Signature));
+    DEBUG ((DEBUG_INFO, "Hdr.Pe32->Signature invalid - 0x%x\n", Hdr.Pe32->Signature));
     return EFI_INVALID_PARAMETER;
   }
   
@@ -183,10 +183,10 @@ TestPointCheckImageMemoryAttribute (
   }
 
   if ((SectionAlignment & (RUNTIME_PAGE_ALLOCATION_GRANULARITY - 1)) != 0) {
-    DEBUG ((EFI_D_INFO, "!!!!!!!!  RecordImageMemoryMap - Section Alignment(0x%x) is not %dK  !!!!!!!!\n", SectionAlignment, RUNTIME_PAGE_ALLOCATION_GRANULARITY >> 10));
+    DEBUG ((DEBUG_INFO, "!!!!!!!!  RecordImageMemoryMap - Section Alignment(0x%x) is not %dK  !!!!!!!!\n", SectionAlignment, RUNTIME_PAGE_ALLOCATION_GRANULARITY >> 10));
     PdbPointer = PeCoffLoaderGetPdbPointer ((VOID*) (UINTN) ImageAddress);
     if (PdbPointer != NULL) {
-      DEBUG ((EFI_D_INFO, "!!!!!!!!  Image - %a  !!!!!!!!\n", PdbPointer));
+      DEBUG ((DEBUG_INFO, "!!!!!!!!  Image - %a  !!!!!!!!\n", PdbPointer));
     }
     return EFI_INVALID_PARAMETER;
   }
@@ -213,7 +213,7 @@ TestPointCheckImageMemoryAttribute (
   for (Index = 0; Index < Hdr.Pe32->FileHeader.NumberOfSections; Index++) {
     Name = Section[Index].Name;
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "  Section - '%c%c%c%c%c%c%c%c'\n",
       Name[0],
       Name[1],
@@ -225,15 +225,15 @@ TestPointCheckImageMemoryAttribute (
       Name[7]
       ));
       
-    DEBUG ((EFI_D_INFO, "    VirtualSize          - 0x%08x\n", Section[Index].Misc.VirtualSize));
-    DEBUG ((EFI_D_INFO, "    VirtualAddress       - 0x%08x\n", Section[Index].VirtualAddress));
-    DEBUG ((EFI_D_INFO, "    SizeOfRawData        - 0x%08x\n", Section[Index].SizeOfRawData));
-    DEBUG ((EFI_D_INFO, "    PointerToRawData     - 0x%08x\n", Section[Index].PointerToRawData));
-    DEBUG ((EFI_D_INFO, "    PointerToRelocations - 0x%08x\n", Section[Index].PointerToRelocations));
-    DEBUG ((EFI_D_INFO, "    PointerToLinenumbers - 0x%08x\n", Section[Index].PointerToLinenumbers));
-    DEBUG ((EFI_D_INFO, "    NumberOfRelocations  - 0x%08x\n", Section[Index].NumberOfRelocations));
-    DEBUG ((EFI_D_INFO, "    NumberOfLinenumbers  - 0x%08x\n", Section[Index].NumberOfLinenumbers));
-    DEBUG ((EFI_D_INFO, "    Characteristics      - 0x%08x\n", Section[Index].Characteristics));
+    DEBUG ((DEBUG_INFO, "    VirtualSize          - 0x%08x\n", Section[Index].Misc.VirtualSize));
+    DEBUG ((DEBUG_INFO, "    VirtualAddress       - 0x%08x\n", Section[Index].VirtualAddress));
+    DEBUG ((DEBUG_INFO, "    SizeOfRawData        - 0x%08x\n", Section[Index].SizeOfRawData));
+    DEBUG ((DEBUG_INFO, "    PointerToRawData     - 0x%08x\n", Section[Index].PointerToRawData));
+    DEBUG ((DEBUG_INFO, "    PointerToRelocations - 0x%08x\n", Section[Index].PointerToRelocations));
+    DEBUG ((DEBUG_INFO, "    PointerToLinenumbers - 0x%08x\n", Section[Index].PointerToLinenumbers));
+    DEBUG ((DEBUG_INFO, "    NumberOfRelocations  - 0x%08x\n", Section[Index].NumberOfRelocations));
+    DEBUG ((DEBUG_INFO, "    NumberOfLinenumbers  - 0x%08x\n", Section[Index].NumberOfLinenumbers));
+    DEBUG ((DEBUG_INFO, "    Characteristics      - 0x%08x\n", Section[Index].Characteristics));
     if ((Section[Index].Characteristics & EFI_IMAGE_SCN_CNT_CODE) != 0) {
       //
       // Check code section

--- a/Platform/Intel/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckMemoryMap.c
+++ b/Platform/Intel/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckMemoryMap.c
@@ -72,7 +72,7 @@ TestPointDumpMemoryMap (
 
   ZeroMem (Pages, sizeof(Pages));
 
-  DEBUG ((EFI_D_INFO, "MemoryMap:\n"));
+  DEBUG ((DEBUG_INFO, "MemoryMap:\n"));
   
   Entry = MemoryMap;
   NumberOfEntries = MemoryMapSize / DescriptorSize;

--- a/Platform/Intel/MinPlatformPkg/Test/Library/TestPointCheckLib/TestPointHelp.c
+++ b/Platform/Intel/MinPlatformPkg/Test/Library/TestPointCheckLib/TestPointHelp.c
@@ -54,14 +54,14 @@ InternalDumpHex (
   Count = Size / COLUME_SIZE;
   Left  = Size % COLUME_SIZE;
   for (Index = 0; Index < Count; Index++) {
-    DEBUG ((EFI_D_INFO, "%04x: ", Index * COLUME_SIZE));
+    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
     InternalDumpData (Data + Index * COLUME_SIZE, COLUME_SIZE);
-    DEBUG ((EFI_D_INFO, "\n"));
+    DEBUG ((DEBUG_INFO, "\n"));
   }
 
   if (Left != 0) {
-    DEBUG ((EFI_D_INFO, "%04x: ", Index * COLUME_SIZE));
+    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
     InternalDumpData (Data + Index * COLUME_SIZE, Left);
-    DEBUG ((EFI_D_INFO, "\n"));
+    DEBUG ((DEBUG_INFO, "\n"));
   }
 }

--- a/Platform/Intel/MinPlatformPkg/Test/Library/TestPointLib/DxeTestPoint.c
+++ b/Platform/Intel/MinPlatformPkg/Test/Library/TestPointLib/DxeTestPoint.c
@@ -161,15 +161,15 @@ InternalTestPointIsValidTable (
   // basic check for header
   //
   if (TestPointData == NULL) {
-    DEBUG ((EFI_D_ERROR, "TestPointData == NULL\n"));
+    DEBUG ((DEBUG_ERROR, "TestPointData == NULL\n"));
     return FALSE;
   }
   if (TestPointSize < sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)) {
-    DEBUG ((EFI_D_ERROR, "TestPointSize < sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)\n"));
+    DEBUG ((DEBUG_ERROR, "TestPointSize < sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)\n"));
     return FALSE;
   }
   if (((TestPointSize - sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)) / TEST_POINT_FEATURES_ITEM_NUMBER) < TestPoint->FeaturesSize) {
-    DEBUG ((EFI_D_ERROR, "((TestPointSize - sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)) / TEST_POINT_FEATURES_ITEM_NUMBER) < FeaturesSize\n"));
+    DEBUG ((DEBUG_ERROR, "((TestPointSize - sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)) / TEST_POINT_FEATURES_ITEM_NUMBER) < FeaturesSize\n"));
     return FALSE;
   }
 
@@ -177,7 +177,7 @@ InternalTestPointIsValidTable (
   // Check Version
   //
   if (TestPoint->Version != PLATFORM_TEST_POINT_VERSION) {
-    DEBUG ((EFI_D_ERROR, "Version != PLATFORM_TEST_POINT_VERSION\n"));
+    DEBUG ((DEBUG_ERROR, "Version != PLATFORM_TEST_POINT_VERSION\n"));
     return FALSE;
   }
 
@@ -186,8 +186,8 @@ InternalTestPointIsValidTable (
   //
   if ((TestPoint->Role < PLATFORM_TEST_POINT_ROLE_PLATFORM_REFERENCE) ||
       (TestPoint->Role > PLATFORM_TEST_POINT_ROLE_IMPLEMENTOR_ODM)) {
-    DEBUG ((EFI_D_ERROR, "Role < PLATFORM_TEST_POINT_ROLE_PLATFORM_REFERENCE ||\n"));
-    DEBUG ((EFI_D_ERROR, "Role > PLATFORM_TEST_POINT_ROLE_IMPLEMENTOR_ODM\n"));
+    DEBUG ((DEBUG_ERROR, "Role < PLATFORM_TEST_POINT_ROLE_PLATFORM_REFERENCE ||\n"));
+    DEBUG ((DEBUG_ERROR, "Role > PLATFORM_TEST_POINT_ROLE_IMPLEMENTOR_ODM\n"));
     return FALSE;
   }
 
@@ -200,7 +200,7 @@ InternalTestPointIsValidTable (
     }
   }
   if (Index == sizeof(TestPoint->ImplementationID)/sizeof(TestPoint->ImplementationID[0])) {
-    DEBUG ((EFI_D_ERROR, "ImplementationID is no NUL CHAR\n"));
+    DEBUG ((DEBUG_ERROR, "ImplementationID is no NUL CHAR\n"));
     return FALSE;
   }
 
@@ -211,11 +211,11 @@ InternalTestPointIsValidTable (
   // basic check for ErrorString
   //
   if (ErrorStringSize == 0) {
-    DEBUG ((EFI_D_ERROR, "ErrorStringSize == 0\n"));
+    DEBUG ((DEBUG_ERROR, "ErrorStringSize == 0\n"));
     return FALSE;
   }
   if ((ErrorStringSize & BIT0) != 0) {
-    DEBUG ((EFI_D_ERROR, "(ErrorStringSize & BIT0) != 0\n"));
+    DEBUG ((DEBUG_ERROR, "(ErrorStringSize & BIT0) != 0\n"));
     return FALSE;
   }
 
@@ -232,11 +232,11 @@ InternalTestPointIsValidTable (
   // check the length of ErrorString
   //
   if (ErrorChar != 0) {
-    DEBUG ((EFI_D_ERROR, "ErrorString has no NUL CHAR\n"));
+    DEBUG ((DEBUG_ERROR, "ErrorString has no NUL CHAR\n"));
     return FALSE;
   }
   if (ErrorStringLength == (ErrorStringSize/2)) {
-    DEBUG ((EFI_D_ERROR, "ErrorString Length incorrect\n"));
+    DEBUG ((DEBUG_ERROR, "ErrorString Length incorrect\n"));
     return FALSE;
   }
 
@@ -270,10 +270,10 @@ TestPointLibSetTable (
   UINT32                           Role;
   CHAR16                           *ImplementationID;
 
-  DEBUG ((EFI_D_ERROR, "TestPointLibSetTable\n"));
+  DEBUG ((DEBUG_ERROR, "TestPointLibSetTable\n"));
 
   if (!InternalTestPointIsValidTable (TestPoint, TestPointSize)) {
-    DEBUG ((EFI_D_ERROR, "InternalTestPointIsValidTable\n"));
+    DEBUG ((DEBUG_ERROR, "InternalTestPointIsValidTable\n"));
     return EFI_VOLUME_CORRUPTED;
   }
 
@@ -281,7 +281,7 @@ TestPointLibSetTable (
   ImplementationID = ((ADAPTER_INFO_PLATFORM_TEST_POINT *)TestPoint)->ImplementationID;
   Aip = InternalTestPointFindAip (Role, ImplementationID, NULL, NULL);
   if (Aip != NULL) {
-    DEBUG ((EFI_D_ERROR, "Aip (0x%x, %S) is found\n", Role, ImplementationID));
+    DEBUG ((DEBUG_ERROR, "Aip (0x%x, %S) is found\n", Role, ImplementationID));
     return EFI_ALREADY_STARTED;
   }
 

--- a/Platform/Intel/MinPlatformPkg/Test/Library/TestPointLib/PeiTestPoint.c
+++ b/Platform/Intel/MinPlatformPkg/Test/Library/TestPointLib/PeiTestPoint.c
@@ -122,15 +122,15 @@ InternalTestPointIsValidTable (
   // basic check for header
   //
   if (TestPointData == NULL) {
-    DEBUG ((EFI_D_ERROR, "TestPointData == NULL\n"));
+    DEBUG ((DEBUG_ERROR, "TestPointData == NULL\n"));
     return FALSE;
   }
   if (TestPointSize < sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)) {
-    DEBUG ((EFI_D_ERROR, "TestPointSize < sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)\n"));
+    DEBUG ((DEBUG_ERROR, "TestPointSize < sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)\n"));
     return FALSE;
   }
   if (((TestPointSize - sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)) / TEST_POINT_FEATURES_ITEM_NUMBER) < TestPoint->FeaturesSize) {
-    DEBUG ((EFI_D_ERROR, "((TestPointSize - sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)) / TEST_POINT_FEATURES_ITEM_NUMBER) < FeaturesSize\n"));
+    DEBUG ((DEBUG_ERROR, "((TestPointSize - sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)) / TEST_POINT_FEATURES_ITEM_NUMBER) < FeaturesSize\n"));
     return FALSE;
   }
 
@@ -138,7 +138,7 @@ InternalTestPointIsValidTable (
   // Check Version
   //
   if (TestPoint->Version != PLATFORM_TEST_POINT_VERSION) {
-    DEBUG ((EFI_D_ERROR, "Version != PLATFORM_TEST_POINT_VERSION\n"));
+    DEBUG ((DEBUG_ERROR, "Version != PLATFORM_TEST_POINT_VERSION\n"));
     return FALSE;
   }
 
@@ -147,8 +147,8 @@ InternalTestPointIsValidTable (
   //
   if ((TestPoint->Role < PLATFORM_TEST_POINT_ROLE_PLATFORM_REFERENCE) ||
       (TestPoint->Role > PLATFORM_TEST_POINT_ROLE_IMPLEMENTOR_ODM)) {
-    DEBUG ((EFI_D_ERROR, "Role < PLATFORM_TEST_POINT_ROLE_PLATFORM_REFERENCE ||\n"));
-    DEBUG ((EFI_D_ERROR, "Role > PLATFORM_TEST_POINT_ROLE_IMPLEMENTOR_ODM\n"));
+    DEBUG ((DEBUG_ERROR, "Role < PLATFORM_TEST_POINT_ROLE_PLATFORM_REFERENCE ||\n"));
+    DEBUG ((DEBUG_ERROR, "Role > PLATFORM_TEST_POINT_ROLE_IMPLEMENTOR_ODM\n"));
     return FALSE;
   }
 
@@ -161,7 +161,7 @@ InternalTestPointIsValidTable (
     }
   }
   if (Index == sizeof(TestPoint->ImplementationID)/sizeof(TestPoint->ImplementationID[0])) {
-    DEBUG ((EFI_D_ERROR, "ImplementationID is no NUL CHAR\n"));
+    DEBUG ((DEBUG_ERROR, "ImplementationID is no NUL CHAR\n"));
     return FALSE;
   }
 
@@ -172,11 +172,11 @@ InternalTestPointIsValidTable (
   // basic check for ErrorString
   //
   if (ErrorStringSize == 0) {
-    DEBUG ((EFI_D_ERROR, "ErrorStringSize == 0\n"));
+    DEBUG ((DEBUG_ERROR, "ErrorStringSize == 0\n"));
     return FALSE;
   }
   if ((ErrorStringSize & BIT0) != 0) {
-    DEBUG ((EFI_D_ERROR, "(ErrorStringSize & BIT0) != 0\n"));
+    DEBUG ((DEBUG_ERROR, "(ErrorStringSize & BIT0) != 0\n"));
     return FALSE;
   }
 
@@ -193,11 +193,11 @@ InternalTestPointIsValidTable (
   // check the length of ErrorString
   //
   if (ErrorChar != 0) {
-    DEBUG ((EFI_D_ERROR, "ErrorString has no NUL CHAR\n"));
+    DEBUG ((DEBUG_ERROR, "ErrorString has no NUL CHAR\n"));
     return FALSE;
   }
   if (ErrorStringLength == (ErrorStringSize/2)) {
-    DEBUG ((EFI_D_ERROR, "ErrorString Length incorrect\n"));
+    DEBUG ((DEBUG_ERROR, "ErrorString Length incorrect\n"));
     return FALSE;
   }
 
@@ -229,10 +229,10 @@ TestPointLibSetTable (
   UINT32                           Role;
   CHAR16                           *ImplementationID;
 
-  DEBUG ((EFI_D_ERROR, "TestPointLibSetTable\n"));
+  DEBUG ((DEBUG_ERROR, "TestPointLibSetTable\n"));
 
   if (!InternalTestPointIsValidTable (TestPoint, TestPointSize)) {
-    DEBUG ((EFI_D_ERROR, "InternalTestPointIsValidTable\n"));
+    DEBUG ((DEBUG_ERROR, "InternalTestPointIsValidTable\n"));
     return EFI_VOLUME_CORRUPTED;
   }
 
@@ -240,7 +240,7 @@ TestPointLibSetTable (
   ImplementationID = ((ADAPTER_INFO_PLATFORM_TEST_POINT *)TestPoint)->ImplementationID;
   Status = InternalTestPointFindAip (Role, ImplementationID, NULL, NULL, NULL);
   if (!EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "Aip (0x%x, %S) is found\n", Role, ImplementationID));
+    DEBUG ((DEBUG_ERROR, "Aip (0x%x, %S) is found\n", Role, ImplementationID));
     return EFI_ALREADY_STARTED;
   }
 

--- a/Platform/Intel/MinPlatformPkg/Test/Library/TestPointLib/SmmTestPoint.c
+++ b/Platform/Intel/MinPlatformPkg/Test/Library/TestPointLib/SmmTestPoint.c
@@ -180,15 +180,15 @@ InternalTestPointIsValidTable (
   // basic check for header
   //
   if (TestPointData == NULL) {
-    DEBUG ((EFI_D_ERROR, "TestPointData == NULL\n"));
+    DEBUG ((DEBUG_ERROR, "TestPointData == NULL\n"));
     return FALSE;
   }
   if (TestPointSize < sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)) {
-    DEBUG ((EFI_D_ERROR, "TestPointSize < sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)\n"));
+    DEBUG ((DEBUG_ERROR, "TestPointSize < sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)\n"));
     return FALSE;
   }
   if (((TestPointSize - sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)) / TEST_POINT_FEATURES_ITEM_NUMBER) < TestPoint->FeaturesSize) {
-    DEBUG ((EFI_D_ERROR, "((TestPointSize - sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)) / TEST_POINT_FEATURES_ITEM_NUMBER) < FeaturesSize\n"));
+    DEBUG ((DEBUG_ERROR, "((TestPointSize - sizeof(ADAPTER_INFO_PLATFORM_TEST_POINT)) / TEST_POINT_FEATURES_ITEM_NUMBER) < FeaturesSize\n"));
     return FALSE;
   }
 
@@ -196,7 +196,7 @@ InternalTestPointIsValidTable (
   // Check Version
   //
   if (TestPoint->Version != PLATFORM_TEST_POINT_VERSION) {
-    DEBUG ((EFI_D_ERROR, "Version != PLATFORM_TEST_POINT_VERSION\n"));
+    DEBUG ((DEBUG_ERROR, "Version != PLATFORM_TEST_POINT_VERSION\n"));
     return FALSE;
   }
 
@@ -205,8 +205,8 @@ InternalTestPointIsValidTable (
   //
   if ((TestPoint->Role < PLATFORM_TEST_POINT_ROLE_PLATFORM_REFERENCE) ||
       (TestPoint->Role > PLATFORM_TEST_POINT_ROLE_IMPLEMENTOR_ODM)) {
-    DEBUG ((EFI_D_ERROR, "Role < PLATFORM_TEST_POINT_ROLE_PLATFORM_REFERENCE ||\n"));
-    DEBUG ((EFI_D_ERROR, "Role > PLATFORM_TEST_POINT_ROLE_IMPLEMENTOR_ODM\n"));
+    DEBUG ((DEBUG_ERROR, "Role < PLATFORM_TEST_POINT_ROLE_PLATFORM_REFERENCE ||\n"));
+    DEBUG ((DEBUG_ERROR, "Role > PLATFORM_TEST_POINT_ROLE_IMPLEMENTOR_ODM\n"));
     return FALSE;
   }
 
@@ -219,7 +219,7 @@ InternalTestPointIsValidTable (
     }
   }
   if (Index == sizeof(TestPoint->ImplementationID)/sizeof(TestPoint->ImplementationID[0])) {
-    DEBUG ((EFI_D_ERROR, "ImplementationID is no NUL CHAR\n"));
+    DEBUG ((DEBUG_ERROR, "ImplementationID is no NUL CHAR\n"));
     return FALSE;
   }
 
@@ -230,11 +230,11 @@ InternalTestPointIsValidTable (
   // basic check for ErrorString
   //
   if (ErrorStringSize == 0) {
-    DEBUG ((EFI_D_ERROR, "ErrorStringSize == 0\n"));
+    DEBUG ((DEBUG_ERROR, "ErrorStringSize == 0\n"));
     return FALSE;
   }
   if ((ErrorStringSize & BIT0) != 0) {
-    DEBUG ((EFI_D_ERROR, "(ErrorStringSize & BIT0) != 0\n"));
+    DEBUG ((DEBUG_ERROR, "(ErrorStringSize & BIT0) != 0\n"));
     return FALSE;
   }
 
@@ -251,11 +251,11 @@ InternalTestPointIsValidTable (
   // check the length of ErrorString
   //
   if (ErrorChar != 0) {
-    DEBUG ((EFI_D_ERROR, "ErrorString has no NUL CHAR\n"));
+    DEBUG ((DEBUG_ERROR, "ErrorString has no NUL CHAR\n"));
     return FALSE;
   }
   if (ErrorStringLength == (ErrorStringSize/2)) {
-    DEBUG ((EFI_D_ERROR, "ErrorString Length incorrect\n"));
+    DEBUG ((DEBUG_ERROR, "ErrorString Length incorrect\n"));
     return FALSE;
   }
 
@@ -289,10 +289,10 @@ TestPointLibSetTable (
   UINT32                           Role;
   CHAR16                           *ImplementationID;
 
-  DEBUG ((EFI_D_ERROR, "TestPointLibSetTable\n"));
+  DEBUG ((DEBUG_ERROR, "TestPointLibSetTable\n"));
 
   if (!InternalTestPointIsValidTable (TestPoint, TestPointSize)) {
-    DEBUG ((EFI_D_ERROR, "InternalTestPointIsValidTable\n"));
+    DEBUG ((DEBUG_ERROR, "InternalTestPointIsValidTable\n"));
     return EFI_VOLUME_CORRUPTED;
   }
 
@@ -300,7 +300,7 @@ TestPointLibSetTable (
   ImplementationID = ((ADAPTER_INFO_PLATFORM_TEST_POINT *)TestPoint)->ImplementationID;
   Aip = InternalTestPointFindAip (Role, ImplementationID, NULL, NULL);
   if (Aip != NULL) {
-    DEBUG ((EFI_D_ERROR, "Aip (0x%x, %S) is found\n", Role, ImplementationID));
+    DEBUG ((DEBUG_ERROR, "Aip (0x%x, %S) is found\n", Role, ImplementationID));
     return EFI_ALREADY_STARTED;
   }
 

--- a/Platform/Intel/PurleyOpenBoardPkg/Acpi/BoardAcpiDxe/BoardAcpiDxe.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Acpi/BoardAcpiDxe/BoardAcpiDxe.c
@@ -191,7 +191,7 @@ PlatformHookInit (
   ASSERT_EFI_ERROR (Status);
   mAcpiParameter = (BIOS_ACPI_PARAM *)AcpiParameterAddr;
 
-  DEBUG ((EFI_D_ERROR, "ACPI Parameter Block Address: 0x%X\n", mAcpiParameter));
+  DEBUG ((DEBUG_ERROR, "ACPI Parameter Block Address: 0x%X\n", mAcpiParameter));
   Status = PcdSet64S (PcdAcpiGnvsAddress, (UINT64)(UINTN)mAcpiParameter);
   ASSERT_EFI_ERROR (Status);
 
@@ -202,7 +202,7 @@ PlatformHookInit (
 #else
   mAcpiParameter->IoApicEnable  = (PcdGet32 (PcdPcIoApicEnable) << 1) | 1;
 #endif
-  DEBUG((EFI_D_ERROR, "io apic settings:%d\n", mAcpiParameter->IoApicEnable));
+  DEBUG((DEBUG_ERROR, "io apic settings:%d\n", mAcpiParameter->IoApicEnable));
 
   AsmCpuid (CPUID_VERSION_INFO,  &RegEax, &RegEbx, &RegEcx, &RegEdx);
   mAcpiParameter->ProcessorId = (RegEax & 0xFFFF0);

--- a/Platform/Intel/PurleyOpenBoardPkg/BoardMtOlympus/Library/BoardInitLib/PeiMtOlympusDetect.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/BoardMtOlympus/Library/BoardInitLib/PeiMtOlympusDetect.c
@@ -22,6 +22,6 @@ MtOlympusBoardDetect (
   VOID
   )
 {
-  DEBUG ((EFI_D_INFO, "MtOlympusBoardDetect\n"));
+  DEBUG ((DEBUG_INFO, "MtOlympusBoardDetect\n"));
   return EFI_SUCCESS;
 }

--- a/Platform/Intel/PurleyOpenBoardPkg/BoardMtOlympus/Library/BoardInitLib/PeiMtOlympusInitPostMemLib.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/BoardMtOlympus/Library/BoardInitLib/PeiMtOlympusInitPostMemLib.c
@@ -56,30 +56,30 @@ MtOlympusBoardInitAfterSiliconInit (
 {
   IIO_UDS               *IioUds;
 
-  DEBUG((EFI_D_ERROR, "MtOlympusBoardInitAfterSiliconInit\n"));
+  DEBUG((DEBUG_ERROR, "MtOlympusBoardInitAfterSiliconInit\n"));
 
   GetIioUdsHob(&IioUds);
 
-  DEBUG ((EFI_D_ERROR, "Memory TOLM: %X\n", IioUds->PlatformData.MemTolm));
+  DEBUG ((DEBUG_ERROR, "Memory TOLM: %X\n", IioUds->PlatformData.MemTolm));
   DEBUG (
-    (EFI_D_ERROR,
+    (DEBUG_ERROR,
     "PCIE   BASE: %lX     Size : %X\n",
     IioUds->PlatformData.PciExpressBase,
     IioUds->PlatformData.PciExpressSize)
     );
   DEBUG (
-    (EFI_D_ERROR,
+    (DEBUG_ERROR,
     "PCI32  BASE: %X     Limit: %X\n",
     IioUds->PlatformData.PlatGlobalMmiolBase,
     IioUds->PlatformData.PlatGlobalMmiolLimit)
     );
   DEBUG (
-    (EFI_D_ERROR,
+    (DEBUG_ERROR,
     "PCI64  BASE: %lX     Limit: %lX\n",
     IioUds->PlatformData.PlatGlobalMmiohBase,
     IioUds->PlatformData.PlatGlobalMmiohLimit)
     );
-  DEBUG ((EFI_D_ERROR, "UC    START: %lX     End  : %lX\n", IioUds->PlatformData.PlatGlobalMmiohBase, (IioUds->PlatformData.PlatGlobalMmiohLimit + 1)));
+  DEBUG ((DEBUG_ERROR, "UC    START: %lX     End  : %lX\n", IioUds->PlatformData.PlatGlobalMmiohBase, (IioUds->PlatformData.PlatGlobalMmiohLimit + 1)));
 
   return EFI_SUCCESS;
 }

--- a/Platform/Intel/PurleyOpenBoardPkg/BoardMtOlympus/Library/BoardInitLib/PeiMtOlympusInitPreMemLib.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/BoardMtOlympus/Library/BoardInitLib/PeiMtOlympusInitPreMemLib.c
@@ -208,17 +208,17 @@ EarlyPlatformPchInit (
   // Read the Second TO status bit
   //
   Data8 = IoRead8 (PcdGet16 (PcdTcoBaseAddress) + R_PCH_TCO2_STS);
-  DEBUG((EFI_D_ERROR, "pre read:%x\n", Data8));
+  DEBUG((DEBUG_ERROR, "pre read:%x\n", Data8));
 
   Data8 = IoRead8 (PcdGet16 (PcdTcoBaseAddress) + R_PCH_TCO2_STS);
-  DEBUG((EFI_D_ERROR, "read:%x\n", Data8));
+  DEBUG((DEBUG_ERROR, "read:%x\n", Data8));
   if ((Data8 & B_PCH_TCO2_STS_SECOND_TO) == B_PCH_TCO2_STS_SECOND_TO) {
     TcoRebootHappened = 1;
   } else {
     TcoRebootHappened = 0;
   }
   if (TcoRebootHappened) {
-    DEBUG ((EFI_D_ERROR, "EarlyPlatformPchInit - TCO Second TO status bit is set. This might be a TCO reboot\n"));
+    DEBUG ((DEBUG_ERROR, "EarlyPlatformPchInit - TCO Second TO status bit is set. This might be a TCO reboot\n"));
   }
 
   //
@@ -268,7 +268,7 @@ UpdatePlatformInfo (
   UINTN                              Index;
 #endif
 
-  DEBUG((EFI_D_ERROR, "platform update platform info entry\n"));
+  DEBUG((DEBUG_ERROR, "platform update platform info entry\n"));
 
   SocketProcessorCoreConfig = &SocketConfiguration->SocketProcessorCoreConfiguration;
   SocketIioConfig = &SocketConfiguration->IioConfig;
@@ -546,7 +546,7 @@ CheckPowerOffNow (
   // Read and check the ACPI registers
   //
   Pm1Sts = IoRead16 (PcdGet16 (PcdPchAcpiIoPortBaseAddress) + R_PCH_ACPI_PM1_STS);
-  DEBUG ((EFI_D_ERROR, "CheckPowerOffNow()- Pm1Sts= 0x%04x\n", Pm1Sts ));
+  DEBUG ((DEBUG_ERROR, "CheckPowerOffNow()- Pm1Sts= 0x%04x\n", Pm1Sts ));
 
   if ((Pm1Sts & B_PCH_ACPI_PM1_STS_PWRBTN) == B_PCH_ACPI_PM1_STS_PWRBTN) {
     IoWrite16 (PcdGet16 (PcdPchAcpiIoPortBaseAddress) + R_PCH_ACPI_PM1_STS, B_PCH_ACPI_PM1_STS_PWRBTN);

--- a/Platform/Intel/PurleyOpenBoardPkg/BoardTiogaPass/Library/BoardInitLib/PeiTiogaPassDetect.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/BoardTiogaPass/Library/BoardInitLib/PeiTiogaPassDetect.c
@@ -23,6 +23,6 @@ TiogaPassBoardDetect (
   VOID
   )
 {
-  DEBUG ((EFI_D_INFO, "TiogaPassBoardDetect\n"));
+  DEBUG ((DEBUG_INFO, "TiogaPassBoardDetect\n"));
   return EFI_SUCCESS;
 }

--- a/Platform/Intel/PurleyOpenBoardPkg/BoardTiogaPass/Library/BoardInitLib/PeiTiogaPassInitPostMemLib.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/BoardTiogaPass/Library/BoardInitLib/PeiTiogaPassInitPostMemLib.c
@@ -57,30 +57,30 @@ TiogaPassBoardInitAfterSiliconInit (
 {
   IIO_UDS               *IioUds;
 
-  DEBUG((EFI_D_ERROR, "TiogaPassBoardInitAfterSiliconInit\n"));
+  DEBUG((DEBUG_ERROR, "TiogaPassBoardInitAfterSiliconInit\n"));
 
   GetIioUdsHob(&IioUds);
 
-  DEBUG ((EFI_D_ERROR, "Memory TOLM: %X\n", IioUds->PlatformData.MemTolm));
+  DEBUG ((DEBUG_ERROR, "Memory TOLM: %X\n", IioUds->PlatformData.MemTolm));
   DEBUG (
-    (EFI_D_ERROR,
+    (DEBUG_ERROR,
     "PCIE   BASE: %lX     Size : %X\n",
     IioUds->PlatformData.PciExpressBase,
     IioUds->PlatformData.PciExpressSize)
     );
   DEBUG (
-    (EFI_D_ERROR,
+    (DEBUG_ERROR,
     "PCI32  BASE: %X     Limit: %X\n",
     IioUds->PlatformData.PlatGlobalMmiolBase,
     IioUds->PlatformData.PlatGlobalMmiolLimit)
     );
   DEBUG (
-    (EFI_D_ERROR,
+    (DEBUG_ERROR,
     "PCI64  BASE: %lX     Limit: %lX\n",
     IioUds->PlatformData.PlatGlobalMmiohBase,
     IioUds->PlatformData.PlatGlobalMmiohLimit)
     );
-  DEBUG ((EFI_D_ERROR, "UC    START: %lX     End  : %lX\n", IioUds->PlatformData.PlatGlobalMmiohBase, (IioUds->PlatformData.PlatGlobalMmiohLimit + 1)));
+  DEBUG ((DEBUG_ERROR, "UC    START: %lX     End  : %lX\n", IioUds->PlatformData.PlatGlobalMmiohBase, (IioUds->PlatformData.PlatGlobalMmiohLimit + 1)));
 
   return EFI_SUCCESS;
 }

--- a/Platform/Intel/PurleyOpenBoardPkg/BoardTiogaPass/Library/BoardInitLib/PeiTiogaPassInitPreMemLib.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/BoardTiogaPass/Library/BoardInitLib/PeiTiogaPassInitPreMemLib.c
@@ -209,17 +209,17 @@ EarlyPlatformPchInit (
   // Read the Second TO status bit
   //
   Data8 = IoRead8 (PcdGet16 (PcdTcoBaseAddress) + R_PCH_TCO2_STS);
-  DEBUG((EFI_D_ERROR, "pre read:%x\n", Data8));
+  DEBUG((DEBUG_ERROR, "pre read:%x\n", Data8));
 
   Data8 = IoRead8 (PcdGet16 (PcdTcoBaseAddress) + R_PCH_TCO2_STS);
-  DEBUG((EFI_D_ERROR, "read:%x\n", Data8));
+  DEBUG((DEBUG_ERROR, "read:%x\n", Data8));
   if ((Data8 & B_PCH_TCO2_STS_SECOND_TO) == B_PCH_TCO2_STS_SECOND_TO) {
     TcoRebootHappened = 1;
   } else {
     TcoRebootHappened = 0;
   }
   if (TcoRebootHappened) {
-    DEBUG ((EFI_D_ERROR, "EarlyPlatformPchInit - TCO Second TO status bit is set. This might be a TCO reboot\n"));
+    DEBUG ((DEBUG_ERROR, "EarlyPlatformPchInit - TCO Second TO status bit is set. This might be a TCO reboot\n"));
   }
 
   //
@@ -304,7 +304,7 @@ UpdatePlatformInfo (
   UINTN                              Index;
 #endif
 
-  DEBUG((EFI_D_ERROR, "platform update platform info entry\n"));
+  DEBUG((DEBUG_ERROR, "platform update platform info entry\n"));
 
   SocketProcessorCoreConfig = &SocketConfiguration->SocketProcessorCoreConfiguration;
   SocketIioConfig = &SocketConfiguration->IioConfig;
@@ -582,7 +582,7 @@ CheckPowerOffNow (
   // Read and check the ACPI registers
   //
   Pm1Sts = IoRead16 (PcdGet16 (PcdPchAcpiIoPortBaseAddress) + R_PCH_ACPI_PM1_STS);
-  DEBUG ((EFI_D_ERROR, "CheckPowerOffNow()- Pm1Sts= 0x%04x\n", Pm1Sts ));
+  DEBUG ((DEBUG_ERROR, "CheckPowerOffNow()- Pm1Sts= 0x%04x\n", Pm1Sts ));
 
   if ((Pm1Sts & B_PCH_ACPI_PM1_STS_PWRBTN) == B_PCH_ACPI_PM1_STS_PWRBTN) {
     IoWrite16 (PcdGet16 (PcdPchAcpiIoPortBaseAddress) + R_PCH_ACPI_PM1_STS, B_PCH_ACPI_PM1_STS_PWRBTN);

--- a/Platform/Intel/PurleyOpenBoardPkg/Features/LinuxBoot/LinuxBoot.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Features/LinuxBoot/LinuxBoot.c
@@ -274,7 +274,7 @@ LoadAndLaunchKernel (
     // Prepare the command line
     Status = LoadLinuxSetCommandLine(HandoverParams, (UINT8 *) &CmdLine);
     if (EFI_ERROR (Status)) {
-        DEBUG((EFI_D_INFO, "Unable to set linux command line; %r.\n", Status));
+        DEBUG((DEBUG_INFO, "Unable to set linux command line; %r.\n", Status));
         goto FatalError;
     }
 

--- a/Platform/Intel/PurleyOpenBoardPkg/Override/MdeModulePkg/Bus/Pci/PciBusDxe/PciCommand.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Override/MdeModulePkg/Bus/Pci/PciBusDxe/PciCommand.c
@@ -240,7 +240,7 @@ LocatePciExpressCapabilityRegBlock (
       DEBUG ((
         DEBUG_WARN,
         "%a: [%02x|%02x|%02x] failed to access config space at offset 0x%x\n",
-        __FUNCTION__,
+        __func__,
         PciIoDevice->BusNumber,
         PciIoDevice->DeviceNumber,
         PciIoDevice->FunctionNumber,

--- a/Platform/Intel/PurleyOpenBoardPkg/Override/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumerator.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Override/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumerator.c
@@ -1003,7 +1003,7 @@ PciHostBridgeAdjustAllocation (
     Status = RejectPciDevice (PciResNode->PciDev);
     if (Status == EFI_SUCCESS) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "PciBus: [%02x|%02x|%02x] was rejected due to resource confliction.\n",
         PciResNode->PciDev->BusNumber, PciResNode->PciDev->DeviceNumber, PciResNode->PciDev->FunctionNumber
         ));

--- a/Platform/Intel/PurleyOpenBoardPkg/Override/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Override/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -57,7 +57,7 @@ PciDevicePresent (
 // will causes failures writting to SPI. This is a WA for LBG since currently OS hidde is not working.
 //
   if(( Bus == 0x0) && ( Device == 0x1F) && (Func == 0x05)){
-    DEBUG ((EFI_D_INFO, "DEBUG - Address - 0x%x  BUS %x DEV %x Func %x SKIP\n", Address, Bus, Device, Func));
+    DEBUG ((DEBUG_INFO, "DEBUG - Address - 0x%x  BUS %x DEV %x Func %x SKIP\n", Address, Bus, Device, Func));
     return EFI_NOT_FOUND;
   }
 
@@ -247,7 +247,7 @@ PciSearchDevice (
   PciIoDevice = NULL;
 
   DEBUG ((
-    EFI_D_INFO,
+    DEBUG_INFO,
     "PciBus: Discovered %s @ [%02x|%02x|%02x]\n",
     IS_PCI_BRIDGE (Pci) ?     L"PPB" :
     IS_CARDBUS_BRIDGE (Pci) ? L"P2C" :
@@ -414,7 +414,7 @@ DumpPpbPaddingResource (
 
     if ((Type != PciBarTypeUnknown) && ((ResourceType == PciBarTypeUnknown) || (ResourceType == Type))) {
       DEBUG ((
-        EFI_D_INFO,
+        DEBUG_INFO,
         "   Padding: Type = %s; Alignment = 0x%lx;\tLength = 0x%lx\n",
         mBarTypeStr[Type], Descriptor->AddrRangeMax, Descriptor->AddrLen
         ));
@@ -441,7 +441,7 @@ DumpPciBars (
     }
 
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "   BAR[%d]: Type = %s; Alignment = 0x%lx;\tLength = 0x%lx;\tOffset = 0x%02x\n",
       Index, mBarTypeStr[MIN (PciIoDevice->PciBar[Index].BarType, PciBarTypeMaxType)],
       PciIoDevice->PciBar[Index].Alignment, PciIoDevice->PciBar[Index].Length, PciIoDevice->PciBar[Index].Offset
@@ -454,13 +454,13 @@ DumpPciBars (
     }
 
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       " VFBAR[%d]: Type = %s; Alignment = 0x%lx;\tLength = 0x%lx;\tOffset = 0x%02x\n",
       Index, mBarTypeStr[MIN (PciIoDevice->VfPciBar[Index].BarType, PciBarTypeMaxType)],
       PciIoDevice->VfPciBar[Index].Alignment, PciIoDevice->VfPciBar[Index].Length, PciIoDevice->VfPciBar[Index].Offset
       ));
   }
-  DEBUG ((EFI_D_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "\n"));
 }
 
 /**
@@ -1916,7 +1916,7 @@ PciParseBar (
       // Fix the length to support some special 64 bit BAR
       //
       if (Value == 0) {
-        DEBUG ((EFI_D_INFO, "[PciBus]BAR probing for upper 32bit of MEM64 BAR returns 0, change to 0xFFFFFFFF.\n"));
+        DEBUG ((DEBUG_INFO, "[PciBus]BAR probing for upper 32bit of MEM64 BAR returns 0, change to 0xFFFFFFFF.\n"));
         Value = (UINT32) -1;
       } else {
         Value |= ((UINT32)(-1) << HighBitSet32 (Value));
@@ -2295,7 +2295,7 @@ CreatePciIoDevice (
                               &Data32
                               );
           DEBUG ((
-            EFI_D_INFO,
+            DEBUG_INFO,
             " ARI: forwarding enabled for PPB[%02x:%02x:%02x]\n",
             Bridge->BusNumber,
             Bridge->DeviceNumber,
@@ -2304,7 +2304,7 @@ CreatePciIoDevice (
         }
       }
 
-      DEBUG ((EFI_D_INFO, " ARI: CapOffset = 0x%x\n", PciIoDevice->AriCapabilityOffset));
+      DEBUG ((DEBUG_INFO, " ARI: CapOffset = 0x%x\n", PciIoDevice->AriCapabilityOffset));
     }
   }
 
@@ -2414,12 +2414,12 @@ CreatePciIoDevice (
       PciIoDevice->ReservedBusNum = (UINT16)(EFI_PCI_BUS_OF_RID (LastVF) - Bus + 1);
 
       DEBUG ((
-        EFI_D_INFO,
+        DEBUG_INFO,
         " SR-IOV: SupportedPageSize = 0x%x; SystemPageSize = 0x%x; FirstVFOffset = 0x%x;\n",
         SupportedPageSize, PciIoDevice->SystemPageSize >> 12, FirstVFOffset
         ));
       DEBUG ((
-        EFI_D_INFO,
+        DEBUG_INFO,
         "         InitialVFs = 0x%x; ReservedBusNum = 0x%x; CapOffset = 0x%x\n",
         PciIoDevice->InitialVFs, PciIoDevice->ReservedBusNum, PciIoDevice->SrIovCapabilityOffset
         ));
@@ -2434,7 +2434,7 @@ CreatePciIoDevice (
                NULL
                );
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, " MR-IOV: CapOffset = 0x%x\n", PciIoDevice->MrIovCapabilityOffset));
+      DEBUG ((DEBUG_INFO, " MR-IOV: CapOffset = 0x%x\n", PciIoDevice->MrIovCapabilityOffset));
     }
   }
 

--- a/Platform/Intel/PurleyOpenBoardPkg/Override/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Override/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
@@ -215,7 +215,7 @@ DumpBridgeResource (
 
   if ((BridgeResource != NULL) && (BridgeResource->Length != 0)) {
     DEBUG ((
-      EFI_D_INFO, "Type = %s; Base = 0x%lx;\tLength = 0x%lx;\tAlignment = 0x%lx\n",
+      DEBUG_INFO, "Type = %s; Base = 0x%lx;\tLength = 0x%lx;\tAlignment = 0x%lx\n",
       mBarTypeStr[MIN (BridgeResource->ResType, PciBarTypeMaxType)],
       BridgeResource->PciDev->PciBar[BridgeResource->Bar].BaseAddress,
       BridgeResource->Length, BridgeResource->Alignment
@@ -228,7 +228,7 @@ DumpBridgeResource (
       if (Resource->ResourceUsage == PciResUsageTypical) {
         Bar = Resource->Virtual ? Resource->PciDev->VfPciBar : Resource->PciDev->PciBar;
         DEBUG ((
-          EFI_D_INFO, "   Base = 0x%lx;\tLength = 0x%lx;\tAlignment = 0x%lx;\tOwner = %s [%02x|%02x|%02x:",
+          DEBUG_INFO, "   Base = 0x%lx;\tLength = 0x%lx;\tAlignment = 0x%lx;\tOwner = %s [%02x|%02x|%02x:",
           Bar[Resource->Bar].BaseAddress, Resource->Length, Resource->Alignment,
           IS_PCI_BRIDGE (&Resource->PciDev->Pci)     ? L"PPB" :
           IS_CARDBUS_BRIDGE (&Resource->PciDev->Pci) ? L"P2C" :
@@ -244,20 +244,20 @@ DumpBridgeResource (
           //
           // The resource requirement comes from the device itself.
           //
-          DEBUG ((EFI_D_INFO, "%02x]", Bar[Resource->Bar].Offset));
+          DEBUG ((DEBUG_INFO, "%02x]", Bar[Resource->Bar].Offset));
         } else {
           //
           // The resource requirement comes from the subordinate devices.
           //
-          DEBUG ((EFI_D_INFO, "**]"));
+          DEBUG ((DEBUG_INFO, "**]"));
         }
       } else {
-        DEBUG ((EFI_D_INFO, "   Base = Padding;\tLength = 0x%lx;\tAlignment = 0x%lx", Resource->Length, Resource->Alignment));
+        DEBUG ((DEBUG_INFO, "   Base = Padding;\tLength = 0x%lx;\tAlignment = 0x%lx", Resource->Length, Resource->Alignment));
       }
       if (BridgeResource->ResType != Resource->ResType) {
-        DEBUG ((EFI_D_INFO, "; Type = %s", mBarTypeStr[MIN (Resource->ResType, PciBarTypeMaxType)]));
+        DEBUG ((DEBUG_INFO, "; Type = %s", mBarTypeStr[MIN (Resource->ResType, PciBarTypeMaxType)]));
       }
-      DEBUG ((EFI_D_INFO, "\n"));
+      DEBUG ((DEBUG_INFO, "\n"));
     }
   }
 }
@@ -321,7 +321,7 @@ DumpResourceMap (
   PCI_RESOURCE_NODE    **ChildResources;
   UINTN                ChildResourceCount;
 
-  DEBUG ((EFI_D_INFO, "PciBus: Resource Map for "));
+  DEBUG ((DEBUG_INFO, "PciBus: Resource Map for "));
 
   Status = gBS->OpenProtocol (
                   Bridge->Handle,
@@ -333,7 +333,7 @@ DumpResourceMap (
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((
-      EFI_D_INFO, "Bridge [%02x|%02x|%02x]\n",
+      DEBUG_INFO, "Bridge [%02x|%02x|%02x]\n",
       Bridge->BusNumber, Bridge->DeviceNumber, Bridge->FunctionNumber
       ));
   } else {
@@ -342,7 +342,7 @@ DumpResourceMap (
             FALSE,
             FALSE
             );
-    DEBUG ((EFI_D_INFO, "Root Bridge %s\n", Str != NULL ? Str : L""));
+    DEBUG ((DEBUG_INFO, "Root Bridge %s\n", Str != NULL ? Str : L""));
     if (Str != NULL) {
       FreePool (Str);
     }
@@ -351,7 +351,7 @@ DumpResourceMap (
   for (Index = 0; Index < ResourceCount; Index++) {
     DumpBridgeResource (Resources[Index]);
   }
-  DEBUG ((EFI_D_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "\n"));
 
   for ( Link = Bridge->ChildList.ForwardLink
       ; Link != &Bridge->ChildList
@@ -622,7 +622,7 @@ PciHostBridgeResourceAllocator (
         // If SubmitResources returns error, PciBus isn't able to start.
         // It's a fatal error so assertion is added.
         //
-        DEBUG ((EFI_D_INFO, "PciBus: HostBridge->SubmitResources() - %r\n", Status));
+        DEBUG ((DEBUG_INFO, "PciBus: HostBridge->SubmitResources() - %r\n", Status));
         ASSERT_EFI_ERROR (Status);
       }
 
@@ -654,7 +654,7 @@ PciHostBridgeResourceAllocator (
     // Notify platform to start to program the resource
     //
     Status = NotifyPhase (PciResAlloc, EfiPciHostBridgeAllocateResources);
-    DEBUG ((EFI_D_INFO, "PciBus: HostBridge->NotifyPhase(AllocateResources) - %r\n", Status));
+    DEBUG ((DEBUG_INFO, "PciBus: HostBridge->NotifyPhase(AllocateResources) - %r\n", Status));
     if (!FeaturePcdGet (PcdPciBusHotplugDeviceSupport)) {
       //
       // If Hot Plug is not supported
@@ -1340,9 +1340,9 @@ PciScanBus (
             TempReservedBusNum = PciDevice->ReservedBusNum;
 
             if (Func == 0) {
-              DEBUG ((EFI_D_INFO, "PCI-IOV ScanBus - SubBusNumber - 0x%x\n", *SubBusNumber));
+              DEBUG ((DEBUG_INFO, "PCI-IOV ScanBus - SubBusNumber - 0x%x\n", *SubBusNumber));
             } else {
-              DEBUG ((EFI_D_INFO, "PCI-IOV ScanBus - SubBusNumber - 0x%x (Update)\n", *SubBusNumber));
+              DEBUG ((DEBUG_INFO, "PCI-IOV ScanBus - SubBusNumber - 0x%x (Update)\n", *SubBusNumber));
             }
           }
         }
@@ -1522,7 +1522,7 @@ PciHostBridgeEnumerator (
     return Status;
   }
 
-  DEBUG((EFI_D_INFO, "PCI Bus First Scanning\n"));
+  DEBUG((DEBUG_INFO, "PCI Bus First Scanning\n"));
   RootBridgeHandle = NULL;
   while (PciResAlloc->GetNextRootBridge (PciResAlloc, &RootBridgeHandle) == EFI_SUCCESS) {
 
@@ -1601,7 +1601,7 @@ PciHostBridgeEnumerator (
     Status = AllRootHPCInitialized (STALL_1_SECOND * 15);
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Some root HPC failed to initialize\n"));
+      DEBUG ((DEBUG_ERROR, "Some root HPC failed to initialize\n"));
       return Status;
     }
 
@@ -1614,7 +1614,7 @@ PciHostBridgeEnumerator (
       return Status;
     }
 
-    DEBUG((EFI_D_INFO, "PCI Bus Second Scanning\n"));
+    DEBUG((DEBUG_INFO, "PCI Bus Second Scanning\n"));
     RootBridgeHandle = NULL;
     while (PciResAlloc->GetNextRootBridge (PciResAlloc, &RootBridgeHandle) == EFI_SUCCESS) {
 

--- a/Platform/Intel/PurleyOpenBoardPkg/Override/Platform/Intel/MinPlatformPkg/Bds/Library/DxePlatformBootManagerLib/BdsPlatform.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Override/Platform/Intel/MinPlatformPkg/Bds/Library/DxePlatformBootManagerLib/BdsPlatform.c
@@ -112,7 +112,7 @@ BdsSignalEventBeforeConsoleAfterTrustedConsole (
   EFI_STATUS    Status;
   EFI_EVENT     BdsConsoleEvent;
 
-  DEBUG ((DEBUG_INFO, "%a \n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a \n", __func__));
 
   Status = CreateBdsEvent (
              TPL_CALLBACK,
@@ -143,7 +143,7 @@ BdsSignalEventBeforeConsoleBeforeEndOfDxe (
   EFI_STATUS    Status;
   EFI_EVENT     BdsConsoleEvent;
 
-  DEBUG ((DEBUG_INFO, "%a \n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a \n", __func__));
 
   Status = CreateBdsEvent (
              TPL_CALLBACK,
@@ -173,7 +173,7 @@ BdsSignalEventAfterConsoleReadyBeforeBootOption (
   EFI_STATUS    Status;
   EFI_EVENT     BdsConsoleEvent;
 
-  DEBUG ((DEBUG_INFO, "%a \n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a \n", __func__));
 
   Status = CreateBdsEvent (
              TPL_CALLBACK,

--- a/Platform/Intel/PurleyOpenBoardPkg/Override/Platform/Intel/MinPlatformPkg/Bds/Library/DxePlatformBootManagerLib/BdsPlatform.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Override/Platform/Intel/MinPlatformPkg/Bds/Library/DxePlatformBootManagerLib/BdsPlatform.c
@@ -202,7 +202,7 @@ PlatformBootManagerBeforeConsole (
   )
 {
 
-  DEBUG ((EFI_D_INFO, "PlatformBootManagerBeforeConsole\n"));
+  DEBUG ((DEBUG_INFO, "PlatformBootManagerBeforeConsole\n"));
 
   //
   // Trusted console can be added in a PciEnumComplete callback
@@ -248,7 +248,7 @@ PlatformBootManagerAfterConsole (
   VOID
   )
 {
-  DEBUG ((EFI_D_INFO, "PlatformBootManagerAfterConsole\n"));
+  DEBUG ((DEBUG_INFO, "PlatformBootManagerAfterConsole\n"));
 
   LinuxBootStart();
 

--- a/Platform/Intel/PurleyOpenBoardPkg/Pci/PciPlatform/PciPlatformHooks.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Pci/PciPlatform/PciPlatformHooks.c
@@ -262,13 +262,13 @@ PciPlatformInitPciIovData (
       return Status;
     }
     DEBUG ((
-          EFI_D_INFO,
+          DEBUG_INFO,
           " Initialized SR-IOV Platform Data: PCIIovPolicy = 0x%x; SystemPageSize = 0x%x;\n",
           PciIovPolicy, SystemPageSize
           ));
   } else {
     DEBUG ((
-          EFI_D_INFO,
+          DEBUG_INFO,
           " Using default values for SystemPageSize;\n"
           ));
   }

--- a/Platform/Intel/PurleyOpenBoardPkg/Policy/Library/SiliconPolicyUpdateLib/SiliconPolicyUpdateLib.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Policy/Library/SiliconPolicyUpdateLib/SiliconPolicyUpdateLib.c
@@ -134,7 +134,7 @@ Returns:
   SYSTEM_CONFIGURATION           *SetupVariables;
   PCH_RC_CONFIGURATION           *PchRcVariables;
 
-  DEBUG((EFI_D_ERROR, "platform common UpdatePeiPchPolicy entry\n"));
+  DEBUG((DEBUG_ERROR, "platform common UpdatePeiPchPolicy entry\n"));
 
   SetupVariables = PcdGetPtr(PcdSetupData);
   PchRcVariables = PcdGetPtr(PcdPchRcConfigurationData);

--- a/Platform/Intel/PurleyOpenBoardPkg/Policy/PlatformCpuPolicy/PlatformCpuPolicy.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Policy/PlatformCpuPolicy/PlatformCpuPolicy.c
@@ -52,14 +52,14 @@ CheckAndReAssignSocketId(
   UINT32                MaxSocketCount;
 
   MaxSocketCount = FixedPcdGet32(PcdMaxCpuSocketCount);
-  DEBUG ((EFI_D_ERROR, "::SocketCount %08x\n", MaxSocketCount));
+  DEBUG ((DEBUG_ERROR, "::SocketCount %08x\n", MaxSocketCount));
   pcdSktIdPtr = (CPU_SOCKET_ID_INFO *)PcdGetPtr(PcdCpuSocketId);
   PcdSize = PcdGetSize (PcdCpuSocketId); //MAX_SOCKET * sizeof(CPU_SOCKET_ID_INFO);
   ASSERT(PcdSize == (MAX_SOCKET * sizeof(CPU_SOCKET_ID_INFO)));
   Status = PcdSetPtrS (PcdCpuSocketId, &PcdSize, (VOID *)pcdSktIdPtr);
   ASSERT_EFI_ERROR (Status);
   if (EFI_ERROR(Status)) return;
-  DEBUG ((EFI_D_INFO, "::SockeId Pcd at %08x, size %x\n", PcdGetPtr(PcdCpuSocketId), PcdSize));
+  DEBUG ((DEBUG_INFO, "::SockeId Pcd at %08x, size %x\n", PcdGetPtr(PcdCpuSocketId), PcdSize));
 
   for(i = 0; i < MAX_SOCKET; i++) {
     if(mIioUds->PlatformData.CpuQpiInfo[i].Valid) {
@@ -99,7 +99,7 @@ CheckAndReAssignSocketId(
         break;
 
      default:
-        DEBUG ((EFI_D_INFO, "::Need more info to make sure we can support!!!\n"));
+        DEBUG ((DEBUG_INFO, "::Need more info to make sure we can support!!!\n"));
         break;
 
     } //end switch
@@ -173,7 +173,7 @@ PlatformCpuPolicyEntryPoint (
                         (VOID **) &Addr
                         );
   if(Status != EFI_SUCCESS) {
-    DEBUG ((EFI_D_INFO, "::Failed to allocate mem for PPM Struct\n"));
+    DEBUG ((DEBUG_INFO, "::Failed to allocate mem for PPM Struct\n"));
     ASSERT_EFI_ERROR (Status);      //may need to create a default
   } else {
     ZeroMem(Addr, sizeof(EFI_PPM_STRUCT));
@@ -182,15 +182,15 @@ PlatformCpuPolicyEntryPoint (
     Status = PcdSet64S (PcdCpuPmStructAddr, i);
     ASSERT_EFI_ERROR (Status);
     if (EFI_ERROR(Status)) return Status;
-    DEBUG ((EFI_D_INFO, "::PPM mem allocate @ %x %X %X\n", i, PcdGet64(PcdCpuPmStructAddr), ppm));
+    DEBUG ((DEBUG_INFO, "::PPM mem allocate @ %x %X %X\n", i, PcdGet64(PcdCpuPmStructAddr), ppm));
     UpiInPkgCEntry = (UINT32 *)(((EFI_PPM_STRUCT *)Addr)->Cst.PkgCstEntryCriteriaMaskKti);
     PcieInPkgCEntry = (UINT32 *)(((EFI_PPM_STRUCT *)Addr)->Cst.PkgCstEntryCriteriaMaskPcie);
     XePtr = (XE_STRUCT *)(&((EFI_PPM_STRUCT *)Addr)->Xe);
     TurboRatioLimitRatioCores = (TURBO_RATIO_LIMIT_RATIO_CORES *)(&((EFI_PPM_STRUCT *)Addr)->TurboRatioLimitRatioCores);
-    DEBUG ((EFI_D_INFO, ":: XE @ %X\n", (UINTN) XePtr));
+    DEBUG ((DEBUG_INFO, ":: XE @ %X\n", (UINTN) XePtr));
 
     CStateLatencyCtrl = (MSR_REGISTER *)(ppm->Cst.LatencyCtrl);
-    DEBUG ((EFI_D_INFO, "CStateLatencyCtrl[%X]\n", (UINTN) CStateLatencyCtrl));
+    DEBUG ((DEBUG_INFO, "CStateLatencyCtrl[%X]\n", (UINTN) CStateLatencyCtrl));
   }
 
   //
@@ -216,7 +216,7 @@ PlatformCpuPolicyEntryPoint (
 
     // Temporary override to prevent accidental enabling until CR dungeon approves
     if (SetupData.SocketConfig.PowerManagementConfig.PackageCState != 0) {
-      DEBUG((EFI_D_ERROR, "Crystal Ridge Configuration Warning: Package c-states are not disabled\n"));
+      DEBUG((DEBUG_ERROR, "Crystal Ridge Configuration Warning: Package c-states are not disabled\n"));
     }
 
     if ((SetupData.SocketConfig.PowerManagementConfig.C6Enable == PPM_AUTO) ||
@@ -322,7 +322,7 @@ PlatformCpuPolicyEntryPoint (
       ASSERT_EFI_ERROR (Status);
       if (EFI_ERROR(Status)) return Status;
     }
-    DEBUG ((EFI_D_INFO, ":: PcdCpuSmmRuntimeCtlHooks= %x\n", PcdGetBool(PcdCpuSmmRuntimeCtlHooks)));
+    DEBUG ((DEBUG_INFO, ":: PcdCpuSmmRuntimeCtlHooks= %x\n", PcdGetBool(PcdCpuSmmRuntimeCtlHooks)));
 
     if(mIioUds->PlatformData.EVMode || SetupData.SystemConfig.LmceEn) {
       Status = PcdSet8S (PcdCpuProcessorMsrLockCtrl, 0);

--- a/Platform/Intel/PurleyOpenBoardPkg/Policy/S3NvramSave/S3NvramSave.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Policy/S3NvramSave/S3NvramSave.c
@@ -67,7 +67,7 @@ SaveS3StructToNvram (
     HobData = GET_GUID_HOB_DATA(GuidHob); 
     CurrentHobSize = GET_GUID_HOB_DATA_SIZE (GuidHob);
 
-    DEBUG((EFI_D_INFO, "   Current Hob Size(bytes) is: %d\n", CurrentHobSize));
+    DEBUG((DEBUG_INFO, "   Current Hob Size(bytes) is: %d\n", CurrentHobSize));
     //
     // Use the HOB data to save Memory Configuration Data
     //
@@ -80,7 +80,7 @@ SaveS3StructToNvram (
 
     ASSERT (VariableData != NULL); 
     S3ChunkSize = MAX_HOB_ENTRY_SIZE / 8;
-    DEBUG((EFI_D_INFO, "   S3ChunkSize Hob Size(bytes): %d\n", S3ChunkSize));
+    DEBUG((DEBUG_INFO, "   S3ChunkSize Hob Size(bytes): %d\n", S3ChunkSize));
 
     while (CurrentHobSize) {
       if (S3ChunkSize > CurrentHobSize) {
@@ -147,7 +147,7 @@ SaveS3StructToNvram (
         }
 
         if (EFI_ERROR (Status)) {
-          DEBUG((EFI_D_ERROR, "Getting variables error: 0x%x\n", Status));
+          DEBUG((DEBUG_ERROR, "Getting variables error: 0x%x\n", Status));
           ASSERT (Status == EFI_SUCCESS); 
         }
 
@@ -198,7 +198,7 @@ SaveS3StructToNvram (
       }
     
         if (EFI_ERROR (Status)) {
-          DEBUG((EFI_D_ERROR, "Set variable error. Status: 0x%x\n", Status));
+          DEBUG((DEBUG_ERROR, "Set variable error. Status: 0x%x\n", Status));
           ASSERT_EFI_ERROR (Status);
         }
       }

--- a/Platform/Intel/PurleyOpenBoardPkg/Policy/SystemBoard/SystemBoardCommon.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Policy/SystemBoard/SystemBoardCommon.c
@@ -54,7 +54,7 @@ SetBifurcations(
        }
        break;
      default:
-       DEBUG((EFI_D_ERROR, "Invalid bifurcation table: Bad Iou (%d)", Iou));
+       DEBUG((DEBUG_ERROR, "Invalid bifurcation table: Bad Iou (%d)", Iou));
        ASSERT(Iou);
        break;
     }
@@ -99,7 +99,7 @@ EnableHotPlug (
     IioGlobalData->SetupData.VppPort[Port]= VppPort;
     IioGlobalData->SetupData.VppAddress[Port] = VppAddress;
   } else {
-      DEBUG((EFI_D_ERROR, "PCIE HOT Plug. Missing VPP values on slot table\n"));
+      DEBUG((DEBUG_ERROR, "PCIE HOT Plug. Missing VPP values on slot table\n"));
   }
 }
 
@@ -477,9 +477,9 @@ DumpPort(
 )
 {
   UINT8 Index;
-  DEBUG((EFI_D_INFO, "IDX, Port Hide, Slot Impl, Slot Number, HotPlug, PcieSSD, VppPort, VppAddress, Interlock\n"));
+  DEBUG((DEBUG_INFO, "IDX, Port Hide, Slot Impl, Slot Number, HotPlug, PcieSSD, VppPort, VppAddress, Interlock\n"));
   for (Index = Port; Index < (Port + NumberOfPorts); Index++ ) {
-  DEBUG((EFI_D_INFO, "%3d|   %2d    |    %2d    |   %3d      |   %3d  |  %3d  |  0x%02x  |  0x%02x     |  %2d      \n", \
+  DEBUG((DEBUG_INFO, "%3d|   %2d    |    %2d    |   %3d      |   %3d  |  %3d  |  0x%02x  |  0x%02x     |  %2d      \n", \
                        Index, \
                        IioGlobalData->SetupData.PEXPHIDE[Index],  \
                        IioGlobalData->SetupData.SLOTIMP[Index],   \
@@ -505,13 +505,13 @@ DumpIioConfiguration(
   UINT8 IouPorts;
   PortIndex = iio * NUMBER_PORTS_PER_SOCKET;
   /// First dump the socket number;
-  DEBUG((EFI_D_INFO, "Socket number: %d \n", iio));
+  DEBUG((DEBUG_INFO, "Socket number: %d \n", iio));
 
   /// Dump DMI configuration:
   if ((iio == 0) && (PortIndex == 0)){
-      DEBUG((EFI_D_INFO, "PORT 0: DMI Port\n"));
+      DEBUG((DEBUG_INFO, "PORT 0: DMI Port\n"));
   } else {
-      DEBUG((EFI_D_INFO, "PORT 0: DMI Port working as PCIE\n"));
+      DEBUG((DEBUG_INFO, "PORT 0: DMI Port working as PCIE\n"));
       DumpPort(IioGlobalData, PortIndex, 1);
   }
   IouPorts=4;
@@ -524,30 +524,30 @@ DumpIioConfiguration(
         case Iio_Iou0:
           Bifurcation = IioGlobalData->SetupData.ConfigIOU0[iio];
           PortIndex += PORT_1A_INDEX;
-          DEBUG((EFI_D_INFO, "IUO0: Root Port 1, Bifurcation: %d\n", Bifurcation));
+          DEBUG((DEBUG_INFO, "IUO0: Root Port 1, Bifurcation: %d\n", Bifurcation));
           break;
         case Iio_Iou1:
           Bifurcation = IioGlobalData->SetupData.ConfigIOU1[iio];
           PortIndex += PORT_2A_INDEX;
-          DEBUG((EFI_D_INFO, "IUO1: Root Port 2, Bifurcation: %d\n", Bifurcation));
+          DEBUG((DEBUG_INFO, "IUO1: Root Port 2, Bifurcation: %d\n", Bifurcation));
           break;
         case Iio_Iou2:
           Bifurcation = IioGlobalData->SetupData.ConfigIOU2[iio];
           PortIndex += PORT_3A_INDEX;
-          DEBUG((EFI_D_INFO, "IUO2: Root Port 3, Bifurcation: %d\n", Bifurcation));
+          DEBUG((DEBUG_INFO, "IUO2: Root Port 3, Bifurcation: %d\n", Bifurcation));
           break;
         case Iio_Mcp0:
           Bifurcation = IioGlobalData->SetupData.ConfigMCP0[iio];
           PortIndex += PORT_4A_INDEX;
-          DEBUG((EFI_D_INFO, "MCP0, Bifurcation: %d\n", Bifurcation));
+          DEBUG((DEBUG_INFO, "MCP0, Bifurcation: %d\n", Bifurcation));
           break;
         case Iio_Mcp1:
           Bifurcation = IioGlobalData->SetupData.ConfigMCP1[iio];
           PortIndex += PORT_5A_INDEX;
-          DEBUG((EFI_D_INFO, "MCP1, Bifurcation: %d\n", Bifurcation));
+          DEBUG((DEBUG_INFO, "MCP1, Bifurcation: %d\n", Bifurcation));
           break;
         default:
-          DEBUG((EFI_D_INFO, "Iou no detected = %d",Iou));
+          DEBUG((DEBUG_INFO, "Iou no detected = %d",Iou));
           break;
         }
       DumpPort(IioGlobalData, PortIndex, IouPorts);

--- a/Platform/Intel/PurleyOpenBoardPkg/Policy/SystemBoard/SystemBoardPei.c
+++ b/Platform/Intel/PurleyOpenBoardPkg/Policy/SystemBoard/SystemBoardPei.c
@@ -157,7 +157,7 @@ InternalDumpData (
 {
   UINTN  Index;
   for (Index = 0; Index < Size; Index++) {
-    DEBUG ((EFI_D_INFO, "%02x", (UINTN)Data[Index]));
+    DEBUG ((DEBUG_INFO, "%02x", (UINTN)Data[Index]));
   }
 }
 
@@ -184,15 +184,15 @@ InternalDumpHex (
   Count = Size / COLUME_SIZE;
   Left  = Size % COLUME_SIZE;
   for (Index = 0; Index < Count; Index++) {
-    DEBUG ((EFI_D_INFO, "%04x: ", Index * COLUME_SIZE));
+    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
     InternalDumpData (Data + Index * COLUME_SIZE, COLUME_SIZE);
-    DEBUG ((EFI_D_INFO, "\n"));
+    DEBUG ((DEBUG_INFO, "\n"));
   }
 
   if (Left != 0) {
-    DEBUG ((EFI_D_INFO, "%04x: ", Index * COLUME_SIZE));
+    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
     InternalDumpData (Data + Index * COLUME_SIZE, Left);
-    DEBUG ((EFI_D_INFO, "\n"));
+    DEBUG ((DEBUG_INFO, "\n"));
   }
 }
 
@@ -242,7 +242,7 @@ SystemBoardPeiEntry (
 {
   EFI_STATUS Status;
 
-  DEBUG ((EFI_D_ERROR, "--> SystemBoard PEI BoardDetection\n"));
+  DEBUG ((DEBUG_ERROR, "--> SystemBoard PEI BoardDetection\n"));
 
   //DumpConfig ();
 

--- a/Platform/Intel/QuarkPlatformPkg/Acpi/Dxe/AcpiPlatform/AcpiPciUpdate.c
+++ b/Platform/Intel/QuarkPlatformPkg/Acpi/Dxe/AcpiPlatform/AcpiPciUpdate.c
@@ -751,13 +751,13 @@ SdtCheckParentPackage (
     //
     // There is valid INTA update item, but no INA package exist, should add it
     //
-    DEBUG ((EFI_D_ERROR, "\n\nShould add INTA item for this device(0x%x)\n\n", PciAddress));
+    DEBUG ((DEBUG_ERROR, "\n\nShould add INTA item for this device(0x%x)\n\n", PciAddress));
 
   } else if ((PciDeviceInfo->INTA[IsAPIC] == 0xFF) && (INTAPkgHandle != NULL) && IsAllFunctions) {
     //
     // For all functions senario, if there is invalid INTA update item, but INTA package does exist, should delete it
     //
-    DEBUG ((EFI_D_ERROR, "\n\nShould remove INTA item for this device(0x%x)\n\n", PciAddress));
+    DEBUG ((DEBUG_ERROR, "\n\nShould remove INTA item for this device(0x%x)\n\n", PciAddress));
 
   }
 
@@ -773,13 +773,13 @@ SdtCheckParentPackage (
     //
     // There is valid INTB update item, but no INTB package exist, should add it
     //
-    DEBUG ((EFI_D_ERROR, "\n\nShould add INTB item for this device(0x%x)\n\n", PciAddress));
+    DEBUG ((DEBUG_ERROR, "\n\nShould add INTB item for this device(0x%x)\n\n", PciAddress));
 
   } else if ((PciDeviceInfo->INTB[IsAPIC] == 0xFF) && (INTBPkgHandle != NULL) && IsAllFunctions) {
     //
     // For all functions senario, if there is invalid INTB update item, but INTB package does exist, should delete it
     //
-    DEBUG ((EFI_D_ERROR, "\n\nShould remove INTB item for this device(0x%x)\n\n", PciAddress));
+    DEBUG ((DEBUG_ERROR, "\n\nShould remove INTB item for this device(0x%x)\n\n", PciAddress));
 
   }
 
@@ -795,13 +795,13 @@ SdtCheckParentPackage (
     //
     // There is valid INTC update item, but no INTC package exist, should add it
     //
-    DEBUG ((EFI_D_ERROR, "\n\nShould add INTC item for this device(0x%x)\n\n", PciAddress));
+    DEBUG ((DEBUG_ERROR, "\n\nShould add INTC item for this device(0x%x)\n\n", PciAddress));
 
   } else if ((PciDeviceInfo->INTC[IsAPIC] == 0xFF) && (INTCPkgHandle != NULL) && IsAllFunctions) {
     //
     // For all functions senario, if there is invalid INTC update item, but INTC package does exist, should delete it
     //
-    DEBUG ((EFI_D_ERROR, "\n\nShould remove INTC item for this device(0x%x)\n\n", PciAddress));
+    DEBUG ((DEBUG_ERROR, "\n\nShould remove INTC item for this device(0x%x)\n\n", PciAddress));
   }
 
   //
@@ -816,13 +816,13 @@ SdtCheckParentPackage (
     //
     // There is valid INTD update item, but no INTD package exist, should add it
     //
-    DEBUG ((EFI_D_ERROR, "\n\nShould add INTD item for this device(0x%x)\n\n", PciAddress));
+    DEBUG ((DEBUG_ERROR, "\n\nShould add INTD item for this device(0x%x)\n\n", PciAddress));
 
   }  else if ((PciDeviceInfo->INTD[IsAPIC] == 0xFF) && (INTDPkgHandle != NULL) && IsAllFunctions) {
     //
     // For all functions senario, if there is invalid INTD update item, but INTD package does exist, should delete it
     //
-    DEBUG ((EFI_D_ERROR, "\n\nShould remove INTD item for this device(0x%x)\n\n", PciAddress));
+    DEBUG ((DEBUG_ERROR, "\n\nShould remove INTD item for this device(0x%x)\n\n", PciAddress));
   }
 
 
@@ -1374,7 +1374,7 @@ SdtCheckPciDeviceInfoChanged (
       if (CompareMem (&(mQNCPciInfo[Index].INTA[0]), &PciDeviceInfo->INTA[0], 10) == 0) {
         *UpdatePRT = FALSE;
         *UpdatePRW = FALSE;
-        //DEBUG ((EFI_D_ERROR, "Find one matched entry[%d] and no change\n", Index));
+        //DEBUG ((DEBUG_ERROR, "Find one matched entry[%d] and no change\n", Index));
       } else {
         if (CompareMem (&(mQNCPciInfo[Index].INTA[0]), &PciDeviceInfo->INTA[0], 8) == 0)
           *UpdatePRT = FALSE;
@@ -1388,14 +1388,14 @@ SdtCheckPciDeviceInfoChanged (
         if (*(UINT16 *)(&PciDeviceInfo->GPEPin) == 0xFFFF)
           *UpdatePRW = FALSE;
 
-        //DEBUG ((EFI_D_ERROR, "Find one matched entry[%d] and but need update PRT:0x%x PRW:0x%x\n", Index, *UpdatePRT, *UpdatePRW));
+        //DEBUG ((DEBUG_ERROR, "Find one matched entry[%d] and but need update PRT:0x%x PRW:0x%x\n", Index, *UpdatePRT, *UpdatePRW));
       }
       break;
     }
   }
 
   //if (Index == 42) {
-  //  DEBUG ((EFI_D_ERROR, "Find No matched entry\n"));
+  //  DEBUG ((DEBUG_ERROR, "Find No matched entry\n"));
   //}
 
   return;

--- a/Platform/Intel/QuarkPlatformPkg/Acpi/Dxe/AcpiPlatform/AcpiPlatform.c
+++ b/Platform/Intel/QuarkPlatformPkg/Acpi/Dxe/AcpiPlatform/AcpiPlatform.c
@@ -755,7 +755,7 @@ AcpiPlatformEntryPoint (
           //
           if ((PciDeviceInfo->BridgeAddress != 0xFFFFFFFF) && (PciDeviceInfo->DeviceAddress != 0xFFFFFFFF)) {
 
-            //DEBUG ((EFI_D_ERROR, "Valid pci info structure: bridge address:0x%x, device address:0x%x\n", PciDeviceInfo->BridgeAddress, PciDeviceInfo->DeviceAddress));
+            //DEBUG ((DEBUG_ERROR, "Valid pci info structure: bridge address:0x%x, device address:0x%x\n", PciDeviceInfo->BridgeAddress, PciDeviceInfo->DeviceAddress));
 
             UpdatePRT = FALSE;
             UpdatePRW = FALSE;
@@ -768,7 +768,7 @@ AcpiPlatformEntryPoint (
               //
               // Update the pci routing information
               //
-              //DEBUG ((EFI_D_ERROR, "Update _PRT\n"));
+              //DEBUG ((DEBUG_ERROR, "Update _PRT\n"));
               SdtUpdatePciRouting (mAcpiSdt, PciRootHandle, PciDeviceInfo);
             }
             //
@@ -778,7 +778,7 @@ AcpiPlatformEntryPoint (
               //
               // Update the pci wakeup information
               //
-              //DEBUG ((EFI_D_ERROR, "Update _PRW\n"));
+              //DEBUG ((DEBUG_ERROR, "Update _PRW\n"));
               SdtUpdatePowerWake (mAcpiSdt, PciRootHandle, PciDeviceInfo);
             }
           }

--- a/Platform/Intel/QuarkPlatformPkg/Acpi/DxeSmm/AcpiSmm/AcpiSmmPlatform.c
+++ b/Platform/Intel/QuarkPlatformPkg/Acpi/DxeSmm/AcpiSmm/AcpiSmmPlatform.c
@@ -238,8 +238,8 @@ Returns:
   TsegBase  = (UINTN)DescriptorBlock->Descriptor[TsegIndex].PhysicalStart;
   TsegSize  = (UINTN)DescriptorBlock->Descriptor[TsegIndex].PhysicalSize;
 
-  DEBUG ((EFI_D_INFO, "SMM  Base: %08X\n", TsegBase));
-  DEBUG ((EFI_D_INFO, "SMM  Size: %08X\n", TsegSize));
+  DEBUG ((DEBUG_INFO, "SMM  Base: %08X\n", TsegBase));
+  DEBUG ((DEBUG_INFO, "SMM  Size: %08X\n", TsegSize));
 
   //
   // Now find the location of the data structure that is used to store the address
@@ -258,9 +258,9 @@ Returns:
   }
   AcpiS3Range->SystemMemoryLength = (UINT32)SystemMemoryLength;
 
-  DEBUG ((EFI_D_INFO, "S3 Memory  Base:    %08X\n", AcpiS3Range->AcpiReservedMemoryBase));
-  DEBUG ((EFI_D_INFO, "S3 Memory  Size:    %08X\n", AcpiS3Range->AcpiReservedMemorySize));
-  DEBUG ((EFI_D_INFO, "S3 SysMemoryLength: %08X\n", AcpiS3Range->SystemMemoryLength));
+  DEBUG ((DEBUG_INFO, "S3 Memory  Base:    %08X\n", AcpiS3Range->AcpiReservedMemoryBase));
+  DEBUG ((DEBUG_INFO, "S3 Memory  Size:    %08X\n", AcpiS3Range->AcpiReservedMemorySize));
+  DEBUG ((DEBUG_INFO, "S3 SysMemoryLength: %08X\n", AcpiS3Range->SystemMemoryLength));
 
   return EFI_SUCCESS;
 }

--- a/Platform/Intel/QuarkPlatformPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/Platform/Intel/QuarkPlatformPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -289,7 +289,7 @@ PlatformBootManagerBeforeConsole (
   gBS->SignalEvent (EndOfDxeEvent);
   gBS->CloseEvent (EndOfDxeEvent);
 
-  DEBUG((EFI_D_INFO,"All EndOfDxe callbacks have returned successfully\n"));
+  DEBUG((DEBUG_INFO,"All EndOfDxe callbacks have returned successfully\n"));
 
   //
   // Install SMM Ready To Lock protocol so all resources can be locked down

--- a/Platform/Intel/QuarkPlatformPkg/Library/PlatformHelperLib/PlatformHelperDxe.c
+++ b/Platform/Intel/QuarkPlatformPkg/Library/PlatformHelperLib/PlatformHelperDxe.c
@@ -173,9 +173,9 @@ PlatformFlashLockConfig (
     Status = SpiProtocol->Lock (SpiProtocol);
 
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Platform: Spi Config Locked Down\n"));
+      DEBUG ((DEBUG_INFO, "Platform: Spi Config Locked Down\n"));
     } else if (Status == EFI_ACCESS_DENIED) {
-      DEBUG ((EFI_D_INFO, "Platform: Spi Config already locked down\n"));
+      DEBUG ((DEBUG_INFO, "Platform: Spi Config already locked down\n"));
     } else {
       ASSERT_EFI_ERROR (Status);
     }
@@ -243,7 +243,7 @@ PlatformFlashLockPolicy (
   SpiFlashDeviceSize = (UINTN) PcdGet32 (PcdSpiFlashDeviceSize);
   CpuAddressFlashDevice = SIZE_4GB - SpiFlashDeviceSize;
   DEBUG (
-      (EFI_D_INFO,
+      (DEBUG_INFO,
       "Platform:FlashDeviceSize = 0x%08x Bytes\n",
       SpiFlashDeviceSize)
       );
@@ -264,7 +264,7 @@ PlatformFlashLockPolicy (
     SpiAddress = 0;
     if (!PlatformIsSpiRangeProtected ((UINT32) SpiAddress, (UINT32) (CpuAddressNvStorage - CpuAddressFlashDevice))) {
       DEBUG (
-        (EFI_D_INFO,
+        (DEBUG_INFO,
         "Platform: Protect Region Base:Len 0x%08x:0x%08x\n",
         (UINTN) SpiAddress, (UINTN)(CpuAddressNvStorage - CpuAddressFlashDevice))
         );
@@ -287,7 +287,7 @@ PlatformFlashLockPolicy (
     //
     if (!PlatformIsSpiRangeProtected ((UINT32) SpiAddress, SpiFlashDeviceSize - ((UINT32) SpiAddress))) {
       DEBUG (
-        (EFI_D_INFO,
+        (DEBUG_INFO,
         "Platform: Protect Region Base:Len 0x%08x:0x%08x\n",
         (UINTN) SpiAddress,
         (UINTN) (SpiFlashDeviceSize - ((UINT32) SpiAddress)))

--- a/Platform/Intel/QuarkPlatformPkg/Library/PlatformSecureLib/PlatformSecureLib.c
+++ b/Platform/Intel/QuarkPlatformPkg/Library/PlatformSecureLib/PlatformSecureLib.c
@@ -33,7 +33,7 @@ CheckResetButtonState (
   UINTN                   ReadLength;
   UINT8                   Buffer[2];
 
-  DEBUG ((EFI_D_INFO, "CheckResetButtonState(): mPlatformType == %d\n", mPlatformType));
+  DEBUG ((DEBUG_INFO, "CheckResetButtonState(): mPlatformType == %d\n", mPlatformType));
   if (mPlatformType == GalileoGen2) {
     //
     // Read state of Reset Button - EXP2.P1_7
@@ -54,7 +54,7 @@ CheckResetButtonState (
     } else {
       I2CSlaveAddress.I2CDeviceAddress = GALILEO_IOEXP_J2LO_7BIT_SLAVE_ADDR;
     }
-    DEBUG ((EFI_D_INFO, "Galileo GPIO Expender Slave Address = %02x\n", I2CSlaveAddress.I2CDeviceAddress));
+    DEBUG ((DEBUG_INFO, "Galileo GPIO Expender Slave Address = %02x\n", I2CSlaveAddress.I2CDeviceAddress));
 
     //
     // Read state of RESET_N_SHLD (GPORT5_BIT0)

--- a/Platform/Intel/QuarkPlatformPkg/Library/Tpm12DeviceLibAtmelI2c/TisPc.c
+++ b/Platform/Intel/QuarkPlatformPkg/Library/Tpm12DeviceLibAtmelI2c/TisPc.c
@@ -57,7 +57,7 @@ WriteTpmBufferMultiple (
 
   I2CDeviceAddr.I2CDeviceAddress = ATMEL_I2C_TPM_SLAVE_ADDRESS;
 
-  DEBUG ((EFI_D_VERBOSE, "WriteTpmBufferMultiple: Addr=%02x  Length=%02x\n", I2CDeviceAddr.I2CDeviceAddress, Length));
+  DEBUG ((DEBUG_VERBOSE, "WriteTpmBufferMultiple: Addr=%02x  Length=%02x\n", I2CDeviceAddr.I2CDeviceAddress, Length));
 
   for (PartialLength = 0; Length > 0; Length -= PartialLength, Buffer += PartialLength) {
     //
@@ -70,18 +70,18 @@ WriteTpmBufferMultiple (
       &PartialLength,
       Buffer
       );
-    DEBUG ((EFI_D_VERBOSE, "  "));
+    DEBUG ((DEBUG_VERBOSE, "  "));
     for (Index = 0; Index < PartialLength; Index++) {
-      DEBUG ((EFI_D_VERBOSE, "%02x ", Buffer[Index]));
+      DEBUG ((DEBUG_VERBOSE, "%02x ", Buffer[Index]));
     }
-    DEBUG ((EFI_D_VERBOSE, "\n"));
+    DEBUG ((DEBUG_VERBOSE, "\n"));
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_VERBOSE, "  Status = %r\n", Status));
+      DEBUG ((DEBUG_VERBOSE, "  Status = %r\n", Status));
       return Status;
     }
   }
 
-  DEBUG ((EFI_D_VERBOSE, "  Status = %r\n", Status));
+  DEBUG ((DEBUG_VERBOSE, "  Status = %r\n", Status));
   return Status;
 }
 
@@ -113,7 +113,7 @@ ReadTpmBufferMultiple (
   I2CDeviceAddr.I2CDeviceAddress = ATMEL_I2C_TPM_SLAVE_ADDRESS;
   WriteLength = 0;
 
-  DEBUG ((EFI_D_VERBOSE, "ReadTpmBufferMultiple: Addr=%02x  Length=%02x\n", I2CDeviceAddr.I2CDeviceAddress, Length));
+  DEBUG ((DEBUG_VERBOSE, "ReadTpmBufferMultiple: Addr=%02x  Length=%02x\n", I2CDeviceAddr.I2CDeviceAddress, Length));
 
   for (PartialLength = 0; Length > 0; Length -= PartialLength, Buffer += PartialLength) {
     //
@@ -128,19 +128,19 @@ ReadTpmBufferMultiple (
       Buffer
       );
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_VERBOSE, "  "));
+      DEBUG ((DEBUG_VERBOSE, "  "));
       for (Index = 0; Index < PartialLength; Index++) {
-        DEBUG ((EFI_D_VERBOSE, "%02x ", Buffer[Index]));
+        DEBUG ((DEBUG_VERBOSE, "%02x ", Buffer[Index]));
       }
-      DEBUG ((EFI_D_VERBOSE, "\n"));
+      DEBUG ((DEBUG_VERBOSE, "\n"));
     }
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_VERBOSE, "  Status = %r\n", Status));
+      DEBUG ((DEBUG_VERBOSE, "  Status = %r\n", Status));
       return Status;
     }
   }
 
-  DEBUG ((EFI_D_VERBOSE, "  Status = %r\n", Status));
+  DEBUG ((DEBUG_VERBOSE, "  Status = %r\n", Status));
   return Status;
 }
 
@@ -216,7 +216,7 @@ Tpm12RequestUseTpm (
     Total += Delta;
     if (Total >= Timeout) {
       Status = EFI_TIMEOUT;
-      DEBUG ((EFI_D_ERROR, "Atmel I2C TPM failed to read: %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Atmel I2C TPM failed to read: %r\n", Status));
       return Status;
     }
   } while (EFI_ERROR (Status));
@@ -394,7 +394,7 @@ Tpm12SubmitCommand (
 
 Done:
   DEBUG ((
-    EFI_D_VERBOSE,
+    DEBUG_VERBOSE,
     "Tpm12SubmitCommand() Status = %r  Time = %ld ms\n",
     Status,
     DivU64x64Remainder (

--- a/Platform/Intel/QuarkPlatformPkg/Library/Tpm12DeviceLibInfineonI2c/TisPc.c
+++ b/Platform/Intel/QuarkPlatformPkg/Library/Tpm12DeviceLibInfineonI2c/TisPc.c
@@ -156,7 +156,7 @@ TpmWriteByte (
              &WriteData
              );
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "TpmWriteByte(): I2C Write to TPM address %0x failed (%r)\n", TpmAddress, Status));
+    DEBUG ((DEBUG_ERROR, "TpmWriteByte(): I2C Write to TPM address %0x failed (%r)\n", TpmAddress, Status));
     ASSERT (FALSE);  // Writes to TPM should always succeed.
   }
 
@@ -224,7 +224,7 @@ TpmReadByte (
                );
 
     if (EFI_ERROR(Status)) {
-      DEBUG ((EFI_D_INFO, "TpmReadByte(): write to TPM address %0x failed (%r)\n", TpmAddress, Status));
+      DEBUG ((DEBUG_INFO, "TpmReadByte(): write to TPM address %0x failed (%r)\n", TpmAddress, Status));
     }
 
     mI2CPrevReadTransfer = FALSE;
@@ -240,7 +240,7 @@ TpmReadByte (
                );
 
     if (EFI_ERROR(Status)) {
-      DEBUG ((EFI_D_INFO, "TpmReadByte(): read from TPM address %0x failed (%r)\n", TpmAddress, Status));
+      DEBUG ((DEBUG_INFO, "TpmReadByte(): read from TPM address %0x failed (%r)\n", TpmAddress, Status));
       ReadData = 0xFF;
     } else {
       ReadData = Data[0];
@@ -264,7 +264,7 @@ TpmReadByte (
     //  Only reads to access register allowed to fail.
     //
     if (TpmAddress != INFINEON_TPM_ACCESS_0_ADDRESS_DEFAULT) {
-      DEBUG ((EFI_D_ERROR, "TpmReadByte(): read from TPM address %0x failed\n", TpmAddress));
+      DEBUG ((DEBUG_ERROR, "TpmReadByte(): read from TPM address %0x failed\n", TpmAddress));
       ASSERT_EFI_ERROR (Status);
     }
   }

--- a/Platform/Intel/QuarkPlatformPkg/Pci/Dxe/PciHostBridge/PciHostBridge.c
+++ b/Platform/Intel/QuarkPlatformPkg/Pci/Dxe/PciHostBridge/PciHostBridge.c
@@ -125,7 +125,7 @@ Returns:
   ASSERT_EFI_ERROR (Status);
   ZeroMem (mResAperture, HostBridge->RootBridgeCount * sizeof(PCI_ROOT_BRIDGE_RESOURCE_APERTURE));
 
-  DEBUG ((EFI_D_INFO, "Address of resource Aperture:  %x\n", mResAperture));
+  DEBUG ((DEBUG_INFO, "Address of resource Aperture:  %x\n", mResAperture));
 
   //
   // Create Root Bridge Device Handle in this Host Bridge
@@ -158,14 +158,14 @@ Returns:
   PrivateData->Aperture.IoBase  = PcdGet16 (PcdPciHostBridgeIoBase);
   PrivateData->Aperture.IoLimit = PcdGet16 (PcdPciHostBridgeIoBase) + (PcdGet16 (PcdPciHostBridgeIoSize) - 1);
 
-  DEBUG ((EFI_D_INFO, "PCI Host Bridge BusBase:               %x\n",  QNC_PCI_HOST_BRIDGE_RESOURCE_APPETURE_BUSBASE));
-  DEBUG ((EFI_D_INFO, "PCI Host Bridge BusLimit:              %x\n",  QNC_PCI_HOST_BRIDGE_RESOURCE_APPETURE_BUSLIMIT));
-  DEBUG ((EFI_D_INFO, "PCI Host Bridge PciResourceMem32Base:  %x\n",  PcdGet32 (PcdPciHostBridgeMemory32Base)));
-  DEBUG ((EFI_D_INFO, "PCI Host Bridge PciResourceMem32Limit: %x\n",  PcdGet32 (PcdPciHostBridgeMemory32Base) + (PcdGet32 (PcdPciHostBridgeMemory32Size) - 1)));
-  DEBUG ((EFI_D_INFO, "PCI Host Bridge PciResourceMem64Base:  %lX\n", PcdGet64 (PcdPciHostBridgeMemory64Base)));
-  DEBUG ((EFI_D_INFO, "PCI Host Bridge PciResourceMem64Limit: %lX\n", PcdGet64 (PcdPciHostBridgeMemory64Base) + (PcdGet64 (PcdPciHostBridgeMemory64Size) - 1)));
-  DEBUG ((EFI_D_INFO, "PCI Host Bridge PciResourceIoBase:     %x\n",  PcdGet16 (PcdPciHostBridgeIoBase)));
-  DEBUG ((EFI_D_INFO, "PCI Host Bridge PciResourceIoLimit:    %x\n",  PcdGet16 (PcdPciHostBridgeIoBase) + (PcdGet16 (PcdPciHostBridgeIoSize) - 1)));
+  DEBUG ((DEBUG_INFO, "PCI Host Bridge BusBase:               %x\n",  QNC_PCI_HOST_BRIDGE_RESOURCE_APPETURE_BUSBASE));
+  DEBUG ((DEBUG_INFO, "PCI Host Bridge BusLimit:              %x\n",  QNC_PCI_HOST_BRIDGE_RESOURCE_APPETURE_BUSLIMIT));
+  DEBUG ((DEBUG_INFO, "PCI Host Bridge PciResourceMem32Base:  %x\n",  PcdGet32 (PcdPciHostBridgeMemory32Base)));
+  DEBUG ((DEBUG_INFO, "PCI Host Bridge PciResourceMem32Limit: %x\n",  PcdGet32 (PcdPciHostBridgeMemory32Base) + (PcdGet32 (PcdPciHostBridgeMemory32Size) - 1)));
+  DEBUG ((DEBUG_INFO, "PCI Host Bridge PciResourceMem64Base:  %lX\n", PcdGet64 (PcdPciHostBridgeMemory64Base)));
+  DEBUG ((DEBUG_INFO, "PCI Host Bridge PciResourceMem64Limit: %lX\n", PcdGet64 (PcdPciHostBridgeMemory64Base) + (PcdGet64 (PcdPciHostBridgeMemory64Size) - 1)));
+  DEBUG ((DEBUG_INFO, "PCI Host Bridge PciResourceIoBase:     %x\n",  PcdGet16 (PcdPciHostBridgeIoBase)));
+  DEBUG ((DEBUG_INFO, "PCI Host Bridge PciResourceIoLimit:    %x\n",  PcdGet16 (PcdPciHostBridgeIoBase) + (PcdGet16 (PcdPciHostBridgeIoSize) - 1)));
 
   PrivateData->Handle = NULL;
   Status = gBS->InstallMultipleProtocolInterfaces (
@@ -354,10 +354,10 @@ Returns:
             }
 
             RootBridgeInstance = DRIVER_INSTANCE_FROM_LIST_ENTRY (List);
-            DEBUG ((EFI_D_INFO, "Address of RootBridgeInstance:   %x)\n", RootBridgeInstance));
-            DEBUG ((EFI_D_INFO, "  Signature:              %x\n", RootBridgeInstance->Signature));
-            DEBUG ((EFI_D_INFO, "  Bus Number Assigned:    %x\n", RootBridgeInstance->BusNumberAssigned));
-            DEBUG ((EFI_D_INFO, "  Bus Scan Count:         %x\n", RootBridgeInstance->BusScanCount));
+            DEBUG ((DEBUG_INFO, "Address of RootBridgeInstance:   %x)\n", RootBridgeInstance));
+            DEBUG ((DEBUG_INFO, "  Signature:              %x\n", RootBridgeInstance->Signature));
+            DEBUG ((DEBUG_INFO, "  Bus Number Assigned:    %x\n", RootBridgeInstance->BusNumberAssigned));
+            DEBUG ((DEBUG_INFO, "  Bus Scan Count:         %x\n", RootBridgeInstance->BusScanCount));
 
             for (Index1 = TypeIo; Index1 < TypeBus; Index1++) {
               if (RootBridgeInstance->ResAllocNode[Index1].Status == ResNone) {
@@ -396,9 +396,9 @@ Returns:
                 AddrLen   = RootBridgeInstance->ResAllocNode[Index].Length;
                 Alignment = RootBridgeInstance->ResAllocNode[Index].Alignment;
 
-                DEBUG ((EFI_D_INFO, "\n\nResource Type to assign :   %x\n", Index));
-                DEBUG ((EFI_D_INFO, "  Length to allocate:       %x\n", RootBridgeInstance->ResAllocNode[Index].Length));
-                DEBUG ((EFI_D_INFO, "  Aligment:                 %x\n", Alignment));
+                DEBUG ((DEBUG_INFO, "\n\nResource Type to assign :   %x\n", Index));
+                DEBUG ((DEBUG_INFO, "  Length to allocate:       %x\n", RootBridgeInstance->ResAllocNode[Index].Length));
+                DEBUG ((DEBUG_INFO, "  Aligment:                 %x\n", Alignment));
 
                 switch (Index) {
                   case TypeIo:
@@ -493,17 +493,17 @@ Returns:
 
                         while(RootBridgeInstance->Aperture.Mem32Base <= BaseAddress) {
 
-                          DEBUG ((EFI_D_INFO, "      Attempting %x allocation at 0x%lx .....", Index, BaseAddress));
+                          DEBUG ((DEBUG_INFO, "      Attempting %x allocation at 0x%lx .....", Index, BaseAddress));
                           Status = gDS->AllocateMemorySpace ( EfiGcdAllocateAddress, EfiGcdMemoryTypeMemoryMappedIo,
                                                   BitsOfAlignment, AddrLen, &BaseAddress, mDriverImageHandle, NULL);
 
                           if (!EFI_ERROR (Status)) {
                             RootBridgeInstance->ResAllocNode[Index].Base    = (UINT64) BaseAddress;
                             RootBridgeInstance->ResAllocNode[Index].Status  = ResAllocated;
-                            DEBUG ((EFI_D_INFO, "... Passed!!\n"));
+                            DEBUG ((DEBUG_INFO, "... Passed!!\n"));
                             goto TypePMem32Found;
                           }
-                          DEBUG ((EFI_D_INFO, "... Failed!!\n"));
+                          DEBUG ((DEBUG_INFO, "... Failed!!\n"));
                           BaseAddress -= (Alignment + 1);
                         } // while
                       } // if
@@ -533,10 +533,10 @@ Returns:
                       break;
                 } // End switch (Index)
 
-                DEBUG ((EFI_D_INFO, "Resource Type Assigned:   %x\n", Index));
+                DEBUG ((DEBUG_INFO, "Resource Type Assigned:   %x\n", Index));
                 if (RootBridgeInstance->ResAllocNode[Index].Status == ResAllocated) {
-                  DEBUG ((EFI_D_INFO, "  Base Address Assigned: %x\n", RootBridgeInstance->ResAllocNode[Index].Base));
-                  DEBUG ((EFI_D_INFO, "  Length Assigned:       %x\n", RootBridgeInstance->ResAllocNode[Index].Length));
+                  DEBUG ((DEBUG_INFO, "  Base Address Assigned: %x\n", RootBridgeInstance->ResAllocNode[Index].Base));
+                  DEBUG ((DEBUG_INFO, "  Length Assigned:       %x\n", RootBridgeInstance->ResAllocNode[Index].Length));
                 } else {
                   DEBUG ((DEBUG_ERROR, "  Resource Allocation failed!  There was no room at the inn\n"));
                 }
@@ -1025,8 +1025,8 @@ Returns:
       //
       while (*Temp == ACPI_ADDRESS_SPACE_DESCRIPTOR) {
         ptr = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *) Temp;
-        DEBUG ((EFI_D_INFO, " ptr->ResType:%x \n",ptr->ResType));
-        DEBUG ((EFI_D_INFO, "  ptr->AddrLen:0x%lx AddrRangeMin:0x%lx AddrRangeMax:0x%lx\n\n",ptr->AddrLen,ptr->AddrRangeMin,ptr->AddrRangeMax));
+        DEBUG ((DEBUG_INFO, " ptr->ResType:%x \n",ptr->ResType));
+        DEBUG ((DEBUG_INFO, "  ptr->AddrLen:0x%lx AddrRangeMin:0x%lx AddrRangeMax:0x%lx\n\n",ptr->AddrLen,ptr->AddrRangeMin,ptr->AddrRangeMax));
 
         switch (ptr->ResType) {
           case ACPI_ADDRESS_SPACE_TYPE_MEM:

--- a/Platform/Intel/QuarkPlatformPkg/Platform/Dxe/PlatformInit/PlatformConfig.c
+++ b/Platform/Intel/QuarkPlatformPkg/Platform/Dxe/PlatformInit/PlatformConfig.c
@@ -254,7 +254,7 @@ Returns:
   //
   QNCGetTSEGMemoryRange (&BaseAddress, &SmramLength);
   NewValue = (UINT32)(BaseAddress + SmramLength);
-  DEBUG ((EFI_D_INFO,"Locking HMBOUND at: = 0x%8x\n",NewValue));
+  DEBUG ((DEBUG_INFO,"Locking HMBOUND at: = 0x%8x\n",NewValue));
   QNCPortWrite (QUARK_NC_HOST_BRIDGE_SB_PORT_ID, QUARK_NC_HOST_BRIDGE_HMBOUND_REG, (NewValue | HMBOUND_LOCK));
 
   //

--- a/Platform/Intel/QuarkPlatformPkg/Platform/Dxe/PlatformInit/PlatformInitDxe.c
+++ b/Platform/Intel/QuarkPlatformPkg/Platform/Dxe/PlatformInit/PlatformInitDxe.c
@@ -19,16 +19,16 @@ GetQncName (
   VOID
   )
 {
-  DEBUG  ((EFI_D_INFO, "QNC Name: "));
+  DEBUG  ((DEBUG_INFO, "QNC Name: "));
   switch (PciRead16 (PCI_LIB_ADDRESS (MC_BUS, MC_DEV, MC_FUN, PCI_DEVICE_ID_OFFSET))) {
   case QUARK_MC_DEVICE_ID:
-    DEBUG  ((EFI_D_INFO, "Quark"));
+    DEBUG  ((DEBUG_INFO, "Quark"));
     break;
   case QUARK2_MC_DEVICE_ID:
-    DEBUG  ((EFI_D_INFO, "Quark2"));
+    DEBUG  ((DEBUG_INFO, "Quark2"));
     break;
   default:
-    DEBUG  ((EFI_D_INFO, "Unknown"));
+    DEBUG  ((DEBUG_INFO, "Unknown"));
   }
 
   //
@@ -36,10 +36,10 @@ GetQncName (
   //
   switch (PciRead8 (PCI_LIB_ADDRESS (MC_BUS, MC_DEV, MC_FUN, PCI_REVISION_ID_OFFSET))) {
   case QNC_MC_REV_ID_A0:
-    DEBUG  ((EFI_D_INFO, " - A0 stepping\n"));
+    DEBUG  ((DEBUG_INFO, " - A0 stepping\n"));
     break;
   default:
-    DEBUG  ((EFI_D_INFO, " - xx\n"));
+    DEBUG  ((DEBUG_INFO, " - xx\n"));
   }
 
   return;

--- a/Platform/Intel/QuarkPlatformPkg/Platform/Dxe/SmbiosMiscDxe/MiscPortInternalConnectorDesignatorFunction.c
+++ b/Platform/Intel/QuarkPlatformPkg/Platform/Dxe/SmbiosMiscDxe/MiscPortInternalConnectorDesignatorFunction.c
@@ -216,7 +216,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscPortInternalConnectorDesignator)
 
   for (Index = 0; Index < SMBIOS_PORT_CONNECTOR_MAX_NUM; Index++) {
     if (ForType8InputData->PortInternalConnectorDesignator == (mMiscConnectorArray[Index])->PortInternalConnectorDesignator) {
-      //DEBUG ((EFI_D_ERROR, "Found Port Connector Data %d : ", Index));
+      //DEBUG ((DEBUG_ERROR, "Found Port Connector Data %d : ", Index));
       break;
     }
   }

--- a/Platform/Intel/QuarkPlatformPkg/Platform/Dxe/SmbiosMiscDxe/MiscSystemSlotDesignationFunction.c
+++ b/Platform/Intel/QuarkPlatformPkg/Platform/Dxe/SmbiosMiscDxe/MiscSystemSlotDesignationFunction.c
@@ -223,7 +223,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscSystemSlotDesignator)
 
   for (Index = 0; Index < SMBIOS_SYSTEM_SLOT_MAX_NUM; Index++) {
     if (ForType9InputData->SlotDesignation == (mMiscSlotArray[Index])->SlotDesignation) {
-      //DEBUG ((EFI_D_ERROR, "Found slot Data %d : ", Index));
+      //DEBUG ((DEBUG_ERROR, "Found slot Data %d : ", Index));
       break;
     }
   }

--- a/Platform/Intel/QuarkPlatformPkg/Platform/Dxe/SmbiosMiscDxe/SmbiosMiscEntryPoint.c
+++ b/Platform/Intel/QuarkPlatformPkg/Platform/Dxe/SmbiosMiscDxe/SmbiosMiscEntryPoint.c
@@ -49,7 +49,7 @@ SmbiosMiscEntryPoint(
   EfiStatus = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID**)&Smbios);
 
   if (EFI_ERROR(EfiStatus)) {
-    DEBUG((EFI_D_ERROR, "Could not locate SMBIOS protocol.  %r\n", EfiStatus));
+    DEBUG((DEBUG_ERROR, "Could not locate SMBIOS protocol.  %r\n", EfiStatus));
     return EfiStatus;
   }
 
@@ -72,7 +72,7 @@ SmbiosMiscEntryPoint(
         );
 
       if (EFI_ERROR(EfiStatus)) {
-        DEBUG((EFI_D_ERROR, "Misc smbios store error.  Index=%d, ReturnStatus=%r\n", Index, EfiStatus));
+        DEBUG((DEBUG_ERROR, "Misc smbios store error.  Index=%d, ReturnStatus=%r\n", Index, EfiStatus));
         return EfiStatus;
       }
     }

--- a/Platform/Intel/QuarkPlatformPkg/Platform/Pei/PlatformInit/BootMode.c
+++ b/Platform/Intel/QuarkPlatformPkg/Platform/Pei/PlatformInit/BootMode.c
@@ -41,7 +41,7 @@ IsBootWithNoChange (
   IsFirstBoot = PcdGetBool(PcdBootState);
   EnableFastBoot = PcdGetBool (PcdEnableFastBoot);
 
-  DEBUG ((EFI_D_INFO, "IsFirstBoot = %x , EnableFastBoot= %x. \n", IsFirstBoot, EnableFastBoot));
+  DEBUG ((DEBUG_INFO, "IsFirstBoot = %x , EnableFastBoot= %x. \n", IsFirstBoot, EnableFastBoot));
 
   if ((!IsFirstBoot) && EnableFastBoot) {
     return TRUE;
@@ -75,7 +75,7 @@ ValidateFvHeader (
   EFI_FIRMWARE_VOLUME_HEADER  *FwVolHeader;
 
   if (BOOT_IN_RECOVERY_MODE == *BootMode) {
-    DEBUG ((EFI_D_INFO, "Boot mode recovery\n"));
+    DEBUG ((DEBUG_INFO, "Boot mode recovery\n"));
     return EFI_SUCCESS;
   }
   //
@@ -143,14 +143,14 @@ UpdateBootMode (
   // Read Sticky R/W Bits
   //
   RegValue = QNCAltPortRead (QUARK_SCSS_SOC_UNIT_SB_PORT_ID, QUARK_SCSS_SOC_UNIT_CFG_STICKY_RW);
-  DEBUG ((EFI_D_ERROR, "RegValue = %08x\n", RegValue));
+  DEBUG ((DEBUG_ERROR, "RegValue = %08x\n", RegValue));
 
   //
   // Check if we need to boot in recovery mode
   //
   if ((RegValue & B_CFG_STICKY_RW_FORCE_RECOVERY) != 0) {
     NewBootMode = BOOT_IN_RECOVERY_MODE;
-    DEBUG ((EFI_D_ERROR, "RECOVERY from sticky bit\n"));;
+    DEBUG ((DEBUG_ERROR, "RECOVERY from sticky bit\n"));;
 
     //
     // Clear force recovery sticky bit
@@ -163,7 +163,7 @@ UpdateBootMode (
 
   } else if (ValidateFvHeader (BootMode) != EFI_SUCCESS) {
     NewBootMode = BOOT_IN_RECOVERY_MODE;
-    DEBUG ((EFI_D_ERROR, "RECOVERY from corrupt FV\n"));;
+    DEBUG ((DEBUG_ERROR, "RECOVERY from corrupt FV\n"));;
   } else if (QNCCheckS3AndClearState ()) {
     //
     // Determine if we're in capsule update mode
@@ -177,14 +177,14 @@ UpdateBootMode (
     if (Status == EFI_SUCCESS) {
       Status = Capsule->CheckCapsuleUpdate (PeiServices);
       if (Status == EFI_SUCCESS) {
-        DEBUG ((EFI_D_INFO, "Boot mode Flash Update\n"));
+        DEBUG ((DEBUG_INFO, "Boot mode Flash Update\n"));
         NewBootMode = BOOT_ON_FLASH_UPDATE;
       } else {
-        DEBUG ((EFI_D_INFO, "Boot mode S3 resume\n"));
+        DEBUG ((DEBUG_INFO, "Boot mode S3 resume\n"));
         NewBootMode = BOOT_ON_S3_RESUME;
       }
     } else {
-      DEBUG ((EFI_D_INFO, "Boot mode S3 resume\n"));
+      DEBUG ((DEBUG_INFO, "Boot mode S3 resume\n"));
       NewBootMode = BOOT_ON_S3_RESUME;
     }
   } else {
@@ -192,19 +192,19 @@ UpdateBootMode (
     // Check if this is a power on reset
     //
     if (QNCCheckPowerOnResetAndClearState ()) {
-      DEBUG ((EFI_D_INFO, "Power On Reset\n"));
+      DEBUG ((DEBUG_INFO, "Power On Reset\n"));
     }
     if (IsBootWithNoChange (PeiServices)) {
-      DEBUG ((EFI_D_INFO, "Boot with Minimum cfg\n"));
+      DEBUG ((DEBUG_INFO, "Boot with Minimum cfg\n"));
       NewBootMode = BOOT_ASSUMING_NO_CONFIGURATION_CHANGES;
     } else {
-      DEBUG ((EFI_D_INFO, "Boot with Full cfg\n"));
+      DEBUG ((DEBUG_INFO, "Boot with Full cfg\n"));
       NewBootMode = BOOT_WITH_FULL_CONFIGURATION;
     }
   }
 
   if (NewBootMode == BOOT_IN_RECOVERY_MODE) {
-    DEBUG ((EFI_D_INFO, "Boot mode recovery\n"));
+    DEBUG ((DEBUG_INFO, "Boot mode recovery\n"));
     Status = PeiServicesInstallPpi (&mPpiListRecoveryBootMode);
     ASSERT_EFI_ERROR (Status);
   }

--- a/Platform/Intel/QuarkPlatformPkg/Platform/Pei/PlatformInit/Generic/Recovery.c
+++ b/Platform/Intel/QuarkPlatformPkg/Platform/Pei/PlatformInit/Generic/Recovery.c
@@ -150,7 +150,7 @@ Returns:
 
   DeviceRecoveryModule    = NULL;
 
-  DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Recovery Entry\n"));
+  DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Recovery Entry\n"));
 
   //
   // Search the platform for some recovery capsule if the DXE IPL
@@ -166,7 +166,7 @@ Returns:
               );
 
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Device Recovery PPI located\n"));
+      DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Device Recovery PPI located\n"));
       NumberOfImageProviders++;
 
       Status = DeviceRecoveryModule->GetNumberRecoveryCapsules (
@@ -175,7 +175,7 @@ Returns:
                                       &NumberRecoveryCapsules
                                       );
 
-      DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Number Of Recovery Capsules: %d\n", NumberRecoveryCapsules));
+      DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Number Of Recovery Capsules: %d\n", NumberRecoveryCapsules));
 
       if (NumberRecoveryCapsules == 0) {
         Index++;
@@ -209,7 +209,7 @@ Returns:
       return Status;
     }
 
-    DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Recovery Capsule Size: %d\n", RecoveryCapsuleSize));
+    DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Recovery Capsule Size: %d\n", RecoveryCapsuleSize));
 
     //
     // Only support the 2 capsule types known
@@ -234,7 +234,7 @@ Returns:
                                      Buffer
                                      );
 
-    DEBUG ((EFI_D_INFO | EFI_D_LOAD, "LoadRecoveryCapsule Returns: %r\n", Status));
+    DEBUG ((DEBUG_INFO | DEBUG_LOAD, "LoadRecoveryCapsule Returns: %r\n", Status));
 
     if (Status == EFI_DEVICE_ERROR) {
       AssertMediaDeviceError (PeiServices);
@@ -253,14 +253,14 @@ Returns:
     Status      = PeiServicesGetHobList ((VOID **)&Hob.Raw);
     while (!END_OF_HOB_LIST (Hob)) {
       if (Hob.Header->HobType == EFI_HOB_TYPE_FV) {
-        DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Hob FV Length: %x\n", Hob.FirmwareVolume->Length));
+        DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Hob FV Length: %x\n", Hob.FirmwareVolume->Length));
 
         if (Hob.FirmwareVolume->BaseAddress == (UINTN) PcdGet32 (PcdFlashFvMainBase)) {
           HobUpdate = TRUE;
           //
           // This looks like the Hob we are interested in
           //
-          DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Hob Updated\n"));
+          DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Hob Updated\n"));
           Hob.FirmwareVolume->BaseAddress = (UINTN) Buffer;
           Hob.FirmwareVolume->Length      = RecoveryCapsuleSize;
         }
@@ -278,13 +278,13 @@ Returns:
       // build FV Hob if it is not built before
       //
       if (!HobUpdate) {
-        DEBUG ((EFI_D_INFO | EFI_D_LOAD, "FV Hob is not found, Build FV Hob then..\n"));
+        DEBUG ((DEBUG_INFO | DEBUG_LOAD, "FV Hob is not found, Build FV Hob then..\n"));
         BuildFvHob (
           (UINTN) Buffer,
           FvHeader->FvLength
           );
 
-        DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Install FV Info PPI..\n"));
+        DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Install FV Info PPI..\n"));
 
         PeiServicesInstallFvInfoPpi (
           NULL,
@@ -326,7 +326,7 @@ Returns:
     }
   }
 
-  DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Recovery Module Returning: %r\n", Status));
+  DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Recovery Module Returning: %r\n", Status));
   return Status;
 }
 

--- a/Platform/Intel/QuarkPlatformPkg/Platform/Pei/PlatformInit/MemoryCallback.c
+++ b/Platform/Intel/QuarkPlatformPkg/Platform/Pei/PlatformInit/MemoryCallback.c
@@ -106,7 +106,7 @@ MemoryDiscoveredPpiNotifyCallback (
   UINT8                                 MorControl;
   UINTN                                 DataSize;
 
-  DEBUG ((EFI_D_INFO, "Platform PEIM Memory Callback\n"));
+  DEBUG ((DEBUG_INFO, "Platform PEIM Memory Callback\n"));
 
   NumSmramRegions = 0;
   SmramDescriptor = NULL;
@@ -176,7 +176,7 @@ MemoryDiscoveredPpiNotifyCallback (
   // If OS requested a memory overwrite perform it now for Embedded SRAM
   //
   if (MOR_CLEAR_MEMORY_VALUE (MorControl)) {
-    DEBUG ((EFI_D_INFO, "Clear Embedded SRAM per MOR request.\n"));
+    DEBUG ((DEBUG_INFO, "Clear Embedded SRAM per MOR request.\n"));
     if (PcdGet32 (PcdESramMemorySize) > 0) {
       if (PcdGet32 (PcdEsramStage1Base) == 0) {
         //
@@ -269,7 +269,7 @@ MemoryDiscoveredPpiNotifyCallback (
     AsmCpuid (CPUID_VIR_PHY_ADDRESS_SIZE, &RegEax, NULL, NULL, NULL);
     CpuAddressWidth = (UINT8) (RegEax & 0xFF);
   }
-  DEBUG ((EFI_D_INFO, "CpuAddressWidth: %d\n", CpuAddressWidth));
+  DEBUG ((DEBUG_INFO, "CpuAddressWidth: %d\n", CpuAddressWidth));
 
   BuildCpuHob (CpuAddressWidth, 16);
 

--- a/Platform/Intel/QuarkPlatformPkg/Platform/Pei/PlatformInit/MrcWrapper.c
+++ b/Platform/Intel/QuarkPlatformPkg/Platform/Pei/PlatformInit/MrcWrapper.c
@@ -84,10 +84,10 @@ MrcConfigureFromMcFuses (
                  QUARK_NC_MEMORY_CONTROLLER_REG_DFUSESTAT
                  );
 
-  DEBUG ((EFI_D_INFO, "MRC McFuseStat 0x%08x\n", McFuseStat));
+  DEBUG ((DEBUG_INFO, "MRC McFuseStat 0x%08x\n", McFuseStat));
 
   if ((McFuseStat & B_DFUSESTAT_ECC_DIS) != 0) {
-    DEBUG ((EFI_D_INFO, "MRC Fuse : fus_dun_ecc_dis.\n"));
+    DEBUG ((DEBUG_INFO, "MRC Fuse : fus_dun_ecc_dis.\n"));
     MrcData->ecc_enables = 0;
   } else {
     MrcData->ecc_enables = 1;
@@ -136,14 +136,14 @@ MrcConfigureFromInfoHob (
   MrcData->rtt_nom_value       = ItemData->DramRttNomVal;
   MrcData->rd_odt_value        = ItemData->SocRdOdtVal;
 
-  DEBUG ((EFI_D_INFO, "MRC dram_width %d\n",  MrcData->dram_width));
-  DEBUG ((EFI_D_INFO, "MRC rank_enables %d\n",MrcData->rank_enables));
-  DEBUG ((EFI_D_INFO, "MRC ddr_speed %d\n",   MrcData->ddr_speed));
-  DEBUG ((EFI_D_INFO, "MRC flags: %s\n",
+  DEBUG ((DEBUG_INFO, "MRC dram_width %d\n",  MrcData->dram_width));
+  DEBUG ((DEBUG_INFO, "MRC rank_enables %d\n",MrcData->rank_enables));
+  DEBUG ((DEBUG_INFO, "MRC ddr_speed %d\n",   MrcData->ddr_speed));
+  DEBUG ((DEBUG_INFO, "MRC flags: %s\n",
     (MrcData->scrambling_enables) ? L"SCRAMBLE_EN" : L""
     ));
 
-  DEBUG ((EFI_D_INFO, "MRC density=%d tCL=%d tRAS=%d tWTR=%d tRRD=%d tFAW=%d\n",
+  DEBUG ((DEBUG_INFO, "MRC density=%d tCL=%d tRAS=%d tWTR=%d tRRD=%d tFAW=%d\n",
     MrcData->params.DENSITY,
     MrcData->params.tCL,
     MrcData->params.tRAS,
@@ -216,7 +216,7 @@ PostInstallMemory (
   // Find the 64KB of memory for Rmu Main at the top of available memory.
   //
   InfoPostInstallMemory (&RmuMainDestBaseAddress, NULL, NULL);
-  DEBUG ((EFI_D_INFO, "RmuMain Base Address : 0x%x\n", RmuMainDestBaseAddress));
+  DEBUG ((DEBUG_INFO, "RmuMain Base Address : 0x%x\n", RmuMainDestBaseAddress));
 
   //
   // Relocate RmuMain.
@@ -227,7 +227,7 @@ PostInstallMemory (
     Status = PlatformFindFvFileRawDataSection (NULL, PcdGetPtr(PcdQuarkMicrocodeFile), (VOID **) &RmuMainSrcBaseAddress, &RmuMainSize);
     ASSERT_EFI_ERROR (Status);
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Found Microcode ADDR:SIZE 0x%08x:0x%04x\n", (UINTN) RmuMainSrcBaseAddress, RmuMainSize));
+      DEBUG ((DEBUG_INFO, "Found Microcode ADDR:SIZE 0x%08x:0x%04x\n", (UINTN) RmuMainSrcBaseAddress, RmuMainSize));
     }
 
     RmuMainRelocation (RmuMainDestBaseAddress, (UINT32) RmuMainSrcBaseAddress, RmuMainSize);
@@ -400,7 +400,7 @@ MemoryInit (
 
   if (BootMode == BOOT_ON_S3_RESUME) {
 
-    DEBUG ((EFI_D_INFO, "Following BOOT_ON_S3_RESUME boot path.\n"));
+    DEBUG ((DEBUG_INFO, "Following BOOT_ON_S3_RESUME boot path.\n"));
 
     Status = InstallS3Memory (PeiServices, VariableServices, MrcData.mem_size);
     if (EFI_ERROR (Status)) {
@@ -417,7 +417,7 @@ MemoryInit (
   //
   // Assign physical memory to PEI and DXE
   //
-  DEBUG ((EFI_D_INFO, "InstallEfiMemory.\n"));
+  DEBUG ((DEBUG_INFO, "InstallEfiMemory.\n"));
 
   Status = InstallEfiMemory (
              PeiServices,
@@ -432,13 +432,13 @@ MemoryInit (
   //
   // Save current configuration into Hob and will save into Variable later in DXE
   //
-  DEBUG ((EFI_D_INFO, "SaveConfig.\n"));
+  DEBUG ((DEBUG_INFO, "SaveConfig.\n"));
   Status = SaveConfig (
              &MrcData
              );
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG ((EFI_D_INFO, "MemoryInit Complete.\n"));
+  DEBUG ((DEBUG_INFO, "MemoryInit Complete.\n"));
 
   return EFI_SUCCESS;
 }
@@ -470,8 +470,8 @@ SaveConfig (
     ((sizeof (MrcData->timings) + 0x7) & (~0x7))
     );
 
-  DEBUG ((EFI_D_INFO, "IIO IoApicBase  = %x IoApicLimit=%x\n", IOAPIC_BASE, (IOAPIC_BASE + IOAPIC_SIZE - 1)));
-  DEBUG ((EFI_D_INFO, "IIO RcbaAddress = %x\n", (UINT32)PcdGet64 (PcdRcbaMmioBaseAddress)));
+  DEBUG ((DEBUG_INFO, "IIO IoApicBase  = %x IoApicLimit=%x\n", IOAPIC_BASE, (IOAPIC_BASE + IOAPIC_SIZE - 1)));
+  DEBUG ((DEBUG_INFO, "IIO RcbaAddress = %x\n", (UINT32)PcdGet64 (PcdRcbaMmioBaseAddress)));
 
   return EFI_SUCCESS;
 }
@@ -624,15 +624,15 @@ InstallEfiMemory (
 
   for (Index = 0; Index < NumRanges; Index++)
   {
-    DEBUG ((EFI_D_INFO, "Found 0x%x bytes at ", MemoryMap[Index].RangeLength));
-    DEBUG ((EFI_D_INFO, "0x%x.\n", MemoryMap[Index].PhysicalAddress));
+    DEBUG ((DEBUG_INFO, "Found 0x%x bytes at ", MemoryMap[Index].RangeLength));
+    DEBUG ((DEBUG_INFO, "0x%x.\n", MemoryMap[Index].PhysicalAddress));
 
     //
     // If OS requested a memory overwrite perform it now.  Only do it for memory
     // used by the OS.
     //
     if (MOR_CLEAR_MEMORY_VALUE (MorControl) && MemoryMap[Index].Type == DualChannelDdrMainMemory) {
-      DEBUG ((EFI_D_INFO, "Clear memory per MOR request.\n"));
+      DEBUG ((DEBUG_INFO, "Clear memory per MOR request.\n"));
       if ((UINTN)MemoryMap[Index].RangeLength > 0) {
         if ((UINTN)MemoryMap[Index].PhysicalAddress == 0) {
           //
@@ -1003,14 +1003,14 @@ InstallS3Memory (
   // install it as PEI Memory.
   //
 
-  DEBUG ((EFI_D_INFO, "TSEG Base = 0x%08x\n", SmramHobDescriptorBlock->Descriptor[SmramRanges-1].PhysicalStart));
+  DEBUG ((DEBUG_INFO, "TSEG Base = 0x%08x\n", SmramHobDescriptorBlock->Descriptor[SmramRanges-1].PhysicalStart));
   S3MemoryRangeData = (RESERVED_ACPI_S3_RANGE*)(UINTN)
     (SmramHobDescriptorBlock->Descriptor[SmramRanges-1].PhysicalStart + RESERVED_ACPI_S3_RANGE_OFFSET);
 
   S3MemoryBase  = (UINTN) (S3MemoryRangeData->AcpiReservedMemoryBase);
-  DEBUG ((EFI_D_INFO, "S3MemoryBase = 0x%08x\n", S3MemoryBase));
+  DEBUG ((DEBUG_INFO, "S3MemoryBase = 0x%08x\n", S3MemoryBase));
   S3MemorySize  = (UINTN) (S3MemoryRangeData->AcpiReservedMemorySize);
-  DEBUG ((EFI_D_INFO, "S3MemorySize = 0x%08x\n", S3MemorySize));
+  DEBUG ((DEBUG_INFO, "S3MemorySize = 0x%08x\n", S3MemorySize));
 
   Status        = PeiServicesInstallPeiMemory (S3MemoryBase, S3MemorySize);
   ASSERT_EFI_ERROR (Status);
@@ -1051,8 +1051,8 @@ InstallS3Memory (
         MemoryMap[Index].PhysicalAddress,
         MemoryMap[Index].RangeLength
         );
-      DEBUG ((EFI_D_INFO, "Build resource HOB for Legacy Region on S3 patch :"));
-      DEBUG ((EFI_D_INFO, " Memory Base:0x%lX Length:0x%lX\n", MemoryMap[Index].PhysicalAddress, MemoryMap[Index].RangeLength));
+      DEBUG ((DEBUG_INFO, "Build resource HOB for Legacy Region on S3 patch :"));
+      DEBUG ((DEBUG_INFO, " Memory Base:0x%lX Length:0x%lX\n", MemoryMap[Index].PhysicalAddress, MemoryMap[Index].RangeLength));
     }
   }
 
@@ -1317,7 +1317,7 @@ GetPlatformMemorySize (
 
     *MemorySize = PEI_MIN_MEMORY_SIZE;
     for (Index = 0; Index < DataSize / sizeof (EFI_MEMORY_TYPE_INFORMATION); Index++) {
-      DEBUG ((EFI_D_INFO, "Index %d, Page: %d\n", Index, MemoryData[Index].NumberOfPages));
+      DEBUG ((DEBUG_INFO, "Index %d, Page: %d\n", Index, MemoryData[Index].NumberOfPages));
       *MemorySize += MemoryData[Index].NumberOfPages * EFI_PAGE_SIZE;
     }
 
@@ -1386,7 +1386,7 @@ BaseMemoryTest (
   while (TempAddress < BeginAddress + MemoryLength) {
     if ((*(UINT32 *) (UINTN) TempAddress) != TestPattern) {
       *ErrorAddress = TempAddress;
-      DEBUG ((EFI_D_ERROR, "Memory test failed at 0x%x.\n", TempAddress));
+      DEBUG ((DEBUG_ERROR, "Memory test failed at 0x%x.\n", TempAddress));
       return EFI_DEVICE_ERROR;
     }
 

--- a/Platform/Intel/QuarkPlatformPkg/Platform/Pei/PlatformInit/PlatformEarlyInit.c
+++ b/Platform/Intel/QuarkPlatformPkg/Platform/Pei/PlatformInit/PlatformEarlyInit.c
@@ -144,7 +144,7 @@ SetLanControllerMacAddr (
   Addr =  Bar0 + R_IOH_MAC_GMAC_REG_8;
   MacVer = *((volatile UINT32 *) (UINTN)(Addr));
 
-  DEBUG ((EFI_D_INFO, "Ioh MAC [B:%d, D:%d, F:%d] VER:%04x ADDR:",
+  DEBUG ((DEBUG_INFO, "Ioh MAC [B:%d, D:%d, F:%d] VER:%04x ADDR:",
     (UINTN) Bus,
     (UINTN) Device,
     (UINTN) Func,
@@ -158,7 +158,7 @@ SetLanControllerMacAddr (
   Data32 = *((UINT32 *) (UINTN)(&MacAddr[0]));
   *((volatile UINT32 *) (UINTN)(Addr)) = Data32;
   Wrote = (volatile UINT8 *) (UINTN)(Addr);
-  DEBUG ((EFI_D_INFO, "%02x-%02x-%02x-%02x-",
+  DEBUG ((DEBUG_INFO, "%02x-%02x-%02x-%02x-",
     (UINTN) Wrote[0],
     (UINTN) Wrote[1],
     (UINTN) Wrote[2],
@@ -177,7 +177,7 @@ SetLanControllerMacAddr (
   *((volatile UINT32 *) (UINTN)(Addr)) = Data32;
   Wrote = (volatile UINT8 *) (UINTN)(Addr);
 
-  DEBUG ((EFI_D_INFO, "%02x-%02x\n", (UINTN) Wrote[0], (UINTN) Wrote[1]));
+  DEBUG ((DEBUG_INFO, "%02x-%02x\n", (UINTN) Wrote[0], (UINTN) Wrote[1]));
 
   //
   // Restore settings for PCI CMD/BAR registers
@@ -272,7 +272,7 @@ EarlyPlatformConfigGpioExpanders (
              GALILEO_GEN2_IOEXP2_7BIT_SLAVE_ADDR,  // IO Expander 2
              15                                    // P1-7
              )) {
-        DEBUG ((EFI_D_INFO, "  Force Recovery mode and reset\n"));
+        DEBUG ((DEBUG_INFO, "  Force Recovery mode and reset\n"));
 
         //
         // Set 'B_CFG_STICKY_RW_FORCE_RECOVERY' sticky bit so we know we need to do a recovery following warm reset
@@ -301,7 +301,7 @@ EarlyPlatformConfigGpioExpanders (
     } else {
       I2CSlaveAddress.I2CDeviceAddress = GALILEO_IOEXP_J2LO_7BIT_SLAVE_ADDR;
     }
-    DEBUG ((EFI_D_INFO, "Galileo GPIO Expender Slave Address = %02x\n", I2CSlaveAddress.I2CDeviceAddress));
+    DEBUG ((DEBUG_INFO, "Galileo GPIO Expender Slave Address = %02x\n", I2CSlaveAddress.I2CDeviceAddress));
 
     //
     // Set I2C_MUX (GPORT1_BIT5) low to route I2C to Arduino Shield connector
@@ -433,7 +433,7 @@ EarlyPlatformConfigGpioExpanders (
       // Return the state of GPORT5_BIT0
       //
       if ((Buffer[1] & BIT0) == 0) {
-        DEBUG ((EFI_D_INFO, "  Force Recovery mode and reset\n"));
+        DEBUG ((DEBUG_INFO, "  Force Recovery mode and reset\n"));
 
         //
         // Set 'B_CFG_STICKY_RW_FORCE_RECOVERY' sticky bit so we know we need to do a recovery following warm reset
@@ -550,23 +550,23 @@ PeiInitPlatform (
     QNCClearSmiAndWake ();
   }
 
-  DEBUG ((EFI_D_INFO, "MRC Entry\n"));
+  DEBUG ((DEBUG_INFO, "MRC Entry\n"));
   MemoryInit ((EFI_PEI_SERVICES**)PeiServices);
 
   //
   // Do Early PCIe init.
   //
-  DEBUG ((EFI_D_INFO, "Early PCIe controller initialization\n"));
+  DEBUG ((DEBUG_INFO, "Early PCIe controller initialization\n"));
   PlatformPciExpressEarlyInit (PlatformType);
 
 
-  DEBUG ((EFI_D_INFO, "Platform Erratas After MRC\n"));
+  DEBUG ((DEBUG_INFO, "Platform Erratas After MRC\n"));
   PlatformErratasPostMrc ();
 
   //
   //
   //
-  DEBUG ((EFI_D_INFO, "EarlyPlatformConfigGpioExpanders ()\n"));
+  DEBUG ((DEBUG_INFO, "EarlyPlatformConfigGpioExpanders ()\n"));
   EarlyPlatformConfigGpioExpanders (PlatformType, BootMode);
 
   //
@@ -602,7 +602,7 @@ EndOfPeiSignalPpiNotifyCallback (
 {
   EFI_STATUS                            Status;
 
-  DEBUG ((EFI_D_INFO, "End of PEI Signal Callback\n"));
+  DEBUG ((DEBUG_INFO, "End of PEI Signal Callback\n"));
 
     //
   // Restore the flash region to be UC
@@ -705,7 +705,7 @@ EarlyPlatformThermalSensorInit (
   VOID
   )
 {
-  DEBUG ((EFI_D_INFO, "Early Platform Thermal Sensor Init\n"));
+  DEBUG ((DEBUG_INFO, "Early Platform Thermal Sensor Init\n"));
 
   //
   // Set Thermal sensor mode.
@@ -740,36 +740,36 @@ EarlyPlatformInfoMessages (
   // Find which 'Stage1' image we are running and print the details
   //
   Edk2ImageHeader = (QUARK_EDKII_STAGE1_HEADER *) PcdGet32 (PcdEsramStage1Base);
-  DEBUG ((EFI_D_INFO, "\n************************************************************\n"));
+  DEBUG ((DEBUG_INFO, "\n************************************************************\n"));
 
   switch ((UINT8)Edk2ImageHeader->ImageIndex & QUARK_STAGE1_IMAGE_TYPE_MASK) {
     case QUARK_STAGE1_BOOT_IMAGE_TYPE:
-      DEBUG ((EFI_D_INFO, "****  Quark EDKII Stage 1 Boot Image %d                ****\n", ((UINT8)Edk2ImageHeader->ImageIndex & ~(QUARK_STAGE1_IMAGE_TYPE_MASK))));
+      DEBUG ((DEBUG_INFO, "****  Quark EDKII Stage 1 Boot Image %d                ****\n", ((UINT8)Edk2ImageHeader->ImageIndex & ~(QUARK_STAGE1_IMAGE_TYPE_MASK))));
       break;
 
     case QUARK_STAGE1_RECOVERY_IMAGE_TYPE:
-      DEBUG ((EFI_D_INFO, "****  Quark EDKII Stage 1 Recovery Image %d            ****\n", ((UINT8)Edk2ImageHeader->ImageIndex & ~(QUARK_STAGE1_IMAGE_TYPE_MASK))));
+      DEBUG ((DEBUG_INFO, "****  Quark EDKII Stage 1 Recovery Image %d            ****\n", ((UINT8)Edk2ImageHeader->ImageIndex & ~(QUARK_STAGE1_IMAGE_TYPE_MASK))));
       break;
 
     default:
-      DEBUG ((EFI_D_INFO, "****  Quark EDKII Unknown Stage 1 Image !!!!           ****\n"));
+      DEBUG ((DEBUG_INFO, "****  Quark EDKII Unknown Stage 1 Image !!!!           ****\n"));
       break;
   }
   DEBUG (
-    (EFI_D_INFO,
+    (DEBUG_INFO,
     "****  Quark EDKII Stage 2 Image 0x%08X:0x%08X ****\n" ,
     (UINTN) PcdGet32 (PcdFlashFvMainBase),
     (UINTN) PcdGet32 (PcdFlashFvMainSize)
     ));
 
   DEBUG (
-    (EFI_D_INFO,
+    (DEBUG_INFO,
     "****  Quark EDKII Payload Image 0x%08X:0x%08X ****\n" ,
     (UINTN) PcdGet32 (PcdFlashFvPayloadBase),
     (UINTN) PcdGet32 (PcdFlashFvPayloadSize)
     ));
 
-  DEBUG ((EFI_D_INFO, "************************************************************\n\n"));
+  DEBUG ((DEBUG_INFO, "************************************************************\n\n"));
 
   DEBUG_CODE_END ();
 }
@@ -801,7 +801,7 @@ CheckForResetDueToErrors (
     ResetDueToError = TRUE;
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nReset due to access violation: %s %s %s %s\n",
       ((RegValue & B_CFG_STICKY_RW_IMR_VIOLATION) != 0) ? L"'IMR'" : L".",
       ((RegValue & B_CFG_STICKY_RW_DECC_VIOLATION) != 0) ? L"'DECC'" : L".",
@@ -837,14 +837,14 @@ EarlyPlatformInit (
 
   PlatformType = (EFI_PLATFORM_TYPE) PcdGet16 (PcdPlatformType);
 
-  DEBUG ((EFI_D_INFO, "EarlyPlatformInit for PlatType=0x%02x\n", (UINTN) PlatformType));
+  DEBUG ((DEBUG_INFO, "EarlyPlatformInit for PlatType=0x%02x\n", (UINTN) PlatformType));
 
   //
   // Check if system reset due to error condition.
   //
   if (CheckForResetDueToErrors (TRUE)) {
     if(FeaturePcdGet (WaitIfResetDueToError)) {
-      DEBUG ((EFI_D_ERROR, "Wait 10 seconds.\n"));
+      DEBUG ((DEBUG_ERROR, "Wait 10 seconds.\n"));
       MicroSecondDelay(10000000);
     }
   }
@@ -1171,7 +1171,7 @@ EarlyPlatformMacInit (
     (CompareMem (ChipsetDefaultMac, IohMac0Address, sizeof (ChipsetDefaultMac))) != 0;
   if (SetMacAddr) {
     if ((*(IohMac0Address) & BIT0) != 0) {
-      DEBUG ((EFI_D_ERROR, "HALT: Multicast Mac Address configured for Ioh MAC [B:%d, D:%d, F:%d]\n",
+      DEBUG ((DEBUG_ERROR, "HALT: Multicast Mac Address configured for Ioh MAC [B:%d, D:%d, F:%d]\n",
         (UINTN) IOH_MAC0_BUS_NUMBER,
         (UINTN) IOH_MAC0_DEVICE_NUMBER,
         (UINTN) IOH_MAC0_FUNCTION_NUMBER
@@ -1187,7 +1187,7 @@ EarlyPlatformMacInit (
         );
     }
   } else {
-    DEBUG ((EFI_D_WARN, "WARNING: Ioh MAC [B:%d, D:%d, F:%d] NO HW ADDR CONFIGURED!!!\n",
+    DEBUG ((DEBUG_WARN, "WARNING: Ioh MAC [B:%d, D:%d, F:%d] NO HW ADDR CONFIGURED!!!\n",
       (UINTN) IOH_MAC0_BUS_NUMBER,
       (UINTN) IOH_MAC0_DEVICE_NUMBER,
       (UINTN) IOH_MAC0_FUNCTION_NUMBER
@@ -1201,7 +1201,7 @@ EarlyPlatformMacInit (
     (CompareMem (ChipsetDefaultMac, IohMac1Address, sizeof (ChipsetDefaultMac))) != 0;
   if (SetMacAddr) {
     if ((*(IohMac1Address) & BIT0) != 0) {
-      DEBUG ((EFI_D_ERROR, "HALT: Multicast Mac Address configured for Ioh MAC [B:%d, D:%d, F:%d]\n",
+      DEBUG ((DEBUG_ERROR, "HALT: Multicast Mac Address configured for Ioh MAC [B:%d, D:%d, F:%d]\n",
         (UINTN) IOH_MAC1_BUS_NUMBER,
         (UINTN) IOH_MAC1_DEVICE_NUMBER,
         (UINTN) IOH_MAC1_FUNCTION_NUMBER
@@ -1217,7 +1217,7 @@ EarlyPlatformMacInit (
           );
     }
   } else {
-    DEBUG ((EFI_D_WARN, "WARNING: Ioh MAC [B:%d, D:%d, F:%d] NO HW ADDR CONFIGURED!!!\n",
+    DEBUG ((DEBUG_WARN, "WARNING: Ioh MAC [B:%d, D:%d, F:%d] NO HW ADDR CONFIGURED!!!\n",
       (UINTN) IOH_MAC1_BUS_NUMBER,
       (UINTN) IOH_MAC1_DEVICE_NUMBER,
       (UINTN) IOH_MAC1_FUNCTION_NUMBER

--- a/Platform/Intel/QuarkPlatformPkg/Platform/SpiFvbServices/FvbInfo.c
+++ b/Platform/Intel/QuarkPlatformPkg/Platform/SpiFvbServices/FvbInfo.c
@@ -256,13 +256,13 @@ GetFtwFvbInfo (
 
       *FvbInfo = FvHeader;
 
-      DEBUG ((EFI_D_INFO, "\nFTW BaseAddr: 0x%lx \n", FvBaseAddress));
-      DEBUG ((EFI_D_INFO, "FvLength: 0x%lx \n", (*FvbInfo)->FvLength));
-      DEBUG ((EFI_D_INFO, "HeaderLength: 0x%x \n", (*FvbInfo)->HeaderLength));
-      DEBUG ((EFI_D_INFO, "FvBlockMap[0].NumBlocks: 0x%x \n", (*FvbInfo)->BlockMap[0].NumBlocks));
-      DEBUG ((EFI_D_INFO, "FvBlockMap[0].BlockLength: 0x%x \n", (*FvbInfo)->BlockMap[0].Length));
-      DEBUG ((EFI_D_INFO, "FvBlockMap[1].NumBlocks: 0x%x \n",   (*FvbInfo)->BlockMap[1].NumBlocks));
-      DEBUG ((EFI_D_INFO, "FvBlockMap[1].BlockLength: 0x%x \n\n", (*FvbInfo)->BlockMap[1].Length));
+      DEBUG ((DEBUG_INFO, "\nFTW BaseAddr: 0x%lx \n", FvBaseAddress));
+      DEBUG ((DEBUG_INFO, "FvLength: 0x%lx \n", (*FvbInfo)->FvLength));
+      DEBUG ((DEBUG_INFO, "HeaderLength: 0x%x \n", (*FvbInfo)->HeaderLength));
+      DEBUG ((DEBUG_INFO, "FvBlockMap[0].NumBlocks: 0x%x \n", (*FvbInfo)->BlockMap[0].NumBlocks));
+      DEBUG ((DEBUG_INFO, "FvBlockMap[0].BlockLength: 0x%x \n", (*FvbInfo)->BlockMap[0].Length));
+      DEBUG ((DEBUG_INFO, "FvBlockMap[1].NumBlocks: 0x%x \n",   (*FvbInfo)->BlockMap[1].NumBlocks));
+      DEBUG ((DEBUG_INFO, "FvBlockMap[1].BlockLength: 0x%x \n\n", (*FvbInfo)->BlockMap[1].Length));
 
       return EFI_SUCCESS;
     }
@@ -317,13 +317,13 @@ GetFvbInfo (
 
       *FvbInfo = FvHeader;
 
-      DEBUG ((EFI_D_INFO, "\nBaseAddr: 0x%lx \n", FvBaseAddress));
-      DEBUG ((EFI_D_INFO, "FvLength: 0x%lx \n", (*FvbInfo)->FvLength));
-      DEBUG ((EFI_D_INFO, "HeaderLength: 0x%x \n", (*FvbInfo)->HeaderLength));
-      DEBUG ((EFI_D_INFO, "FvBlockMap[0].NumBlocks: 0x%x \n", (*FvbInfo)->BlockMap[0].NumBlocks));
-      DEBUG ((EFI_D_INFO, "FvBlockMap[0].BlockLength: 0x%x \n", (*FvbInfo)->BlockMap[0].Length));
-      DEBUG ((EFI_D_INFO, "FvBlockMap[1].NumBlocks: 0x%x \n",   (*FvbInfo)->BlockMap[1].NumBlocks));
-      DEBUG ((EFI_D_INFO, "FvBlockMap[1].BlockLength: 0x%x \n\n", (*FvbInfo)->BlockMap[1].Length));
+      DEBUG ((DEBUG_INFO, "\nBaseAddr: 0x%lx \n", FvBaseAddress));
+      DEBUG ((DEBUG_INFO, "FvLength: 0x%lx \n", (*FvbInfo)->FvLength));
+      DEBUG ((DEBUG_INFO, "HeaderLength: 0x%x \n", (*FvbInfo)->HeaderLength));
+      DEBUG ((DEBUG_INFO, "FvBlockMap[0].NumBlocks: 0x%x \n", (*FvbInfo)->BlockMap[0].NumBlocks));
+      DEBUG ((DEBUG_INFO, "FvBlockMap[0].BlockLength: 0x%x \n", (*FvbInfo)->BlockMap[0].Length));
+      DEBUG ((DEBUG_INFO, "FvBlockMap[1].NumBlocks: 0x%x \n",   (*FvbInfo)->BlockMap[1].NumBlocks));
+      DEBUG ((DEBUG_INFO, "FvBlockMap[1].BlockLength: 0x%x \n\n", (*FvbInfo)->BlockMap[1].Length));
 
       return EFI_SUCCESS;
     }

--- a/Platform/Intel/QuarkPlatformPkg/Platform/SpiFvbServices/FwBlockService.c
+++ b/Platform/Intel/QuarkPlatformPkg/Platform/SpiFvbServices/FwBlockService.c
@@ -1428,7 +1428,7 @@ GetFvbHeader (
     return EFI_NOT_FOUND;
   }
 
-  DEBUG((EFI_D_INFO, "Fvb base : %08x\n",*BaseAddress));
+  DEBUG((DEBUG_INFO, "Fvb base : %08x\n",*BaseAddress));
 
   *FwVolHeader  = (EFI_FIRMWARE_VOLUME_HEADER *) (UINTN) (*BaseAddress);
   Status        = ValidateFvHeader (*FwVolHeader);
@@ -1500,7 +1500,7 @@ SmmSpiInit (
           // Supported SPI device found
           //
           DEBUG (
-              ((EFI_D_INFO),
+              ((DEBUG_INFO),
               "Smm Mode: Supported SPI Flash device found, Vendor Id: 0x%02x, Device ID: 0x%02x%02x!\n",
               FlashID[0],
               FlashID[1],
@@ -1515,7 +1515,7 @@ SmmSpiInit (
   if (FlashIndex >= EnumSpiFlashMax) {
     Status = EFI_UNSUPPORTED;
     DEBUG (
-        (EFI_D_ERROR,
+        (DEBUG_ERROR,
         "ERROR - Unknown SPI Flash Device, Vendor Id: 0x%02x, Device ID: 0x%02x%02x!\n",
         FlashID[0],
         FlashID[1],
@@ -1727,7 +1727,7 @@ Returns:
             // Supported SPI device found
             //
             DEBUG (
-              ((EFI_D_INFO),
+              ((DEBUG_INFO),
               "Supported SPI Flash device found, Vendor Id: 0x%02x, Device ID: 0x%02x%02x!\n",
               FlashID[0],
               FlashID[1],

--- a/Platform/Intel/SimicsOpenBoardPkg/AcpiTables/MinPlatformAcpiTables/AcpiPlatform.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/AcpiTables/MinPlatformAcpiTables/AcpiPlatform.c
@@ -214,9 +214,9 @@ DebugDisplayReOrderTable(
 {
   UINT32 Index;
 
-  DEBUG ((EFI_D_ERROR, "Index  AcpiProcId  ApicId  Flags  SwApicId  Skt\n"));
+  DEBUG ((DEBUG_ERROR, "Index  AcpiProcId  ApicId  Flags  SwApicId  Skt\n"));
   for (Index=0; Index<MAX_CPU_NUM; Index++) {
-    DEBUG ((EFI_D_ERROR, " %02d       0x%02X      0x%02X      %d      0x%02X     %d\n",
+    DEBUG ((DEBUG_ERROR, " %02d       0x%02X      0x%02X      %d      0x%02X     %d\n",
                            Index, mCpuApicIdOrderTable[Index].AcpiProcessorId,
                            mCpuApicIdOrderTable[Index].ApicId,
                            mCpuApicIdOrderTable[Index].Flags,
@@ -338,7 +338,7 @@ SortCpuLocalApicInTable (
     //
     //keep for debug purpose
 	//
-    DEBUG(( EFI_D_ERROR, "::ACPI::  APIC ID Order Table Init.   CoreThreadMask = %x,  mNumOfBitShift = %x\n", CoreThreadMask, mNumOfBitShift));
+    DEBUG(( DEBUG_ERROR, "::ACPI::  APIC ID Order Table Init.   CoreThreadMask = %x,  mNumOfBitShift = %x\n", CoreThreadMask, mNumOfBitShift));
     DebugDisplayReOrderTable();
     //
     //make sure 1st entry is BSP
@@ -348,7 +348,7 @@ SortCpuLocalApicInTable (
     } else {
       BspApicId = (*(volatile UINT32 *)(UINTN)0xFEE00020) >> 24;
     }
-    DEBUG ((EFI_D_INFO, "BspApicId - 0x%x\n", BspApicId));
+    DEBUG ((DEBUG_INFO, "BspApicId - 0x%x\n", BspApicId));
 
     if(mCpuApicIdOrderTable[0].ApicId != BspApicId) {
       //
@@ -357,7 +357,7 @@ SortCpuLocalApicInTable (
       Index = ApicId2SwProcApicId(BspApicId);
 
       if(MAX_CPU_NUM <= Index) {
-        DEBUG ((EFI_D_ERROR, "Asserting the SortCpuLocalApicInTable Index Bufferflow\n"));
+        DEBUG ((DEBUG_ERROR, "Asserting the SortCpuLocalApicInTable Index Bufferflow\n"));
         ASSERT_EFI_ERROR(EFI_INVALID_PARAMETER);
       }
 
@@ -415,7 +415,7 @@ SortCpuLocalApicInTable (
     //
     //keep for debug purpose
     //
-    DEBUG ((EFI_D_ERROR, "APIC ID Order Table ReOrdered\n"));
+    DEBUG ((DEBUG_ERROR, "APIC ID Order Table ReOrdered\n"));
     DebugDisplayReOrderTable();
 
     mCpuOrderSorted = TRUE;
@@ -914,11 +914,11 @@ InstallMadtFromScratch (
   //
   Status = InitializeMadtHeader (&MadtTableHeader);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "InitializeMadtHeader failed: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "InitializeMadtHeader failed: %r\n", Status));
     goto Done;
   }
 
-  DEBUG ((EFI_D_INFO, "Number of CPUs detected = %d \n", mNumberOfCPUs));
+  DEBUG ((DEBUG_INFO, "Number of CPUs detected = %d \n", mNumberOfCPUs));
 
   //
   // Build Processor Local APIC Structures and Processor Local X2APIC Structures
@@ -961,7 +961,7 @@ InstallMadtFromScratch (
         );
     }
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "CopyMadtStructure (local APIC/x2APIC) failed: %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "CopyMadtStructure (local APIC/x2APIC) failed: %r\n", Status));
       goto Done;
     }
   }
@@ -986,7 +986,7 @@ InstallMadtFromScratch (
       &MadtStructs[MadtStructsIndex++]
       );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "CopyMadtStructure (I/O APIC) failed: %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "CopyMadtStructure (I/O APIC) failed: %r\n", Status));
       goto Done;
     }
   }
@@ -1008,7 +1008,7 @@ InstallMadtFromScratch (
         &MadtStructs[MadtStructsIndex++]
         );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "CopyMadtStructure (I/O APIC) failed: %r\n", Status));
+        DEBUG ((DEBUG_ERROR, "CopyMadtStructure (I/O APIC) failed: %r\n", Status));
         goto Done;
       }
   }
@@ -1034,7 +1034,7 @@ InstallMadtFromScratch (
     &MadtStructs[MadtStructsIndex++]
     );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "CopyMadtStructure (IRQ2 source override) failed: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "CopyMadtStructure (IRQ2 source override) failed: %r\n", Status));
     goto Done;
   }
 
@@ -1053,7 +1053,7 @@ InstallMadtFromScratch (
     &MadtStructs[MadtStructsIndex++]
     );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "CopyMadtStructure (IRQ9 source override) failed: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "CopyMadtStructure (IRQ9 source override) failed: %r\n", Status));
     goto Done;
   }
 
@@ -1073,7 +1073,7 @@ InstallMadtFromScratch (
     &MadtStructs[MadtStructsIndex++]
     );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "CopyMadtStructure (APIC NMI) failed: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "CopyMadtStructure (APIC NMI) failed: %r\n", Status));
     goto Done;
   }
 
@@ -1096,7 +1096,7 @@ InstallMadtFromScratch (
     &MadtStructs[MadtStructsIndex++]
     );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "CopyMadtStructure (x2APIC NMI) failed: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "CopyMadtStructure (x2APIC NMI) failed: %r\n", Status));
     goto Done;
   }
 
@@ -1111,7 +1111,7 @@ InstallMadtFromScratch (
     (UINT8 **)&NewMadtTable
     );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "BuildAcpiTable failed: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "BuildAcpiTable failed: %r\n", Status));
     goto Done;
   }
 
@@ -1331,9 +1331,9 @@ PlatformUpdateTables (
     FadtHeader->DutyOffset = PcdGet8 (PcdFadtDutyOffset);
     FadtHeader->DutyWidth = PcdGet8 (PcdFadtDutyWidth);
 
-    DEBUG(( EFI_D_ERROR, "ACPI FADT table @ address 0x%x\n", Table ));
-    DEBUG(( EFI_D_ERROR, "  IaPcBootArch 0x%x\n", FadtHeader->IaPcBootArch ));
-    DEBUG(( EFI_D_ERROR, "  Flags 0x%x\n", FadtHeader->Flags ));
+    DEBUG(( DEBUG_ERROR, "ACPI FADT table @ address 0x%x\n", Table ));
+    DEBUG(( DEBUG_ERROR, "  IaPcBootArch 0x%x\n", FadtHeader->IaPcBootArch ));
+    DEBUG(( DEBUG_ERROR, "  Flags 0x%x\n", FadtHeader->Flags ));
     break;
 
   case EFI_ACPI_3_0_HIGH_PRECISION_EVENT_TIMER_TABLE_SIGNATURE:
@@ -1353,8 +1353,8 @@ PlatformUpdateTables (
     HpetBlockId.Bits.VendorId       = HpetCapabilities.Bits.VendorId;
     HpetTable->EventTimerBlockId    = HpetBlockId.Uint32;
     HpetTable->MainCounterMinimumClockTickInPeriodicMode = (UINT16)HpetCapabilities.Bits.CounterClockPeriod;
-    DEBUG(( EFI_D_ERROR, "ACPI HPET table @ address 0x%x\n", Table ));
-    DEBUG(( EFI_D_ERROR, "  HPET base 0x%x\n", PcdGet32 (PcdHpetBaseAddress) ));
+    DEBUG(( DEBUG_ERROR, "ACPI HPET table @ address 0x%x\n", Table ));
+    DEBUG(( DEBUG_ERROR, "  HPET base 0x%x\n", PcdGet32 (PcdHpetBaseAddress) ));
     break;
 
   case EFI_ACPI_3_0_PCI_EXPRESS_MEMORY_MAPPED_CONFIGURATION_SPACE_BASE_ADDRESS_DESCRIPTION_TABLE_SIGNATURE:

--- a/Platform/Intel/SimicsOpenBoardPkg/BoardX58Ich10/Library/BoardInitLib/PeiX58Ich10Detect.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/BoardX58Ich10/Library/BoardInitLib/PeiX58Ich10Detect.c
@@ -21,6 +21,6 @@ X58Ich10BoardDetect (
   VOID
   )
 {
-  DEBUG ((EFI_D_INFO, "X58Ich10BoardDetect\n"));
+  DEBUG ((DEBUG_INFO, "X58Ich10BoardDetect\n"));
   return EFI_SUCCESS;
 }

--- a/Platform/Intel/SimicsOpenBoardPkg/BoardX58Ich10/Library/BoardInitLib/PeiX58Ich10InitPostMemLib.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/BoardX58Ich10/Library/BoardInitLib/PeiX58Ich10InitPostMemLib.c
@@ -29,6 +29,6 @@ X58Ich10BoardInitAfterSiliconInit (
   )
 {
 
-  DEBUG((EFI_D_ERROR, "X58Ich10BoardInitAfterSiliconInit\n"));
+  DEBUG((DEBUG_ERROR, "X58Ich10BoardInitAfterSiliconInit\n"));
   return EFI_SUCCESS;
 }

--- a/Platform/Intel/SimicsOpenBoardPkg/BoardX58Ich10/Library/BoardInitLib/PeiX58Ich10InitPreMemLib.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/BoardX58Ich10/Library/BoardInitLib/PeiX58Ich10InitPreMemLib.c
@@ -56,7 +56,7 @@ X58Ich10BoardBootModeDetect (
 {
   EFI_BOOT_MODE BootMode = BOOT_WITH_FULL_CONFIGURATION;
 
-  DEBUG((EFI_D_INFO, "modeValue = %x\n", IoBitFieldRead16(ICH10_PMBASE_IO + 4, 10, 12)));
+  DEBUG((DEBUG_INFO, "modeValue = %x\n", IoBitFieldRead16(ICH10_PMBASE_IO + 4, 10, 12)));
   if (IoBitFieldRead16(ICH10_PMBASE_IO + 4, 10, 12) == 0x5) {
     BootMode = BOOT_ON_S3_RESUME;
   }

--- a/Platform/Intel/SimicsOpenBoardPkg/Library/BoardBdsHookLib/BoardBdsHookLib.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/Library/BoardBdsHookLib/BoardBdsHookLib.c
@@ -273,7 +273,7 @@ RemoveStaleFvFileOptions (
       DevicePathString = ConvertDevicePathToText(BootOptions[Index].FilePath,
                            FALSE, FALSE);
       DEBUG ((
-        EFI_ERROR (Status) ? EFI_D_WARN : DEBUG_VERBOSE,
+        EFI_ERROR (Status) ? DEBUG_WARN : DEBUG_VERBOSE,
         "%a: removing stale Boot#%04x %s: %r\n",
         __FUNCTION__,
         (UINT32)BootOptions[Index].OptionNumber,

--- a/Platform/Intel/SimicsOpenBoardPkg/Library/BoardBdsHookLib/BoardBdsHookLib.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/Library/BoardBdsHookLib/BoardBdsHookLib.c
@@ -275,7 +275,7 @@ RemoveStaleFvFileOptions (
       DEBUG ((
         EFI_ERROR (Status) ? DEBUG_WARN : DEBUG_VERBOSE,
         "%a: removing stale Boot#%04x %s: %r\n",
-        __FUNCTION__,
+        __func__,
         (UINT32)BootOptions[Index].OptionNumber,
         DevicePathString == NULL ? L"<unavailable>" : DevicePathString,
         Status
@@ -948,7 +948,7 @@ SetPciIntLine (
 //      DEBUG((
 //        DEBUG_ERROR,
 //       "%a: PCI host bridge (00:00.0) should have no interrupts!\n",
-//        __FUNCTION__
+//        __func__
 //        ));
 //      ASSERT (FALSE);
     }
@@ -997,7 +997,7 @@ SetPciIntLine (
       Status = PciIo->GetLocation (PciIo, &Segment, &Bus, &Device, &Function);
       ASSERT_EFI_ERROR (Status);
 
-      DEBUG ((DEBUG_VERBOSE, "%a: [%02x:%02x.%x] %s -> 0x%02x\n", __FUNCTION__,
+      DEBUG ((DEBUG_VERBOSE, "%a: [%02x:%02x.%x] %s -> 0x%02x\n", __func__,
         (UINT32)Bus, (UINT32)Device, (UINT32)Function, DevPathString,
         IrqLine));
 
@@ -1081,7 +1081,7 @@ PciAcpiInitialization (
       break;
     default:
       DEBUG ((DEBUG_ERROR, "%a: Unknown Host Bridge Device ID: 0x%04x\n",
-        __FUNCTION__, mHostBridgeDevId));
+        __func__, mHostBridgeDevId));
       ASSERT (FALSE);
       return;
   }
@@ -1113,7 +1113,7 @@ PlatformBdsConnectSequence (
 {
   UINTN Index;
 
-  DEBUG ((DEBUG_INFO, "%a called\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a called\n", __func__));
 
   Index = 0;
 
@@ -1283,7 +1283,7 @@ BdsReadyToBootCallback (
   IN  VOID                      *Context
   )
 {
-   DEBUG ((DEBUG_INFO, "%a called\n", __FUNCTION__));
+   DEBUG ((DEBUG_INFO, "%a called\n", __func__));
 }
 
 
@@ -1313,7 +1313,7 @@ BdsSmmReadyToLockCallback (
     return;
   }
 
-  DEBUG ((DEBUG_INFO, "%a called\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a called\n", __func__));
 
   //
   // Dispatch the deferred 3rd party images.
@@ -1377,7 +1377,7 @@ BdsPciEnumCompleteCallback (
     PlatformConsole[MaxCount - 1].DevicePath = NULL;
   }
 
-  DEBUG ((DEBUG_INFO, "%a called\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a called\n", __func__));
 
   PlatformInitializeConsole (PlatformConsole);
 }
@@ -1401,7 +1401,7 @@ BdsBeforeConsoleAfterTrustedConsoleCallback (
   UINTN                         Index;
   EFI_STATUS                    Status;
 
-  DEBUG ((DEBUG_INFO, "%a called\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a called\n", __func__));
 
   NvBootOptions = EfiBootManagerGetLoadOptions (&NvBootOptionCount, LoadOptionTypeBoot);
   for (Index = 0; Index < NvBootOptionCount; Index++) {
@@ -1410,7 +1410,7 @@ BdsBeforeConsoleAfterTrustedConsoleCallback (
       DEBUG ((
         DEBUG_ERROR,
         "%a: removing Boot#%04x %r\n",
-        __FUNCTION__,
+        __func__,
         (UINT32) NvBootOptions[Index].OptionNumber,
         Status
         ));
@@ -1441,7 +1441,7 @@ BdsBeforeConsoleBeforeEndOfDxeGuidCallback (
   IN EFI_EVENT          Event,
   IN VOID               *Context
 ){
-  DEBUG ((DEBUG_INFO, "%a called\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a called\n", __func__));
 }
 
 /**
@@ -1459,7 +1459,7 @@ BdsAfterConsoleReadyBeforeBootOptionCallback (
 {
   EFI_BOOT_MODE                      BootMode;
 
-  DEBUG ((DEBUG_INFO, "%a called\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a called\n", __func__));
 
   //
   // Get current Boot Mode

--- a/Platform/Intel/SimicsOpenBoardPkg/Library/LoadLinuxLib/Linux.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/Library/LoadLinuxLib/Linux.c
@@ -135,7 +135,7 @@ LoadLinuxInitializeKernelSetup (
   //
   ZeroMem (KernelSetup, 0x1f1);
   ZeroMem (((UINT8 *)KernelSetup) + SetupEnd, 4096 - SetupEnd);
-  DEBUG ((EFI_D_INFO, "Cleared kernel setup 0-0x1f1, 0x%Lx-0x1000\n",
+  DEBUG ((DEBUG_INFO, "Cleared kernel setup 0-0x1f1, 0x%Lx-0x1000\n",
     (UINT64)SetupEnd));
 
   return EFI_SUCCESS;
@@ -336,7 +336,7 @@ SetupLinuxMemmap (
 
     default:
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "Invalid EFI memory descriptor type (0x%x)!\n",
         MemoryMap->Type
         ));
@@ -641,7 +641,7 @@ LoadLinux (
   Bp->hdr.code32_start = (UINT32)(UINTN) Kernel;
   if (Bp->hdr.version >= 0x20c && Bp->hdr.handover_offset &&
       (Bp->hdr.xloadflags & (sizeof (UINTN) == 4 ? BIT2 : BIT3))) {
-    DEBUG ((EFI_D_INFO, "Jumping to kernel EFI handover point at ofs %x\n", Bp->hdr.handover_offset));
+    DEBUG ((DEBUG_INFO, "Jumping to kernel EFI handover point at ofs %x\n", Bp->hdr.handover_offset));
 
     DisableInterrupts ();
     JumpToUefiKernel ((VOID*) gImageHandle, (VOID*) gST, KernelSetup, Kernel);
@@ -652,7 +652,7 @@ LoadLinux (
   //
   SetupLinuxBootParams (KernelSetup);
 
-  DEBUG ((EFI_D_INFO, "Jumping to kernel\n"));
+  DEBUG ((DEBUG_INFO, "Jumping to kernel\n"));
   DisableInterrupts ();
   SetLinuxDescriptorTables ();
   JumpToKernel (Kernel, (VOID*) KernelSetup);

--- a/Platform/Intel/SimicsOpenBoardPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -151,13 +151,13 @@ InitRootBridge (
   DevicePath = AllocateCopyPool (sizeof mRootBridgeDevicePathTemplate,
                  &mRootBridgeDevicePathTemplate);
   if (DevicePath == NULL) {
-    DEBUG ((EFI_D_ERROR, "%a: %r\n", __FUNCTION__, EFI_OUT_OF_RESOURCES));
+    DEBUG ((DEBUG_ERROR, "%a: %r\n", __FUNCTION__, EFI_OUT_OF_RESOURCES));
     return EFI_OUT_OF_RESOURCES;
   }
   DevicePath->AcpiDevicePath.UID = RootBusNumber;
   RootBus->DevicePath = (EFI_DEVICE_PATH_PROTOCOL *)DevicePath;
 
-  DEBUG ((EFI_D_INFO,
+  DEBUG ((DEBUG_INFO,
     "%a: populated root bus %d, with room for %d subordinate bus(es)\n",
     __FUNCTION__, RootBusNumber, MaxSubBusNumber - RootBusNumber));
   return EFI_SUCCESS;
@@ -243,7 +243,7 @@ PciHostBridgeGetRootBridges (
   //
   Bridges = AllocatePool ((1 + (UINTN)ExtraRootBridges) * sizeof *Bridges);
   if (Bridges == NULL) {
-    DEBUG ((EFI_D_ERROR, "%a: %r\n", __FUNCTION__, EFI_OUT_OF_RESOURCES));
+    DEBUG ((DEBUG_ERROR, "%a: %r\n", __FUNCTION__, EFI_OUT_OF_RESOURCES));
     return NULL;
   }
   Initialized = 0;
@@ -383,24 +383,24 @@ PciHostBridgeResourceConflict (
 {
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *Descriptor;
   UINTN                             RootBridgeIndex;
-  DEBUG ((EFI_D_ERROR, "PciHostBridge: Resource conflict happens!\n"));
+  DEBUG ((DEBUG_ERROR, "PciHostBridge: Resource conflict happens!\n"));
 
   RootBridgeIndex = 0;
   Descriptor = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *) Configuration;
   while (Descriptor->Desc == ACPI_ADDRESS_SPACE_DESCRIPTOR) {
-    DEBUG ((EFI_D_ERROR, "RootBridge[%d]:\n", RootBridgeIndex++));
+    DEBUG ((DEBUG_ERROR, "RootBridge[%d]:\n", RootBridgeIndex++));
     for (; Descriptor->Desc == ACPI_ADDRESS_SPACE_DESCRIPTOR; Descriptor++) {
       ASSERT (Descriptor->ResType <
               (sizeof (mPciHostBridgeLibAcpiAddressSpaceTypeStr) /
                sizeof (mPciHostBridgeLibAcpiAddressSpaceTypeStr[0])
                )
               );
-      DEBUG ((EFI_D_ERROR, " %s: Length/Alignment = 0x%lx / 0x%lx\n",
+      DEBUG ((DEBUG_ERROR, " %s: Length/Alignment = 0x%lx / 0x%lx\n",
               mPciHostBridgeLibAcpiAddressSpaceTypeStr[Descriptor->ResType],
               Descriptor->AddrLen, Descriptor->AddrRangeMax
               ));
       if (Descriptor->ResType == ACPI_ADDRESS_SPACE_TYPE_MEM) {
-        DEBUG ((EFI_D_ERROR, "     Granularity/SpecificFlag = %ld / %02x%s\n",
+        DEBUG ((DEBUG_ERROR, "     Granularity/SpecificFlag = %ld / %02x%s\n",
                 Descriptor->AddrSpaceGranularity, Descriptor->SpecificFlag,
                 ((Descriptor->SpecificFlag &
                   EFI_ACPI_MEMORY_RESOURCE_SPECIFIC_FLAG_CACHEABLE_PREFETCHABLE

--- a/Platform/Intel/SimicsOpenBoardPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -151,7 +151,7 @@ InitRootBridge (
   DevicePath = AllocateCopyPool (sizeof mRootBridgeDevicePathTemplate,
                  &mRootBridgeDevicePathTemplate);
   if (DevicePath == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: %r\n", __FUNCTION__, EFI_OUT_OF_RESOURCES));
+    DEBUG ((DEBUG_ERROR, "%a: %r\n", __func__, EFI_OUT_OF_RESOURCES));
     return EFI_OUT_OF_RESOURCES;
   }
   DevicePath->AcpiDevicePath.UID = RootBusNumber;
@@ -159,7 +159,7 @@ InitRootBridge (
 
   DEBUG ((DEBUG_INFO,
     "%a: populated root bus %d, with room for %d subordinate bus(es)\n",
-    __FUNCTION__, RootBusNumber, MaxSubBusNumber - RootBusNumber));
+    __func__, RootBusNumber, MaxSubBusNumber - RootBusNumber));
   return EFI_SUCCESS;
 }
 
@@ -243,7 +243,7 @@ PciHostBridgeGetRootBridges (
   //
   Bridges = AllocatePool ((1 + (UINTN)ExtraRootBridges) * sizeof *Bridges);
   if (Bridges == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: %r\n", __FUNCTION__, EFI_OUT_OF_RESOURCES));
+    DEBUG ((DEBUG_ERROR, "%a: %r\n", __func__, EFI_OUT_OF_RESOURCES));
     return NULL;
   }
   Initialized = 0;

--- a/Platform/Intel/SimicsOpenBoardPkg/Library/PeiReportFvLib/Fv.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/Library/PeiReportFvLib/Fv.c
@@ -28,10 +28,10 @@ PeiFvInitialization (
 {
   BOOLEAN SecureS3Needed;
 
-  DEBUG ((EFI_D_INFO, "Platform PEI Firmware Volume Initialization\n"));
+  DEBUG ((DEBUG_INFO, "Platform PEI Firmware Volume Initialization\n"));
 
   DEBUG (
-    (EFI_D_ERROR, "Firmware Volume HOB: 0x%x 0x%x\n",
+    (DEBUG_ERROR, "Firmware Volume HOB: 0x%x 0x%x\n",
       PcdGet32 (PcdSimicsPeiMemFvBase),
       PcdGet32 (PcdSimicsPeiMemFvSize)
       )

--- a/Platform/Intel/SimicsOpenBoardPkg/SecCore/SecMain.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SecCore/SecMain.c
@@ -165,7 +165,7 @@ FindFfsSectionInstance (
     }
 
     Section = (EFI_COMMON_SECTION_HEADER*)(UINTN) CurrentAddress;
-    DEBUG ((EFI_D_VERBOSE, "Section->Type: 0x%x\n", Section->Type));
+    DEBUG ((DEBUG_VERBOSE, "Section->Type: 0x%x\n", Section->Type));
 
     Size = SECTION_SIZE (Section);
     if (Size < sizeof (*Section)) {
@@ -188,7 +188,7 @@ FindFfsSectionInstance (
         Instance--;
       }
     }
-    DEBUG ((EFI_D_VERBOSE, "Section->Type (0x%x) != SectionType (0x%x)\n", Section->Type, SectionType));
+    DEBUG ((DEBUG_VERBOSE, "Section->Type (0x%x) != SectionType (0x%x)\n", Section->Type, SectionType));
   }
 
   return EFI_NOT_FOUND;
@@ -255,7 +255,7 @@ FindFfsFileAndSection (
   EFI_PHYSICAL_ADDRESS        EndOfFile;
 
   if (Fv->Signature != EFI_FVH_SIGNATURE) {
-    DEBUG ((EFI_D_ERROR, "FV at %p does not have FV header signature\n", Fv));
+    DEBUG ((DEBUG_ERROR, "FV at %p does not have FV header signature\n", Fv));
     return EFI_VOLUME_CORRUPTED;
   }
 
@@ -277,7 +277,7 @@ FindFfsFileAndSection (
     if (Size < (sizeof (*File) + sizeof (EFI_COMMON_SECTION_HEADER))) {
       return EFI_VOLUME_CORRUPTED;
     }
-    DEBUG ((EFI_D_VERBOSE, "File->Type: 0x%x\n", File->Type));
+    DEBUG ((DEBUG_VERBOSE, "File->Type: 0x%x\n", File->Type));
 
     EndOfFile = CurrentAddress + Size;
     if (EndOfFile > EndOfFirmwareVolume) {
@@ -288,7 +288,7 @@ FindFfsFileAndSection (
     // Look for the request file type
     //
     if (File->Type != FileType) {
-      DEBUG ((EFI_D_VERBOSE, "File->Type (0x%x) != FileType (0x%x)\n", File->Type, FileType));
+      DEBUG ((DEBUG_VERBOSE, "File->Type (0x%x) != FileType (0x%x)\n", File->Type, FileType));
       continue;
     }
 
@@ -336,7 +336,7 @@ DecompressMemFvs (
 
   FvSection = (EFI_COMMON_SECTION_HEADER*) NULL;
 
-  DEBUG ((EFI_D_VERBOSE, "Find and decompress FV image.\n"));
+  DEBUG ((DEBUG_VERBOSE, "Find and decompress FV image.\n"));
   Status = FindFfsFileAndSection (
              *Fv,
              EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE,
@@ -344,7 +344,7 @@ DecompressMemFvs (
              (EFI_COMMON_SECTION_HEADER**) &Section
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Unable to find GUID defined section\n"));
+    DEBUG ((DEBUG_ERROR, "Unable to find GUID defined section\n"));
     return Status;
   }
 
@@ -355,21 +355,21 @@ DecompressMemFvs (
              &SectionAttribute
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Unable to GetInfo for GUIDed section\n"));
+    DEBUG ((DEBUG_ERROR, "Unable to GetInfo for GUIDed section\n"));
     return Status;
   }
 
   OutputBuffer = (VOID*) ((UINT8*)(UINTN) PcdGet32 (PcdSimicsDxeMemFvBase) + SIZE_1MB);
   ScratchBuffer = ALIGN_POINTER ((UINT8*) OutputBuffer + OutputBufferSize, SIZE_1MB);
 
-  DEBUG ((EFI_D_VERBOSE, "PcdSimicsDxeMemFvBase: 0x%x\n", PcdGet32 (PcdSimicsDxeMemFvBase)));
-  DEBUG ((EFI_D_VERBOSE, "OutputBuffer: 0x%x\n", OutputBuffer));
-  DEBUG ((EFI_D_VERBOSE, "OutputBufferSize: 0x%x\n", OutputBufferSize));
-  DEBUG ((EFI_D_VERBOSE, "ScratchBuffer: 0x%x\n", ScratchBuffer));
-  DEBUG ((EFI_D_VERBOSE, "ScratchBufferSize: 0x%x\n", ScratchBufferSize));
-  DEBUG ((EFI_D_VERBOSE, "PcdSimicsDecompressionScratchEnd: 0x%x\n", PcdGet32 (PcdSimicsDecompressionScratchEnd)));
+  DEBUG ((DEBUG_VERBOSE, "PcdSimicsDxeMemFvBase: 0x%x\n", PcdGet32 (PcdSimicsDxeMemFvBase)));
+  DEBUG ((DEBUG_VERBOSE, "OutputBuffer: 0x%x\n", OutputBuffer));
+  DEBUG ((DEBUG_VERBOSE, "OutputBufferSize: 0x%x\n", OutputBufferSize));
+  DEBUG ((DEBUG_VERBOSE, "ScratchBuffer: 0x%x\n", ScratchBuffer));
+  DEBUG ((DEBUG_VERBOSE, "ScratchBufferSize: 0x%x\n", ScratchBufferSize));
+  DEBUG ((DEBUG_VERBOSE, "PcdSimicsDecompressionScratchEnd: 0x%x\n", PcdGet32 (PcdSimicsDecompressionScratchEnd)));
 
-  DEBUG ((EFI_D_VERBOSE, "%a: OutputBuffer@%p+0x%x ScratchBuffer@%p+0x%x "
+  DEBUG ((DEBUG_VERBOSE, "%a: OutputBuffer@%p+0x%x ScratchBuffer@%p+0x%x "
     "PcdSimicsDecompressionScratchEnd=0x%x\n", __FUNCTION__, OutputBuffer,
     OutputBufferSize, ScratchBuffer, ScratchBufferSize,
     PcdGet32 (PcdSimicsDecompressionScratchEnd)));
@@ -383,7 +383,7 @@ DecompressMemFvs (
              &AuthenticationStatus
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Error during GUID section decode\n"));
+    DEBUG ((DEBUG_ERROR, "Error during GUID section decode\n"));
     return Status;
   }
 
@@ -395,7 +395,7 @@ DecompressMemFvs (
              &FvSection
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Unable to find PEI FV section\n"));
+    DEBUG ((DEBUG_ERROR, "Unable to find PEI FV section\n"));
     return Status;
   }
 
@@ -407,7 +407,7 @@ DecompressMemFvs (
   CopyMem (PeiMemFv, (VOID*) (FvSection + 1), PcdGet32 (PcdSimicsPeiMemFvSize));
 
   if (PeiMemFv->Signature != EFI_FVH_SIGNATURE) {
-    DEBUG ((EFI_D_ERROR, "Extracted FV at %p does not have FV header signature\n", PeiMemFv));
+    DEBUG ((DEBUG_ERROR, "Extracted FV at %p does not have FV header signature\n", PeiMemFv));
     CpuDeadLoop ();
     return EFI_VOLUME_CORRUPTED;
   }
@@ -420,7 +420,7 @@ DecompressMemFvs (
              &FvSection
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Unable to find DXE FV section\n"));
+    DEBUG ((DEBUG_ERROR, "Unable to find DXE FV section\n"));
     return Status;
   }
 
@@ -440,7 +440,7 @@ DecompressMemFvs (
   CopyMem (DxeMemFv, (VOID*) ((UINTN)FvSection + FvHeaderSize), PcdGet32 (PcdSimicsDxeMemFvSize));
 
   if (DxeMemFv->Signature != EFI_FVH_SIGNATURE) {
-    DEBUG ((EFI_D_ERROR, "Extracted FV at %p does not have FV header signature\n", DxeMemFv));
+    DEBUG ((DEBUG_ERROR, "Extracted FV at %p does not have FV header signature\n", DxeMemFv));
     CpuDeadLoop ();
     return EFI_VOLUME_CORRUPTED;
   }
@@ -469,7 +469,7 @@ FindPeiCoreImageBaseInFv (
   EFI_STATUS                  Status;
   EFI_COMMON_SECTION_HEADER   *Section;
 
-  DEBUG ((EFI_D_VERBOSE, "Find PEI Core image.\n"));
+  DEBUG ((DEBUG_VERBOSE, "Find PEI Core image.\n"));
   Status = FindFfsFileAndSection (
              Fv,
              EFI_FV_FILETYPE_PEI_CORE,
@@ -484,13 +484,13 @@ FindPeiCoreImageBaseInFv (
                &Section
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Unable to find PEI Core image\n"));
+      DEBUG ((DEBUG_ERROR, "Unable to find PEI Core image\n"));
       return Status;
     }
   }
 
   *PeiCoreImageBase = (EFI_PHYSICAL_ADDRESS)(UINTN)(Section + 1);
-  DEBUG ((EFI_D_VERBOSE, "PEI core image base 0x%016LX.\n", *PeiCoreImageBase));
+  DEBUG ((DEBUG_VERBOSE, "PEI core image base 0x%016LX.\n", *PeiCoreImageBase));
   return EFI_SUCCESS;
 }
 
@@ -500,7 +500,7 @@ IsS3Resume (
   VOID
   )
 {
-  DEBUG((EFI_D_VERBOSE, "modeValue = %x\n", IoBitFieldRead16(ICH10_PMBASE_IO + 4, 10, 12)));
+  DEBUG((DEBUG_VERBOSE, "modeValue = %x\n", IoBitFieldRead16(ICH10_PMBASE_IO + 4, 10, 12)));
   return (IoBitFieldRead16(ICH10_PMBASE_IO + 4, 10, 12) == 0x5);
 }
 
@@ -543,14 +543,14 @@ FindPeiCoreImageBase (
     // A malicious runtime OS may have injected something into our previously
     // decoded PEI FV, but we don't care about that unless SMM/SMRAM is required.
     //
-    DEBUG ((EFI_D_VERBOSE, "SEC: S3 resume\n"));
+    DEBUG ((DEBUG_VERBOSE, "SEC: S3 resume\n"));
     GetS3ResumePeiFv (BootFv);
   } else {
     //
     // We're either not resuming, or resuming "securely" -- we'll decompress
     // both PEI FV and DXE FV from pristine flash.
     //
-    DEBUG ((EFI_D_VERBOSE, "SEC: %a\n",
+    DEBUG ((DEBUG_VERBOSE, "SEC: %a\n",
       S3Resume ? "S3 resume (with PEI decompression)" : "Normal boot"));
     FindMainFv (BootFv);
 
@@ -739,7 +739,7 @@ SecCoreStartupWithStack (
 
   ProcessLibraryConstructorList ();
 
-  DEBUG ((EFI_D_INFO,
+  DEBUG ((DEBUG_INFO,
     "SecCoreStartupWithStack(0x%x, 0x%x)\n",
     (UINT32)(UINTN)BootFv,
     (UINT32)(UINTN)TopOfCurrentStack
@@ -868,7 +868,7 @@ TemporaryRamMigration (
   BOOLEAN                          OldStatus;
   BASE_LIBRARY_JUMP_BUFFER         JumpBuffer;
 
-  DEBUG ((EFI_D_INFO,
+  DEBUG ((DEBUG_INFO,
     "TemporaryRamMigration(0x%Lx, 0x%Lx, 0x%Lx)\n",
     TemporaryMemoryBase,
     PermanentMemoryBase,

--- a/Platform/Intel/SimicsOpenBoardPkg/SecCore/SecMain.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SecCore/SecMain.c
@@ -370,7 +370,7 @@ DecompressMemFvs (
   DEBUG ((DEBUG_VERBOSE, "PcdSimicsDecompressionScratchEnd: 0x%x\n", PcdGet32 (PcdSimicsDecompressionScratchEnd)));
 
   DEBUG ((DEBUG_VERBOSE, "%a: OutputBuffer@%p+0x%x ScratchBuffer@%p+0x%x "
-    "PcdSimicsDecompressionScratchEnd=0x%x\n", __FUNCTION__, OutputBuffer,
+    "PcdSimicsDecompressionScratchEnd=0x%x\n", __func__, OutputBuffer,
     OutputBufferSize, ScratchBuffer, ScratchBufferSize,
     PcdGet32 (PcdSimicsDecompressionScratchEnd)));
   ASSERT ((UINTN)ScratchBuffer + ScratchBufferSize ==

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsDxe/Platform.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsDxe/Platform.c
@@ -228,7 +228,7 @@ ExtractConfig (
   MAIN_FORM_STATE MainFormState;
   EFI_STATUS      Status;
 
-  DEBUG ((EFI_D_VERBOSE, "%a: Request=\"%s\"\n", __FUNCTION__, Request));
+  DEBUG ((DEBUG_VERBOSE, "%a: Request=\"%s\"\n", __FUNCTION__, Request));
 
   Status = PlatformConfigToFormState (&MainFormState);
   if (EFI_ERROR (Status)) {
@@ -243,10 +243,10 @@ ExtractConfig (
                                 (VOID *) &MainFormState, sizeof MainFormState,
                                 Results, Progress);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: BlockToConfig(): %r, Progress=\"%s\"\n",
+    DEBUG ((DEBUG_ERROR, "%a: BlockToConfig(): %r, Progress=\"%s\"\n",
       __FUNCTION__, Status, (Status == EFI_DEVICE_ERROR) ? NULL : *Progress));
   } else {
-    DEBUG ((EFI_D_VERBOSE, "%a: Results=\"%s\"\n", __FUNCTION__, *Results));
+    DEBUG ((DEBUG_VERBOSE, "%a: Results=\"%s\"\n", __FUNCTION__, *Results));
   }
   return Status;
 }
@@ -321,7 +321,7 @@ RouteConfig (
   UINTN           BlockSize;
   EFI_STATUS      Status;
 
-  DEBUG ((EFI_D_VERBOSE, "%a: Configuration=\"%s\"\n", __FUNCTION__,
+  DEBUG ((DEBUG_VERBOSE, "%a: Configuration=\"%s\"\n", __FUNCTION__,
     Configuration));
 
   //
@@ -343,7 +343,7 @@ RouteConfig (
   Status = gHiiConfigRouting->ConfigToBlock (gHiiConfigRouting, Configuration,
                                 (VOID *) &MainFormState, &BlockSize, Progress);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: ConfigToBlock(): %r, Progress=\"%s\"\n",
+    DEBUG ((DEBUG_ERROR, "%a: ConfigToBlock(): %r, Progress=\"%s\"\n",
       __FUNCTION__, Status,
       (Status == EFI_BUFFER_TOO_SMALL) ? NULL : *Progress));
     return Status;
@@ -372,7 +372,7 @@ Callback (
   OUT    EFI_BROWSER_ACTION_REQUEST             *ActionRequest
   )
 {
-  DEBUG ((EFI_D_VERBOSE, "%a: Action=0x%Lx QuestionId=%d Type=%d\n",
+  DEBUG ((DEBUG_VERBOSE, "%a: Action=0x%Lx QuestionId=%d Type=%d\n",
     __FUNCTION__, (UINT64) Action, QuestionId, Type));
 
   if (Action != EFI_BROWSER_ACTION_CHANGED) {
@@ -660,7 +660,7 @@ ExecutePlatformConfig (
 
   Status = PlatformConfigLoad (&PlatformConfig, &OptionalElements);
   if (EFI_ERROR (Status)) {
-    DEBUG (((Status == EFI_NOT_FOUND) ? EFI_D_VERBOSE : EFI_D_ERROR,
+    DEBUG (((Status == EFI_NOT_FOUND) ? DEBUG_VERBOSE : DEBUG_ERROR,
       "%a: failed to load platform config: %r\n", __FUNCTION__, Status));
     return Status;
   }

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsDxe/Platform.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsDxe/Platform.c
@@ -228,7 +228,7 @@ ExtractConfig (
   MAIN_FORM_STATE MainFormState;
   EFI_STATUS      Status;
 
-  DEBUG ((DEBUG_VERBOSE, "%a: Request=\"%s\"\n", __FUNCTION__, Request));
+  DEBUG ((DEBUG_VERBOSE, "%a: Request=\"%s\"\n", __func__, Request));
 
   Status = PlatformConfigToFormState (&MainFormState);
   if (EFI_ERROR (Status)) {
@@ -244,9 +244,9 @@ ExtractConfig (
                                 Results, Progress);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: BlockToConfig(): %r, Progress=\"%s\"\n",
-      __FUNCTION__, Status, (Status == EFI_DEVICE_ERROR) ? NULL : *Progress));
+      __func__, Status, (Status == EFI_DEVICE_ERROR) ? NULL : *Progress));
   } else {
-    DEBUG ((DEBUG_VERBOSE, "%a: Results=\"%s\"\n", __FUNCTION__, *Results));
+    DEBUG ((DEBUG_VERBOSE, "%a: Results=\"%s\"\n", __func__, *Results));
   }
   return Status;
 }
@@ -321,7 +321,7 @@ RouteConfig (
   UINTN           BlockSize;
   EFI_STATUS      Status;
 
-  DEBUG ((DEBUG_VERBOSE, "%a: Configuration=\"%s\"\n", __FUNCTION__,
+  DEBUG ((DEBUG_VERBOSE, "%a: Configuration=\"%s\"\n", __func__,
     Configuration));
 
   //
@@ -344,7 +344,7 @@ RouteConfig (
                                 (VOID *) &MainFormState, &BlockSize, Progress);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: ConfigToBlock(): %r, Progress=\"%s\"\n",
-      __FUNCTION__, Status,
+      __func__, Status,
       (Status == EFI_BUFFER_TOO_SMALL) ? NULL : *Progress));
     return Status;
   }
@@ -373,7 +373,7 @@ Callback (
   )
 {
   DEBUG ((DEBUG_VERBOSE, "%a: Action=0x%Lx QuestionId=%d Type=%d\n",
-    __FUNCTION__, (UINT64) Action, QuestionId, Type));
+    __func__, (UINT64) Action, QuestionId, Type));
 
   if (Action != EFI_BROWSER_ACTION_CHANGED) {
     return EFI_UNSUPPORTED;
@@ -661,7 +661,7 @@ ExecutePlatformConfig (
   Status = PlatformConfigLoad (&PlatformConfig, &OptionalElements);
   if (EFI_ERROR (Status)) {
     DEBUG (((Status == EFI_NOT_FOUND) ? DEBUG_VERBOSE : DEBUG_ERROR,
-      "%a: failed to load platform config: %r\n", __FUNCTION__, Status));
+      "%a: failed to load platform config: %r\n", __func__, Status));
     return Status;
   }
 

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsPei/FeatureControl.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsPei/FeatureControl.c
@@ -63,7 +63,7 @@ OnMpServicesAvailable (
   EFI_PEI_MP_SERVICES_PPI *MpServices;
   EFI_STATUS              Status;
 
-  DEBUG ((DEBUG_VERBOSE, "%a: %a\n", gEfiCallerBaseName, __FUNCTION__));
+  DEBUG ((DEBUG_VERBOSE, "%a: %a\n", gEfiCallerBaseName, __func__));
   //
   // Write the MSR on all the APs in parallel.
   //
@@ -77,7 +77,7 @@ OnMpServicesAvailable (
                          NULL                 // ProcedureArgument
                          );
   if (EFI_ERROR (Status) && Status != EFI_NOT_STARTED) {
-    DEBUG ((DEBUG_ERROR, "%a: StartupAllAps(): %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: StartupAllAps(): %r\n", __func__, Status));
     return Status;
   }
 
@@ -110,6 +110,6 @@ InstallFeatureControlCallback (
   Status = PeiServicesNotifyPpi (&mMpServicesNotify);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: failed to set up MP Services callback: %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
   }
 }

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsPei/FeatureControl.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsPei/FeatureControl.c
@@ -63,7 +63,7 @@ OnMpServicesAvailable (
   EFI_PEI_MP_SERVICES_PPI *MpServices;
   EFI_STATUS              Status;
 
-  DEBUG ((EFI_D_VERBOSE, "%a: %a\n", gEfiCallerBaseName, __FUNCTION__));
+  DEBUG ((DEBUG_VERBOSE, "%a: %a\n", gEfiCallerBaseName, __FUNCTION__));
   //
   // Write the MSR on all the APs in parallel.
   //
@@ -77,7 +77,7 @@ OnMpServicesAvailable (
                          NULL                 // ProcedureArgument
                          );
   if (EFI_ERROR (Status) && Status != EFI_NOT_STARTED) {
-    DEBUG ((EFI_D_ERROR, "%a: StartupAllAps(): %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: StartupAllAps(): %r\n", __FUNCTION__, Status));
     return Status;
   }
 
@@ -109,7 +109,7 @@ InstallFeatureControlCallback (
 
   Status = PeiServicesNotifyPpi (&mMpServicesNotify);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: failed to set up MP Services callback: %r\n",
+    DEBUG ((DEBUG_ERROR, "%a: failed to set up MP Services callback: %r\n",
       __FUNCTION__, Status));
   }
 }

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsPei/MemDetect.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsPei/MemDetect.c
@@ -154,7 +154,7 @@ GetFirstNonAddress (
 
   if (Pci64Size == 0) {
     if (mBootMode != BOOT_ON_S3_RESUME) {
-      DEBUG ((EFI_D_INFO, "%a: disabling 64-bit PCI host aperture\n",
+      DEBUG ((DEBUG_INFO, "%a: disabling 64-bit PCI host aperture\n",
         __FUNCTION__));
       PcdSet64S (PcdPciMmio64Size, 0);
     }
@@ -190,7 +190,7 @@ GetFirstNonAddress (
     //
     PcdSet64S (PcdPciMmio64Base, Pci64Base);
     PcdSet64S (PcdPciMmio64Size, Pci64Size);
-    DEBUG ((EFI_D_INFO, "%a: Pci64Base=0x%Lx Pci64Size=0x%Lx\n",
+    DEBUG ((DEBUG_INFO, "%a: Pci64Base=0x%Lx Pci64Size=0x%Lx\n",
       __FUNCTION__, Pci64Base, Pci64Size));
   }
 
@@ -350,7 +350,7 @@ PublishPeiMemory (
     MemorySize = mS3AcpiReservedMemorySize;
   } else {
     PeiMemoryCap = GetPeiMemoryCap ();
-    DEBUG ((EFI_D_INFO, "%a: mPhysMemAddressWidth=%d PeiMemoryCap=%u KB\n",
+    DEBUG ((DEBUG_INFO, "%a: mPhysMemAddressWidth=%d PeiMemoryCap=%u KB\n",
       __FUNCTION__, mPhysMemAddressWidth, PeiMemoryCap >> 10));
 
     //
@@ -368,7 +368,7 @@ PublishPeiMemory (
       PcdGet32 (PcdSimicsDxeMemFvBase) + PcdGet32 (PcdSimicsDxeMemFvSize);
     MemorySize = LowerMemorySize - MemoryBase;
   }
-  DEBUG((EFI_D_INFO, "MemoryBase=0x%lx MemorySize=0x%lx\n", MemoryBase, MemorySize));
+  DEBUG((DEBUG_INFO, "MemoryBase=0x%lx MemorySize=0x%lx\n", MemoryBase, MemorySize));
   //
   // Publish this memory to the PEI Core
   //
@@ -397,7 +397,7 @@ QemuInitializeRam (
   EFI_SMRAM_HOB_DESCRIPTOR_BLOCK        *SmramHobDescriptorBlock;
   VOID                                  *GuidHob;
 
-  DEBUG ((EFI_D_INFO, "%a called\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a called\n", __FUNCTION__));
 
   //
   // Determine total memory size available

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsPei/MemDetect.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsPei/MemDetect.c
@@ -49,7 +49,7 @@ X58TsegMbytesInitialization(
       DEBUG_ERROR,
       "%a: no TSEG (SMRAM) on host bridge DID=0x%04x; "
       "only DID=0x%04x (X58) is supported\n",
-      __FUNCTION__,
+      __func__,
       mHostBridgeDevId,
       INTEL_ICH10_DEVICE_ID
       ));
@@ -155,7 +155,7 @@ GetFirstNonAddress (
   if (Pci64Size == 0) {
     if (mBootMode != BOOT_ON_S3_RESUME) {
       DEBUG ((DEBUG_INFO, "%a: disabling 64-bit PCI host aperture\n",
-        __FUNCTION__));
+        __func__));
       PcdSet64S (PcdPciMmio64Size, 0);
     }
 
@@ -191,7 +191,7 @@ GetFirstNonAddress (
     PcdSet64S (PcdPciMmio64Base, Pci64Base);
     PcdSet64S (PcdPciMmio64Size, Pci64Size);
     DEBUG ((DEBUG_INFO, "%a: Pci64Base=0x%Lx Pci64Size=0x%Lx\n",
-      __FUNCTION__, Pci64Base, Pci64Size));
+      __func__, Pci64Base, Pci64Size));
   }
 
   //
@@ -351,7 +351,7 @@ PublishPeiMemory (
   } else {
     PeiMemoryCap = GetPeiMemoryCap ();
     DEBUG ((DEBUG_INFO, "%a: mPhysMemAddressWidth=%d PeiMemoryCap=%u KB\n",
-      __FUNCTION__, mPhysMemAddressWidth, PeiMemoryCap >> 10));
+      __func__, mPhysMemAddressWidth, PeiMemoryCap >> 10));
 
     //
     // Determine the range of memory to use during PEI
@@ -397,7 +397,7 @@ QemuInitializeRam (
   EFI_SMRAM_HOB_DESCRIPTOR_BLOCK        *SmramHobDescriptorBlock;
   VOID                                  *GuidHob;
 
-  DEBUG ((DEBUG_INFO, "%a called\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a called\n", __func__));
 
   //
   // Determine total memory size available

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsPei/Platform.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsPei/Platform.c
@@ -364,7 +364,7 @@ MiscInitialization (
       break;
     default:
       DEBUG ((DEBUG_ERROR, "%a: Unknown Host Bridge Device ID: 0x%04x\n",
-        __FUNCTION__, mHostBridgeDevId));
+        __func__, mHostBridgeDevId));
       ASSERT (FALSE);
       return;
   }

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsPei/Platform.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsPei/Platform.c
@@ -363,7 +363,7 @@ MiscInitialization (
       AcpiEnBit  = ICH10_ACPI_CNTL_ACPI_EN;
       break;
     default:
-      DEBUG ((EFI_D_ERROR, "%a: Unknown Host Bridge Device ID: 0x%04x\n",
+      DEBUG ((DEBUG_ERROR, "%a: Unknown Host Bridge Device ID: 0x%04x\n",
         __FUNCTION__, mHostBridgeDevId));
       ASSERT (FALSE);
       return;
@@ -449,7 +449,7 @@ BootModeInitialization (
 {
   EFI_STATUS    Status;
 
- DEBUG((EFI_D_INFO, "modeValue = %x\n", IoBitFieldRead16(ICH10_PMBASE_IO + 4, 10, 12)));
+ DEBUG((DEBUG_INFO, "modeValue = %x\n", IoBitFieldRead16(ICH10_PMBASE_IO + 4, 10, 12)));
   if (IoBitFieldRead16(ICH10_PMBASE_IO + 4, 10, 12) == 0x5) {
     mBootMode = BOOT_ON_S3_RESUME;
   }
@@ -479,7 +479,7 @@ ReserveEmuVariableNvStore (
       AllocateRuntimePages (
         EFI_SIZE_TO_PAGES (2 * PcdGet32 (PcdFlashNvStorageFtwSpareSize))
         );
-  DEBUG ((EFI_D_INFO,
+  DEBUG ((DEBUG_INFO,
           "Reserved variable store memory: 0x%lX; size: %dkb\n",
           VariableStore,
           (2 * PcdGet32 (PcdFlashNvStorageFtwSpareSize)) / 1024
@@ -511,12 +511,12 @@ SimicsVersionCheck(
     for (i = 0; i < 0x80; i++) {
       SimicsStr[i] = PciRead8(PciAddrPtr + CapOffset + 0x10 + i);
     }
-    DEBUG((EFI_D_INFO, "=============SIMICS Version info=============\n"));
-    DEBUG((EFI_D_INFO, "Model number = %d\n", ModelNumber));
-    DEBUG((EFI_D_INFO, "Major version = %d\n", MajorVersion));
-    DEBUG((EFI_D_INFO, "Minor version = %d\n", MinorVersion));
-    DEBUG((EFI_D_INFO, "%a\n", SimicsStr));
-    DEBUG((EFI_D_INFO, "=============================================\n"));
+    DEBUG((DEBUG_INFO, "=============SIMICS Version info=============\n"));
+    DEBUG((DEBUG_INFO, "Model number = %d\n", ModelNumber));
+    DEBUG((DEBUG_INFO, "Major version = %d\n", MajorVersion));
+    DEBUG((DEBUG_INFO, "Minor version = %d\n", MinorVersion));
+    DEBUG((DEBUG_INFO, "%a\n", SimicsStr));
+    DEBUG((DEBUG_INFO, "=============================================\n"));
   }
 }
 
@@ -527,15 +527,15 @@ DebugDumpCmos (
 {
   UINT8 Loop;
 
-  DEBUG ((EFI_D_INFO, "CMOS:\n"));
+  DEBUG ((DEBUG_INFO, "CMOS:\n"));
 
   for (Loop = 0; Loop < 0x80; Loop++) {
     if ((Loop % 0x10) == 0) {
-      DEBUG ((EFI_D_INFO, "%02x:", Loop));
+      DEBUG ((DEBUG_INFO, "%02x:", Loop));
     }
-    DEBUG ((EFI_D_INFO, " %02x", CmosRead8 (Loop)));
+    DEBUG ((DEBUG_INFO, " %02x", CmosRead8 (Loop)));
     if ((Loop % 0x10) == 0xf) {
-      DEBUG ((EFI_D_INFO, "\n"));
+      DEBUG ((DEBUG_INFO, "\n"));
     }
   }
 }
@@ -593,13 +593,13 @@ InitializePlatform (
 {
   EFI_STATUS    Status;
 
-  DEBUG ((EFI_D_ERROR, "Platform PEIM Loaded\n"));
+  DEBUG ((DEBUG_ERROR, "Platform PEIM Loaded\n"));
 
   SimicsVersionCheck ();
   DebugDumpCmos ();
 
   if (QemuFwCfgS3Enabled ()) {
-    DEBUG ((EFI_D_INFO, "S3 support was detected on SIMICS\n"));
+    DEBUG ((DEBUG_INFO, "S3 support was detected on SIMICS\n"));
     mS3Supported = TRUE;
     Status = PcdSetBoolS (PcdAcpiS3Enable, TRUE);
     ASSERT_EFI_ERROR (Status);

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsVideoDxe/Driver.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsVideoDxe/Driver.c
@@ -146,7 +146,7 @@ QemuVideoControllerDriverSupported (
   }
   Card = QemuVideoDetect(Pci.Hdr.ClassCode[1], Pci.Hdr.VendorId, Pci.Hdr.DeviceId);
   if (Card != NULL) {
-    DEBUG ((EFI_D_INFO, "QemuVideo: %s detected\n", Card->Name));
+    DEBUG ((DEBUG_INFO, "QemuVideo: %s detected\n", Card->Name));
     Status = EFI_SUCCESS;
   }
 
@@ -297,10 +297,10 @@ QemuVideoControllerDriverStart (
                         );
     if (EFI_ERROR (Status) ||
         MmioDesc->ResType != ACPI_ADDRESS_SPACE_TYPE_MEM) {
-      DEBUG ((EFI_D_INFO, "QemuVideo: No mmio bar, fallback to port io\n"));
+      DEBUG ((DEBUG_INFO, "QemuVideo: No mmio bar, fallback to port io\n"));
       Private->Variant = QEMU_VIDEO_BOCHS;
     } else {
-      DEBUG ((EFI_D_INFO, "QemuVideo: Using mmio bar @ 0x%lx\n",
+      DEBUG ((DEBUG_INFO, "QemuVideo: Using mmio bar @ 0x%lx\n",
               MmioDesc->AddrRangeMin));
     }
 
@@ -317,7 +317,7 @@ QemuVideoControllerDriverStart (
     UINT16 BochsId;
     BochsId = BochsRead(Private, VBE_DISPI_INDEX_ID);
     if ((BochsId & 0xFFF0) != VBE_DISPI_ID0) {
-      DEBUG ((EFI_D_INFO, "QemuVideo: BochsID mismatch (got 0x%x)\n", BochsId));
+      DEBUG ((DEBUG_INFO, "QemuVideo: BochsID mismatch (got 0x%x)\n", BochsId));
       Status = EFI_DEVICE_ERROR;
       goto RestoreAttributes;
     }
@@ -951,7 +951,7 @@ InitializeBochsGraphicsMode (
   QEMU_VIDEO_BOCHS_MODES  *ModeData
   )
 {
-  DEBUG ((EFI_D_INFO, "InitializeBochsGraphicsMode: %dx%d @ %d\n",
+  DEBUG ((DEBUG_INFO, "InitializeBochsGraphicsMode: %dx%d @ %d\n",
           ModeData->Width, ModeData->Height, ModeData->ColorDepth));
 
   /* unblank */

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsVideoDxe/Gop.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsVideoDxe/Gop.c
@@ -29,7 +29,7 @@ QemuVideoCompleteModeInfo (
     Info->PixelInformation.BlueMask = PIXEL24_BLUE_MASK;
     Info->PixelInformation.ReservedMask = 0;
   } else if (ModeData->ColorDepth == 32) {
-    DEBUG ((EFI_D_INFO, "PixelBlueGreenRedReserved8BitPerColor\n"));
+    DEBUG ((DEBUG_INFO, "PixelBlueGreenRedReserved8BitPerColor\n"));
     Info->PixelFormat = PixelBlueGreenRedReserved8BitPerColor;
   }
   Info->PixelsPerScanLine = Info->HorizontalResolution;
@@ -64,7 +64,7 @@ QemuVideoCompleteModeData (
   Mode->FrameBufferSize = EFI_PAGES_TO_SIZE (
                             EFI_SIZE_TO_PAGES (Mode->FrameBufferSize)
                             );
-  DEBUG ((EFI_D_INFO, "FrameBufferBase: 0x%Lx, FrameBufferSize: 0x%Lx\n",
+  DEBUG ((DEBUG_INFO, "FrameBufferBase: 0x%Lx, FrameBufferSize: 0x%Lx\n",
     Mode->FrameBufferBase, (UINT64)Mode->FrameBufferSize));
 
   FreePool (FrameBufDesc);

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsVideoDxe/Initialize.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsVideoDxe/Initialize.c
@@ -179,7 +179,7 @@ QemuVideoCirrusModeSetup (
     ModeData->HorizontalResolution          = VideoMode->Width;
     ModeData->VerticalResolution            = VideoMode->Height;
     ModeData->ColorDepth                    = VideoMode->ColorDepth;
-    DEBUG ((EFI_D_INFO,
+    DEBUG ((DEBUG_INFO,
       "Adding Mode %d as Cirrus Internal Mode %d: %dx%d, %d-bit\n",
       (INT32) (ModeData - Private->ModeData),
       ModeData->InternalModeIndex,
@@ -288,7 +288,7 @@ QemuVideoBochsModeSetup (
         EFI_ERROR (
           Private->PciIo->Mem.Read (Private->PciIo, EfiPciIoWidthUint32,
                                 PCI_BAR_IDX2, 40, 1, &AvailableFbSize))) {
-      DEBUG ((EFI_D_ERROR, "%a: can't read size of drawable buffer from QXL "
+      DEBUG ((DEBUG_ERROR, "%a: can't read size of drawable buffer from QXL "
         "ROM\n", __FUNCTION__));
       return EFI_NOT_FOUND;
     }
@@ -296,7 +296,7 @@ QemuVideoBochsModeSetup (
     AvailableFbSize  = BochsRead (Private, VBE_DISPI_INDEX_VIDEO_MEMORY_64K);
     AvailableFbSize *= SIZE_64KB;
   }
-  DEBUG ((EFI_D_INFO, "%a: AvailableFbSize=0x%x\n", __FUNCTION__,
+  DEBUG ((DEBUG_INFO, "%a: AvailableFbSize=0x%x\n", __FUNCTION__,
     AvailableFbSize));
 
   //
@@ -321,7 +321,7 @@ QemuVideoBochsModeSetup (
       ModeData->HorizontalResolution = VideoMode->Width;
       ModeData->VerticalResolution   = VideoMode->Height;
       ModeData->ColorDepth           = VideoMode->ColorDepth;
-      DEBUG ((EFI_D_INFO,
+      DEBUG ((DEBUG_INFO,
         "Adding Mode %d as Bochs Internal Mode %d: %dx%d, %d-bit\n",
         (INT32) (ModeData - Private->ModeData),
         ModeData->InternalModeIndex,

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsVideoDxe/Initialize.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsVideoDxe/Initialize.c
@@ -289,14 +289,14 @@ QemuVideoBochsModeSetup (
           Private->PciIo->Mem.Read (Private->PciIo, EfiPciIoWidthUint32,
                                 PCI_BAR_IDX2, 40, 1, &AvailableFbSize))) {
       DEBUG ((DEBUG_ERROR, "%a: can't read size of drawable buffer from QXL "
-        "ROM\n", __FUNCTION__));
+        "ROM\n", __func__));
       return EFI_NOT_FOUND;
     }
   } else {
     AvailableFbSize  = BochsRead (Private, VBE_DISPI_INDEX_VIDEO_MEMORY_64K);
     AvailableFbSize *= SIZE_64KB;
   }
-  DEBUG ((DEBUG_INFO, "%a: AvailableFbSize=0x%x\n", __FUNCTION__,
+  DEBUG ((DEBUG_INFO, "%a: AvailableFbSize=0x%x\n", __func__,
     AvailableFbSize));
 
   //

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsVideoDxe/VbeShim.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsVideoDxe/VbeShim.c
@@ -112,7 +112,7 @@ InstallVbeShim (
     //
     Handler = (Int0x10->Segment << 4) + Int0x10->Offset;
     if (Handler >= SegmentC && Handler < SegmentF) {
-      DEBUG ((EFI_D_INFO, "%a: Video BIOS handler found at %04x:%04x\n",
+      DEBUG ((DEBUG_INFO, "%a: Video BIOS handler found at %04x:%04x\n",
         __FUNCTION__, Int0x10->Segment, Int0x10->Offset));
       return;
     }
@@ -298,5 +298,5 @@ InstallVbeShim (
   Int0x10->Segment = (UINT16) ((UINT32)SegmentC >> 4);
   Int0x10->Offset  = (UINT16) ((UINTN) (VbeModeInfo + 1) - SegmentC);
 
-  DEBUG ((EFI_D_INFO, "%a: VBE shim installed\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: VBE shim installed\n", __FUNCTION__));
 }

--- a/Platform/Intel/SimicsOpenBoardPkg/SimicsVideoDxe/VbeShim.c
+++ b/Platform/Intel/SimicsOpenBoardPkg/SimicsVideoDxe/VbeShim.c
@@ -71,12 +71,12 @@ InstallVbeShim (
     DEBUG ((
       DEBUG_WARN,
       "%a: page 0 protected, not installing VBE shim\n",
-      __FUNCTION__
+      __func__
       ));
     DEBUG ((
       DEBUG_WARN,
       "%a: page 0 protection prevents Windows 7 from booting anyway\n",
-      __FUNCTION__
+      __func__
       ));
     return;
   }
@@ -113,7 +113,7 @@ InstallVbeShim (
     Handler = (Int0x10->Segment << 4) + Int0x10->Offset;
     if (Handler >= SegmentC && Handler < SegmentF) {
       DEBUG ((DEBUG_INFO, "%a: Video BIOS handler found at %04x:%04x\n",
-        __FUNCTION__, Int0x10->Segment, Int0x10->Offset));
+        __func__, Int0x10->Segment, Int0x10->Offset));
       return;
     }
 
@@ -124,7 +124,7 @@ InstallVbeShim (
     DEBUG ((
       DEBUG_INFO,
       "%a: failed to allocate page at zero: %r\n",
-      __FUNCTION__,
+      __func__,
       Segment0AllocationStatus
       ));
   } else {
@@ -144,7 +144,7 @@ InstallVbeShim (
       DEBUG((
             DEBUG_ERROR,
             "%a: unknown host bridge device ID: 0x%04x\n",
-            __FUNCTION__,
+            __func__,
             HostBridgeDevId
       ));
       ASSERT (FALSE);
@@ -298,5 +298,5 @@ InstallVbeShim (
   Int0x10->Segment = (UINT16) ((UINT32)SegmentC >> 4);
   Int0x10->Offset  = (UINT16) ((UINTN) (VbeModeInfo + 1) - SegmentC);
 
-  DEBUG ((DEBUG_INFO, "%a: VBE shim installed\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: VBE shim installed\n", __func__));
 }

--- a/Platform/Intel/Vlv2TbltDevicePkg/AcpiPlatform/AcpiPlatform.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/AcpiPlatform/AcpiPlatform.c
@@ -352,7 +352,7 @@ PlatformUpdateTables (
             //
             // Sanity check to make sure proc-id is not arbitrary.
             //
-            DEBUG ((EFI_D_ERROR, "ApicPtr->AcpiLocalApic.AcpiProcessorId = %x, MaximumNumberOfCPUs = %x\n", \
+            DEBUG ((DEBUG_ERROR, "ApicPtr->AcpiLocalApic.AcpiProcessorId = %x, MaximumNumberOfCPUs = %x\n", \
             ApicPtr->AcpiLocalApic.AcpiProcessorId, MaximumNumberOfCPUs));
             if(ApicPtr->AcpiLocalApic.AcpiProcessorId > MaximumNumberOfCPUs) {
               ApicPtr->AcpiLocalApic.AcpiProcessorId = (UINT8)MaximumNumberOfCPUs;
@@ -713,11 +713,11 @@ PR1FSASetting (
   // for FSA on  PR1.
   //
   if (mPlatformInfo->BoardId == BOARD_ID_BL_FFRD && mPlatformInfo->BoardRev >= PR1) {
-    DEBUG((EFI_D_ERROR, "Set FSA status = 1 for FFRD PR1\n"));
+    DEBUG((DEBUG_ERROR, "Set FSA status = 1 for FFRD PR1\n"));
     mGlobalNvsArea.Area->FsaStatus  = mSystemConfiguration.PchFSAOn;
   }
   if (mPlatformInfo->BoardId == BOARD_ID_BL_FFRD8) {
-    DEBUG((EFI_D_ERROR, "Set FSA status = 1 for FFRD8\n"));
+    DEBUG((DEBUG_ERROR, "Set FSA status = 1 for FFRD8\n"));
     mGlobalNvsArea.Area->FsaStatus  = mSystemConfiguration.PchFSAOn;
   }
 
@@ -877,7 +877,7 @@ AcpiPlatformEntryPoint (
          sizeof (EFI_GLOBAL_NVS_AREA),
          0
          );
-  DEBUG((EFI_D_ERROR, "mGlobalNvsArea.Area is at 0x%X\n", mGlobalNvsArea.Area));
+  DEBUG((DEBUG_ERROR, "mGlobalNvsArea.Area is at 0x%X\n", mGlobalNvsArea.Area));
 
   //
   // Update global NVS area for ASL and SMM init code to use.
@@ -980,7 +980,7 @@ AcpiPlatformEntryPoint (
       mSystemConfiguration.PchUsb20       = 1;
       mSystemConfiguration.PchUsb30Mode   = 0;
       mSystemConfiguration.UsbXhciSupport = 0;
-      DEBUG ((EFI_D_INFO, "EHCI is enabled as default. SOC 0x%x\n", pchStepping));
+      DEBUG ((DEBUG_INFO, "EHCI is enabled as default. SOC 0x%x\n", pchStepping));
     } else {
       //
       //  For A1 and later, XHCI is enabled as default.
@@ -988,7 +988,7 @@ AcpiPlatformEntryPoint (
       mSystemConfiguration.PchUsb20       = 0;
       mSystemConfiguration.PchUsb30Mode   = 1;
       mSystemConfiguration.UsbXhciSupport = 1;
-      DEBUG ((EFI_D_INFO, "XHCI is enabled as default. SOC 0x%x\n", pchStepping));
+      DEBUG ((DEBUG_INFO, "XHCI is enabled as default. SOC 0x%x\n", pchStepping));
     }
   }
 
@@ -1006,7 +1006,7 @@ AcpiPlatformEntryPoint (
     mGlobalNvsArea.Area->XhciMode = 3;
   }
 
-  DEBUG ((EFI_D_ERROR, "ACPI NVS XHCI:0x%x\n", mGlobalNvsArea.Area->XhciMode));
+  DEBUG ((DEBUG_ERROR, "ACPI NVS XHCI:0x%x\n", mGlobalNvsArea.Area->XhciMode));
 
   mGlobalNvsArea.Area->PmicEnable                       = GLOBAL_NVS_DEVICE_DISABLE;
   mGlobalNvsArea.Area->BatteryChargingSolution          = GLOBAL_NVS_DEVICE_DISABLE;
@@ -1036,7 +1036,7 @@ AcpiPlatformEntryPoint (
     //
     // Auto detect mode.
     //
-    DEBUG ((EFI_D_ERROR, "Auto detect mode------------start\n"));
+    DEBUG ((DEBUG_ERROR, "Auto detect mode------------start\n"));
 
     //
     // Silicon Steppings.
@@ -1044,14 +1044,14 @@ AcpiPlatformEntryPoint (
     switch (PchStepping()) {
       case PchA0: // A0/A1
       case PchA1:
-        DEBUG ((EFI_D_ERROR, "SOC A0/A1: eMMC 4.41 Configuration\n"));
+        DEBUG ((DEBUG_ERROR, "SOC A0/A1: eMMC 4.41 Configuration\n"));
         mSystemConfiguration.LpsseMMCEnabled            = 1;
         mSystemConfiguration.LpsseMMC45Enabled          = 0;
         break;
 
       case PchB0: // B0 and later.
       default:
-        DEBUG ((EFI_D_ERROR, "SOC B0 and later: eMMC 4.5 Configuration\n"));
+        DEBUG ((DEBUG_ERROR, "SOC B0 and later: eMMC 4.5 Configuration\n"));
         mSystemConfiguration.LpsseMMCEnabled            = 0;
         mSystemConfiguration.LpsseMMC45Enabled          = 1;
         break;
@@ -1060,14 +1060,14 @@ AcpiPlatformEntryPoint (
       //
       // eMMC 4.41
       //
-      DEBUG ((EFI_D_ERROR, "Force to eMMC 4.41 Configuration\n"));
+      DEBUG ((DEBUG_ERROR, "Force to eMMC 4.41 Configuration\n"));
       mSystemConfiguration.LpsseMMCEnabled            = 1;
       mSystemConfiguration.LpsseMMC45Enabled          = 0;
   } else if (mSystemConfiguration.eMMCBootMode == 3) {
       //
       // eMMC 4.5
       //
-      DEBUG ((EFI_D_ERROR, "Force to eMMC 4.5 Configuration\n"));
+      DEBUG ((DEBUG_ERROR, "Force to eMMC 4.5 Configuration\n"));
       mSystemConfiguration.LpsseMMCEnabled            = 0;
       mSystemConfiguration.LpsseMMC45Enabled          = 1;
 
@@ -1075,19 +1075,19 @@ AcpiPlatformEntryPoint (
       //
       // Disable eMMC controllers.
       //
-      DEBUG ((EFI_D_ERROR, "Disable eMMC controllers\n"));
+      DEBUG ((DEBUG_ERROR, "Disable eMMC controllers\n"));
       mSystemConfiguration.LpsseMMCEnabled            = 0;
       mSystemConfiguration.LpsseMMC45Enabled          = 0;
   }
 
   mGlobalNvsArea.Area->emmcVersion = 0;
   if (mSystemConfiguration.LpsseMMCEnabled) {
-     DEBUG ((EFI_D_ERROR, "mGlobalNvsArea.Area->emmcVersion = 0\n"));
+     DEBUG ((DEBUG_ERROR, "mGlobalNvsArea.Area->emmcVersion = 0\n"));
      mGlobalNvsArea.Area->emmcVersion = 0;
   }
 
   if (mSystemConfiguration.LpsseMMC45Enabled) {
-     DEBUG ((EFI_D_ERROR, "mGlobalNvsArea.Area->emmcVersion = 1\n"));
+     DEBUG ((DEBUG_ERROR, "mGlobalNvsArea.Area->emmcVersion = 1\n"));
      mGlobalNvsArea.Area->emmcVersion = 1;
   }
 
@@ -1100,10 +1100,10 @@ AcpiPlatformEntryPoint (
       (mSystemConfiguration.LpssPwm0Enabled == 0) && \
       (mSystemConfiguration.LpssPwm1Enabled == 0)) {
     mGlobalNvsArea.Area->MicrosoftIoT = GLOBAL_NVS_DEVICE_ENABLE;
-    DEBUG ((EFI_D_ERROR, "JP1 is set to be MSFT IOT configuration.\n"));
+    DEBUG ((DEBUG_ERROR, "JP1 is set to be MSFT IOT configuration.\n"));
   } else {
     mGlobalNvsArea.Area->MicrosoftIoT = GLOBAL_NVS_DEVICE_DISABLE;
-    DEBUG ((EFI_D_ERROR, "JP1 is not set to be MSFT IOT configuration.\n"));
+    DEBUG ((DEBUG_ERROR, "JP1 is not set to be MSFT IOT configuration.\n"));
   }
 
   //
@@ -1237,7 +1237,7 @@ SettingI2CTouchAddress (
   } else {
     mGlobalNvsArea.Area->I2CTouchAddress = mSystemConfiguration.I2CTouchAd;
   }
-  DEBUG((EFI_D_ERROR, "GlobalNvsArea.Area->I2CTouchAddress: [%02x]\n", mGlobalNvsArea.Area->I2CTouchAddress));
+  DEBUG((DEBUG_ERROR, "GlobalNvsArea.Area->I2CTouchAddress: [%02x]\n", mGlobalNvsArea.Area->I2CTouchAddress));
 }
 
 

--- a/Platform/Intel/Vlv2TbltDevicePkg/Application/FirmwareUpdate/FirmwareUpdate.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/Application/FirmwareUpdate/FirmwareUpdate.c
@@ -373,9 +373,9 @@ ShellAppMain (
       // Handle block based on address and contents.
       //
       if (!UpdateBlock (Address)) {
-        DEBUG((EFI_D_INFO, "Skipping block at 0x%lx\n", Address));
+        DEBUG((DEBUG_INFO, "Skipping block at 0x%lx\n", Address));
       } else if (!EFI_ERROR (InternalCompareBlock (Address, Buffer))) {
-        DEBUG((EFI_D_INFO, "Skipping block at 0x%lx (already programmed)\n", Address));
+        DEBUG((DEBUG_INFO, "Skipping block at 0x%lx (already programmed)\n", Address));
       } else {
         //
         // Display a dot for each block being updated.
@@ -597,7 +597,7 @@ Returns:
   Status = SpiFlashWrite ((UINTN) BaseAddress, &BufferSize, Buffer);
   ASSERT_EFI_ERROR(Status);
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "\nFlash write error."));
+    DEBUG((DEBUG_ERROR, "\nFlash write error."));
     return Status;
   }
 
@@ -605,9 +605,9 @@ Returns:
 
   Status = InternalCompareBlock (BaseAddress, Buffer);
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "\nError when writing to BaseAddress %lx with different at offset %x.", BaseAddress, Status));
+    DEBUG((DEBUG_ERROR, "\nError when writing to BaseAddress %lx with different at offset %x.", BaseAddress, Status));
   } else {
-    DEBUG((EFI_D_INFO, "\nVerified data written to Block at %lx is correct.", BaseAddress));
+    DEBUG((DEBUG_INFO, "\nVerified data written to Block at %lx is correct.", BaseAddress));
   }
 
   return Status;

--- a/Platform/Intel/Vlv2TbltDevicePkg/FvInfoPei/FvInfoPei.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/FvInfoPei/FvInfoPei.c
@@ -1,10 +1,12 @@
 /** @file
 
   Copyright (c) 2004  - 2014, Intel Corporation. All rights reserved.<BR>
-                                                                                   
+                                                                                   
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-                                                                                   
+                                                                                   
+
 
 Module Name:
 
@@ -60,7 +62,7 @@ PeimInitializeFvInfo (
 {
   EFI_STATUS  Status;
   Status = (**PeiServices).InstallPpi (PeiServices, &mPpiList[0]);
-  ASSERT_EFI_ERROR (Status);
+  ASSERT_EDEBUG_OR (Status);
 
   DEBUG ((EFI_D_INFO, "\nFvInfo Add Fv Info\n"));
 

--- a/Platform/Intel/Vlv2TbltDevicePkg/FvbRuntimeDxe/FvbInfo.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/FvbRuntimeDxe/FvbInfo.c
@@ -3,10 +3,12 @@
   These data is intent to decouple FVB driver with FV header.
 
 Copyright (c) 2006  - 2015, Intel Corporation. All rights reserved.<BR>
-                                                                                   
+                                                                                   
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-                                                                                   
+                                                                                   
+
 
 **/
 
@@ -153,13 +155,13 @@ GetFvbInfo (
       //
       FvHeader->Checksum = CalculateCheckSum16 ((UINT16 *) FvHeader, FvHeader->HeaderLength);
 
-      *FvbInfo = FvHeader;
-
-      DEBUG ((EFI_D_INFO, "\nBaseAddr: 0x%lx \n", FvBaseAddress));
-      DEBUG ((EFI_D_INFO, "FvLength: 0x%lx \n", (*FvbInfo)->FvLength));
-      DEBUG ((EFI_D_INFO, "HeaderLength: 0x%x \n", (*FvbInfo)->HeaderLength));
-      DEBUG ((EFI_D_INFO, "FvBlockMap[0].NumBlocks: 0x%x \n", (*FvbInfo)->BlockMap[0].NumBlocks));
-      DEBUG ((EFI_D_INFO, "FvBlockMap[0].BlockLength: 0x%x \n", (*FvbInfo)->BlockMap[0].Length));
+      *FvbInfoDEBUG_eader;
+DEBUG_
+      DEBUG ((DEBUG_INFO, "\nBaseAddr: 0x%lx \n", FvBaseAddress));
+      DEBUG ((DEBUG_INFO, "FvLength: 0x%lx \n", (*FvbInfo)->FvLength));
+      DEBUG ((DEBUG_INFO, "HeaderLength: 0x%x \n", (*FvbInfo)->HeaderLength));
+      DEBUG ((DEBUG_INFO, "FvBlockMap[0].NumBlocks: 0x%x \n", (*FvbInfo)->BlockMap[0].NumBlocks));
+      DEBUG ((DEBUG_INFO, "FvBlockMap[0].BlockLength: 0x%x \n", (*FvbInfo)->BlockMap[0].Length));
       DEBUG ((EFI_D_INFO, "FvBlockMap[1].NumBlocks: 0x%x \n",   (*FvbInfo)->BlockMap[1].NumBlocks));
       DEBUG ((EFI_D_INFO, "FvBlockMap[1].BlockLength: 0x%x \n\n", (*FvbInfo)->BlockMap[1].Length));
 

--- a/Platform/Intel/Vlv2TbltDevicePkg/FvbRuntimeDxe/FvbService.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/FvbRuntimeDxe/FvbService.c
@@ -5,10 +5,12 @@
   It depends on which Flash Device Library to be linked with this driver.
 
 Copyright (c) 2006  - 2014, Intel Corporation. All rights reserved.<BR>
-                                                                                   
+                                                                                   
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-                                                                                   
+                                                                                   
+
 
 **/
 
@@ -380,7 +382,7 @@ FvbWriteBlock (
   if (BlockOffset > LbaLength) {
     return (EFI_INVALID_PARAMETER);
   }
-
+DEBUG_
   if ( LbaLength < ( *NumBytes + BlockOffset ) ) {
     DEBUG ((EFI_D_ERROR,
       "FvWriteBlock: Reducing Numbytes from 0x%x to 0x%x\n",
@@ -645,7 +647,7 @@ FvbProtocolGetBlockSize (
   OUT UINTN                              *NumOfBlocks
   )
 {
-  EFI_FW_VOL_BLOCK_DEVICE                 *FvbDevice;
+  EFI_FW_DEBUG_OCK_DEVICE                 *FvbDevice;
 
   DEBUG((EFI_D_INFO,
     "FvbProtocolGetBlockSize: Lba: 0x%lx BlockSize: 0x%x NumOfBlocks: 0x%x\n",
@@ -686,7 +688,7 @@ FvbProtocolGetAttributes (
 
   FvbDevice = FVB_DEVICE_FROM_THIS (This);
 
-  *Attributes = FvbGetVolumeAttributes (FvbDevice->Instance);
+  *AttribuDEBUG_FvbGetVolumeAttributes (FvbDevice->Instance);
 
   DEBUG ((EFI_D_INFO,
     "FvbProtocolGetAttributes: This: 0x%x Attributes: 0x%x\n",
@@ -715,7 +717,7 @@ FvbProtocolSetAttributes (
   )
 {
   EFI_STATUS                            Status;
-  EFI_FW_VOL_BLOCK_DEVICE               *FvbDevice;
+  EFI_FW_DEBUG_OCK_DEVICE               *FvbDevice;
 
   DEBUG((EFI_D_INFO,
     "FvbProtocolSetAttributes: Before SET -  This: 0x%x Attributes: 0x%x\n",
@@ -725,7 +727,7 @@ FvbProtocolSetAttributes (
 
   FvbDevice = FVB_DEVICE_FROM_THIS (This);
 
-  Status = FvbSetVolumeAttributes (FvbDevice->Instance, Attributes);
+  Status DEBUG_etVolumeAttributes (FvbDevice->Instance, Attributes);
 
   DEBUG((EFI_D_INFO,
     "FvbProtocolSetAttributes: After SET -  This: 0x%x Attributes: 0x%x\n",
@@ -769,7 +771,7 @@ FvbProtocolEraseBlocks (
   VA_LIST                               args;
   EFI_LBA                               StartingLba;
   UINTN                                 NumOfLba;
-  EFI_STATUS                            Status;
+  EFI_STADEBUG_                         Status;
 
   DEBUG((EFI_D_INFO, "FvbProtocolEraseBlocks: \n"));
   FvbDevice = FVB_DEVICE_FROM_THIS (This);
@@ -870,7 +872,7 @@ FvbProtocolWrite (
 
   EFI_FW_VOL_BLOCK_DEVICE               *FvbDevice;
 
-  FvbDevice = FVB_DEVICE_FROM_THIS (This);
+  FvbDeviDEBUG_VB_DEVICE_FROM_THIS (This);
 
   DEBUG((EFI_D_INFO,
     "FvbProtocolWrite: Lba: 0x%lx Offset: 0x%x NumBytes: 0x%x, Buffer: 0x%x\n",
@@ -926,7 +928,7 @@ FvbProtocolRead (
   EFI_FW_VOL_BLOCK_DEVICE   *FvbDevice;
   EFI_STATUS                Status;
 
-  FvbDevice = FVB_DEVICE_FROM_THIS (This);
+  FvbDeviDEBUG_VB_DEVICE_FROM_THIS (This);
   Status = FvbReadBlock (FvbDevice->Instance, Lba, Offset, NumBytes, Buffer);
   DEBUG((EFI_D_INFO,
     "FvbProtocolRead: Lba: 0x%lx Offset: 0x%x NumBytes: 0x%x, Buffer: 0x%x\n",
@@ -1030,13 +1032,13 @@ FvbInitialize (
     if (!IsFvHeaderValid (BaseAddress, FwVolHeader)) {
       //
       // If not valid, get FvbInfo from the information carried in
-      // FVB driver.
+      // FVB dDEBUG_
       //
       DEBUG ((EFI_D_ERROR, "Fvb: FV header @ 0x%lx invalid\n", BaseAddress));
       Status          = GetFvbInfo (BaseAddress, &FwVolHeader);
       ASSERT_EFI_ERROR(Status);
       //
-      //  Write back a healthy FV header.
+      //  WritDEBUG_ a healthy FV header.
       //
       DEBUG ((EFI_D_ERROR, "FwBlockService.c: Writing back healthy FV header\n"));
       LibFvbFlashDeviceBlockLock ((UINTN)BaseAddress, FwVolHeader->BlockMap->Length, FALSE);

--- a/Platform/Intel/Vlv2TbltDevicePkg/FvbRuntimeDxe/FvbServiceDxe.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/FvbRuntimeDxe/FvbServiceDxe.c
@@ -5,10 +5,12 @@
   It depends on which Flash Device Library to be linked with this driver.
 
 Copyright (c) 2006  - 2014, Intel Corporation. All rights reserved.<BR>
-                                                                                   
+                                                                                   
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-                                                                                   
+                                                                                   
+
 
 **/
 
@@ -86,7 +88,7 @@ InstallFvbProtocol (
   FwVolHeader = &FwhInstance->VolumeHeader;
 
   //
-  // Set up the devicepath.
+  // Set uDEBUG_devicepath.
   //
   DEBUG ((EFI_D_INFO, "FwBlockService.c: Setting up DevicePath for 0x%lx:\n", FwhInstance->FvBase));
   if (FwVolHeader->ExtHeaderOffset == 0) {
@@ -114,7 +116,7 @@ InstallFvbProtocol (
                   );
   if (EFI_ERROR (Status) ) {
     //
-    // LocateDevicePath fails so install a new interface and device path.
+    // LocatDEBUG_ePath fails so install a new interface and device path.
     //
     DEBUG ((EFI_D_INFO, "FwBlockService.c: LocateDevicePath failed, install new interface 0x%lx:\n", FwhInstance->FvBase));
     FwbHandle = NULL;
@@ -125,13 +127,13 @@ InstallFvbProtocol (
                      &gEfiDevicePathProtocolGuid,
                      FvbDevice->DevicePath,
                      NULL
-                     );
+            DEBUG_   );
     ASSERT_EFI_ERROR (Status);
     DEBUG ((EFI_D_INFO, "FwBlockService.c: IMPI FirmwareVolBlockProt, DevPath 0x%lx: %r\n", FwhInstance->FvBase, Status));
 
   } else if (IsDevicePathEnd (FvbDevice->DevicePath)) {
     //
-    // Device allready exists, so reinstall the FVB protocol.
+    // DevicDEBUG_eady exists, so reinstall the FVB protocol.
     //
     DEBUG ((EFI_D_ERROR, "FwBlockService.c: LocateDevicePath succeeded, reinstall interface 0x%lx:\n", FwhInstance->FvBase));
     Status = gBS->HandleProtocol (

--- a/Platform/Intel/Vlv2TbltDevicePkg/Library/EfiRegTableLib/EfiRegTableLib.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/Library/EfiRegTableLib/EfiRegTableLib.c
@@ -225,7 +225,7 @@ ProcessRegTablePci (
       break;
 
     default:
-      DEBUG ((EFI_D_ERROR, "RegTable ERROR: Unknown RegTable OpCode (%x)\n", OPCODE_BASE (RegTableEntry->Generic.OpCode)));
+      DEBUG ((DEBUG_ERROR, "RegTable ERROR: Unknown RegTable OpCode (%x)\n", OPCODE_BASE (RegTableEntry->Generic.OpCode)));
       ASSERT (0);
       break;
     }

--- a/Platform/Intel/Vlv2TbltDevicePkg/Library/FlashDeviceLib/FlashDeviceLibDxe.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/Library/FlashDeviceLib/FlashDeviceLibDxe.c
@@ -50,7 +50,7 @@ LibFvbFlashDeviceSupportInit (
                   );
   ASSERT_EFI_ERROR (Status);
   // There is no need to call Init, because Runtime or SMM FVB already does that.
-  DEBUG((EFI_D_ERROR, "LibFvbFlashDeviceSupportInit - no init\n"));
+  DEBUG((DEBUG_ERROR, "LibFvbFlashDeviceSupportInit - no init\n"));
   return EFI_SUCCESS;
 }
 

--- a/Platform/Intel/Vlv2TbltDevicePkg/Library/FlashDeviceLib/FlashDeviceLibDxeRuntimeSmm.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/Library/FlashDeviceLib/FlashDeviceLibDxeRuntimeSmm.c
@@ -136,11 +136,11 @@ LibFvbFlashDeviceSupportInit (
             //
             // Found a matching SPI device, FlashIndex now contains flash device.
             //
-            DEBUG ((EFI_D_ERROR, "OK - Found SPI Flash Type in SPI Flash Driver, Device Type ID 0 = 0x%02x!\n", mInitTable[FlashIndex].DeviceId0));
-            DEBUG ((EFI_D_ERROR, "Device Type ID 1 = 0x%02x!\n", mInitTable[FlashIndex].DeviceId1));
+            DEBUG ((DEBUG_ERROR, "OK - Found SPI Flash Type in SPI Flash Driver, Device Type ID 0 = 0x%02x!\n", mInitTable[FlashIndex].DeviceId0));
+            DEBUG ((DEBUG_ERROR, "Device Type ID 1 = 0x%02x!\n", mInitTable[FlashIndex].DeviceId1));
 
             if (mInitTable[FlashIndex].BiosStartOffset == (UINTN) (-1)) {
-              DEBUG ((EFI_D_ERROR, "ERROR - The size of BIOS image is bigger than SPI Flash device!\n"));
+              DEBUG ((DEBUG_ERROR, "ERROR - The size of BIOS image is bigger than SPI Flash device!\n"));
               CpuDeadLoop ();
             }
             break;
@@ -153,18 +153,18 @@ LibFvbFlashDeviceSupportInit (
     }
   }
 
-  DEBUG ((EFI_D_ERROR, "SPI flash chip VID = 0x%X, DID0 = 0x%X, DID1 = 0x%X\n", SfId[0], SfId[1], SfId[2]));
+  DEBUG ((DEBUG_ERROR, "SPI flash chip VID = 0x%X, DID0 = 0x%X, DID1 = 0x%X\n", SfId[0], SfId[1], SfId[2]));
 
   if (FlashIndex < EnumSpiFlashMax)  {
     return EFI_SUCCESS;
   } else {
   if (SpiReadError != 0) {
-      DEBUG ((EFI_D_ERROR, "ERROR - SPI Read ID execution failed! Error Count = %d\n", SpiReadError));
+      DEBUG ((DEBUG_ERROR, "ERROR - SPI Read ID execution failed! Error Count = %d\n", SpiReadError));
    }
     else {
       if (SpiNotMatchError != 0) {
-        DEBUG ((EFI_D_ERROR, "ERROR - No supported SPI flash chip found! Error Count = %d\n", SpiNotMatchError));
-        DEBUG ((EFI_D_ERROR, "SPI flash chip VID = 0x%X, DID0 = 0x%X, DID1 = 0x%X\n", SfId[0], SfId[1], SfId[2]));
+        DEBUG ((DEBUG_ERROR, "ERROR - No supported SPI flash chip found! Error Count = %d\n", SpiNotMatchError));
+        DEBUG ((DEBUG_ERROR, "SPI flash chip VID = 0x%X, DID0 = 0x%X, DID1 = 0x%X\n", SfId[0], SfId[1], SfId[2]));
       }
     }
     return EFI_UNSUPPORTED;

--- a/Platform/Intel/Vlv2TbltDevicePkg/Library/MultiPlatformLib/BoardClkGens/BoardClkGens.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/Library/MultiPlatformLib/BoardClkGens/BoardClkGens.c
@@ -84,17 +84,17 @@ ConfigureClockGenerator (
   {
     UINT8 i;
     for (i = 0; i < sizeof (Buffer); i++) {
-      DEBUG((EFI_D_ERROR, "CK505 default Clock Generator Byte %d: %x\n", i, Buffer[i]));
+      DEBUG((DEBUG_ERROR, "CK505 default Clock Generator Byte %d: %x\n", i, Buffer[i]));
     }
 #if CLKGEN_EN
     for (i = 0; i < ConfigurationTableLength; i++) {
-      DEBUG((EFI_D_ERROR, "BIOS structure Clock Generator Byte %d: %x\n", i, ConfigurationTable[i]));
+      DEBUG((DEBUG_ERROR, "BIOS structure Clock Generator Byte %d: %x\n", i, ConfigurationTable[i]));
     }
 #endif
   }
 #endif
 
-  DEBUG((EFI_D_ERROR, "Expected Clock Generator ID is %x, expecting %x\n", mSupportedClockGeneratorTable[ClockType].ClockId,(Buffer[7]&0xF)));
+  DEBUG((DEBUG_ERROR, "Expected Clock Generator ID is %x, expecting %x\n", mSupportedClockGeneratorTable[ClockType].ClockId,(Buffer[7]&0xF)));
 
   //
   // Program clock generator
@@ -164,7 +164,7 @@ ConfigureClockGenerator (
         );
 
       for (i = 0; i < ConfigurationTableLength; i++) {
-        DEBUG((EFI_D_ERROR, "Clock Generator Byte %d: %x\n", i, Buffer[i]));
+        DEBUG((DEBUG_ERROR, "Clock Generator Byte %d: %x\n", i, Buffer[i]));
       }
     }
     #endif
@@ -218,7 +218,7 @@ ReadClockGeneratorID (
   //
   // Sanity check that the requested clock type is present in our supported clocks table
   //
-  DEBUG((EFI_D_ERROR, "Expected Clock Generator ID is 0x%x\n", Buffer[7]));
+  DEBUG((DEBUG_ERROR, "Expected Clock Generator ID is 0x%x\n", Buffer[7]));
 
   return (Buffer[7]);
 }
@@ -270,7 +270,7 @@ ConfigurePlatformClocks (
   Status = GetPlatformInfoHob ((CONST EFI_PEI_SERVICES **) PeiServices, &PlatformInfoHob);
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG((EFI_D_ERROR, "PlatformInfo protocol is working in ConfigurePlatformClocks()...%x\n",PlatformInfoHob->PlatformFlavor));
+  DEBUG((DEBUG_ERROR, "PlatformInfo protocol is working in ConfigurePlatformClocks()...%x\n",PlatformInfoHob->PlatformFlavor));
 
   //
   // Locate SMBUS PPI
@@ -299,7 +299,7 @@ ConfigurePlatformClocks (
                                                );
 
   if (EFI_ERROR (Status) || ((Data & 0x0F) != CK505_GENERATOR_ID)) {
-      DEBUG((EFI_D_ERROR, "Clock Generator CK505 Not Present, vendor ID on board is %x\n",(Data & 0x0F)));
+      DEBUG((DEBUG_ERROR, "Clock Generator CK505 Not Present, vendor ID on board is %x\n",(Data & 0x0F)));
       return EFI_SUCCESS;
 }
 
@@ -344,7 +344,7 @@ ConfigurePlatformClocks (
   //
   // Perform platform-specific intialization dependent upon Board ID:
   //
-  DEBUG((EFI_D_ERROR, "board id is %x, platform id is %x\n",PlatformInfoHob->BoardId,PlatformInfoHob->PlatformFlavor));
+  DEBUG((DEBUG_ERROR, "board id is %x, platform id is %x\n",PlatformInfoHob->BoardId,PlatformInfoHob->PlatformFlavor));
 
 
   switch (PlatformInfoHob->BoardId) {
@@ -404,7 +404,7 @@ InstallPlatformClocksNotify (
 {
   EFI_STATUS                    Status;
 
-  DEBUG ((EFI_D_INFO, "InstallPlatformClocksNotify()...\n"));
+  DEBUG ((DEBUG_INFO, "InstallPlatformClocksNotify()...\n"));
 
   Status = (*PeiServices)->NotifyPpi(PeiServices, &mNotifyList[0]);
   ASSERT_EFI_ERROR (Status);

--- a/Platform/Intel/Vlv2TbltDevicePkg/Library/MultiPlatformLib/BoardGpios/BoardGpios.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/Library/MultiPlatformLib/BoardGpios/BoardGpios.c
@@ -44,7 +44,7 @@ ConfigurePlatformSysCtrlGpio (
   UINT32        Status;
   EFI_PLATFORM_INFO_HOB               *PlatformInfoHob;
 
-   DEBUG ((EFI_D_INFO, "ConfigurePlatformSysCtrlGpio()...\n"));
+   DEBUG ((DEBUG_INFO, "ConfigurePlatformSysCtrlGpio()...\n"));
 
   //
   // Obtain Platform Info from HOB.
@@ -56,7 +56,7 @@ ConfigurePlatformSysCtrlGpio (
   // The GPIO settings are dependent upon the platform.  Obtain the Board ID through
   // the EC to determine the current platform.
   //
-   DEBUG ((EFI_D_INFO, "Platform Flavor | Board ID = 0x%X | 0x%X\n", PlatformInfoHob->PlatformFlavor, PlatformInfoHob->BoardId));
+   DEBUG ((DEBUG_INFO, "Platform Flavor | Board ID = 0x%X | 0x%X\n", PlatformInfoHob->PlatformFlavor, PlatformInfoHob->BoardId));
 
 
 
@@ -100,7 +100,7 @@ InstallPlatformSysCtrlGPIONotify (
 {
   EFI_STATUS                    Status;
 
-  DEBUG ((EFI_D_INFO, "InstallPlatformSysCtrlGPIONotify()...\n"));
+  DEBUG ((DEBUG_INFO, "InstallPlatformSysCtrlGPIONotify()...\n"));
 
   Status = (*PeiServices)->NotifyPpi(PeiServices, &mNotifyList[0]);
   ASSERT_EFI_ERROR (Status);
@@ -133,7 +133,7 @@ MultiPlatformGpioTableInit (
   UINTN                           VarSize;
   SYSTEM_CONFIGURATION            SystemConfiguration;
 
-  DEBUG ((EFI_D_INFO, "MultiPlatformGpioTableInit()...\n"));
+  DEBUG ((DEBUG_INFO, "MultiPlatformGpioTableInit()...\n"));
 
   //
   // Select/modify the GPIO initialization data based on the Board ID.
@@ -234,10 +234,10 @@ InternalGpioConfig (
     mmio_padval= IO_BASE_ADDRESS + Gpio_Mmio_Offset + R_PCH_CFIO_PAD_VAL   + Gpio_Conf_Data[index].offset * 16;
 
 #ifdef EFI_DEBUG
-    DEBUG ((EFI_D_INFO, "%s, ", Gpio_Conf_Data[index].pad_name));
+    DEBUG ((DEBUG_INFO, "%s, ", Gpio_Conf_Data[index].pad_name));
 
 #endif
-    DEBUG ((EFI_D_INFO, "Usage = %d, Func# = %d, IntType = %d, Pull Up/Down = %d, MMIO Base = 0x%08x, ",
+    DEBUG ((DEBUG_INFO, "Usage = %d, Func# = %d, IntType = %d, Pull Up/Down = %d, MMIO Base = 0x%08x, ",
       Gpio_Conf_Data[index].usage,
       Gpio_Conf_Data[index].func,
       Gpio_Conf_Data[index].int_type,
@@ -267,7 +267,7 @@ InternalGpioConfig (
     }
 
 
-    DEBUG ((EFI_D_INFO, "Set PAD_VAL = 0x%08x, ", pad_val.dw));
+    DEBUG ((DEBUG_INFO, "Set PAD_VAL = 0x%08x, ", pad_val.dw));
 
     MmioWrite32(mmio_padval, pad_val.dw);
 
@@ -354,7 +354,7 @@ InternalGpioConfig (
       conf0_val.dw |= (Gpio_Conf_Data[index].int_type & 0x0f)<<24;
     }
 
-    DEBUG ((EFI_D_INFO, "Set CONF0 = 0x%08x\n", conf0_val.dw));
+    DEBUG ((DEBUG_INFO, "Set CONF0 = 0x%08x\n", conf0_val.dw));
 
     //
     // Write back the targeted GPIO config value according to platform (board) GPIO setting.
@@ -390,7 +390,7 @@ MultiPlatformGpioProgram (
   CFIO_INIT_STRUCT*           PlatformCfioDataPtr;
 
   PlatformCfioDataPtr = (CFIO_INIT_STRUCT *) (UINTN) PlatformInfoHob->PlatformCfioData;
-  DEBUG ((EFI_D_INFO, "MultiPlatformGpioProgram()...\n"));
+  DEBUG ((DEBUG_INFO, "MultiPlatformGpioProgram()...\n"));
 
   //
   //  SCORE GPIO WELL -- IO base registers
@@ -501,7 +501,7 @@ MultiPlatformGpioProgram (
   switch (PlatformInfoHob->BoardId) {
     case BOARD_ID_MINNOW2:
     case BOARD_ID_MINNOW2_TURBOT:
-      DEBUG ((EFI_D_INFO, "Start to config Minnow2 GPIO pins\n"));
+      DEBUG ((DEBUG_INFO, "Start to config Minnow2 GPIO pins\n"));
       InternalGpioConfig(GPIO_SCORE_OFFSET, sizeof(mMinnow2_GpioInitData_SC)/sizeof(mMinnow2_GpioInitData_SC[0]),   (GPIO_CONF_PAD_INIT *) (UINTN) PlatformInfoHob->PlatformGpioData_SC);
       InternalGpioConfig(GPIO_NCORE_OFFSET, sizeof(mMinnow2_GpioInitData_NC)/sizeof(mMinnow2_GpioInitData_NC[0]),   (GPIO_CONF_PAD_INIT *) (UINTN) PlatformInfoHob->PlatformGpioData_NC);
       InternalGpioConfig(GPIO_SSUS_OFFSET,  sizeof(mMinnow2_GpioInitData_SUS)/sizeof(mMinnow2_GpioInitData_SUS[0]), (GPIO_CONF_PAD_INIT *) (UINTN) PlatformInfoHob->PlatformGpioData_SUS);
@@ -520,7 +520,7 @@ MultiPlatformGpioProgram (
      }
    }
 #else
-   DEBUG ((EFI_D_INFO, "Skip MultiPlatformGpioProgram()...for SIMICS or HYB model\n"));
+   DEBUG ((DEBUG_INFO, "Skip MultiPlatformGpioProgram()...for SIMICS or HYB model\n"));
 #endif
   return EFI_SUCCESS;
 }

--- a/Platform/Intel/Vlv2TbltDevicePkg/Library/MultiPlatformLib/MultiPlatformLib.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/Library/MultiPlatformLib/MultiPlatformLib.c
@@ -2,10 +2,12 @@
   Multiplatform initialization.
 
   Copyright (c) 2010 - 2014, Intel Corporation. All rights reserved.<BR>
-                                                                                   
+                                                                                   
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-                                                                                   
+                                                                                   
+
 
 **/
 
@@ -87,7 +89,7 @@ MultiPlatformInfoInit (
   //
   // Enable ICH IOAPIC
   //
-  PlatformInfoHob->SysData.SysIoApicEnable  = ICH_IOAPIC;
+  PlatformDEBUG_b->SysData.SysIoApicEnable  = ICH_IOAPIC;
 
   DEBUG ((EFI_D_ERROR, "PlatformFlavor is %x (%x=tablet,%x=mobile,%x=desktop)\n",
     PlatformInfoHob->PlatformFlavor,

--- a/Platform/Intel/Vlv2TbltDevicePkg/Library/PchPlatformLib/PchPlatformLibrary.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/Library/PchPlatformLib/PchPlatformLibrary.c
@@ -1,10 +1,12 @@
 /**
 
 Copyright (c) 2012  - 2014, Intel Corporation. All rights reserved
-                                                                                   
+                                                                                   
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-                                                                                   
+                                                                                   
+
 
   @file
   PchPlatformLib.c
@@ -122,7 +124,7 @@ IsPchSupported (
 
   //
   // Verify that this is a supported chipset
-  //
+  //DEBUG_
   if (PcuVendorId != (UINT16) V_PCH_LPC_VENDOR_ID || !IS_PCH_VLV_LPC_DEVICE_ID (PcuDeviceId)) {
     DEBUG ((EFI_D_ERROR, "VLV SC code doesn't support the PcuDeviceId: 0x%04x!\n", PcuDeviceId));
     return FALSE;

--- a/Platform/Intel/Vlv2TbltDevicePkg/Library/PlatformCmosLib/PlatformCmosLib.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/Library/PlatformCmosLib/PlatformCmosLib.c
@@ -1,10 +1,12 @@
 /*++
 
 Copyright (c) 2010 - 2014, Intel Corporation. All rights reserved.<BR>
-                                                                                   
+                                                                                   
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-                                                                                   
+                                                                                   
+
 
 
 Module Name:
@@ -24,8 +26,8 @@ Abstract:
 
 #define DEFAULT_VALUE          0
 #define  DEFAULT_ATTRIBUTES     0
-#define  EXCLUDE_FROM_CHECKSUM   CMOS_ATTRIBUTE_EXCLUDE_FROM_CHECKSUM
-
+#define  EXCLUDE_FROM_CHECKSUM   CMOS_ATTRIBUTE_EXCLUDE_FROMDEBUG_SUMDEBUG_DEBUG_
+DEBUG_
 #define CMOS_DEBUG_PRINT_LEVEL_DEFAULT_VALUE      0x46   // EFI_D_WARN|EFI_D_INFO|EFI_D_LOAD
 #define CMOS_DEBUG_PRINT_LEVEL_3_DEFAULT_VALUE    0x80   // EFI_D_ERROR
 

--- a/Platform/Intel/Vlv2TbltDevicePkg/Library/Tpm2DeviceLibSeCPei/Tpm2DeviceLibSeC.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/Library/Tpm2DeviceLibSeCPei/Tpm2DeviceLibSeC.c
@@ -76,7 +76,7 @@ Tpm2SubmitCommand (
   EFI_STATUS  Status = EFI_SUCCESS;
 
   if(NULL == InputParameterBlock || NULL == OutputParameterBlock || 0 == InputParameterBlockSize) {
-    DEBUG ((EFI_D_ERROR, "Buffer == NULL or InputParameterBlockSize == 0\n"));
+    DEBUG ((DEBUG_ERROR, "Buffer == NULL or InputParameterBlockSize == 0\n"));
     Status = EFI_INVALID_PARAMETER;
     return Status;
   }

--- a/Platform/Intel/Vlv2TbltDevicePkg/MonoStatusCode/PlatformStatusCode.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/MonoStatusCode/PlatformStatusCode.c
@@ -1,10 +1,12 @@
 /** @file
 
   Copyright (c) 2004  - 2014, Intel Corporation. All rights reserved.<BR>
-                                                                                   
+                                                                                   
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-                                                                                   
+                                                                                   
+
 
 Module Name:
 
@@ -83,7 +85,7 @@ Port80ReportStatusCode (
       }
     }
   }
-  if (Port80Code != 0){
+  if (Port80DEBUG_= 0){
     IoWrite16 (0x80, (UINT16) Port80Code);
     DEBUG ((EFI_D_ERROR, "POSTCODE=<%04x>\n", Port80Code));
   }

--- a/Platform/Intel/Vlv2TbltDevicePkg/PlatformDxe/IchPlatformPolicy.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/PlatformDxe/IchPlatformPolicy.c
@@ -54,7 +54,7 @@ InitPchPlatformPolicy (
   BOOLEAN                          ModifyVariable;
 
   ModifyVariable = FALSE;
-  DEBUG ((EFI_D_INFO, "InitPchPlatformPolicy() - Start\n"));
+  DEBUG ((DEBUG_INFO, "InitPchPlatformPolicy() - Start\n"));
 
   Status  = gBS->LocateProtocol (&gDxePchPlatformPolicyProtocolGuid, NULL, (VOID **) &DxePlatformPchPolicy);
   ASSERT_EFI_ERROR (Status);
@@ -130,7 +130,7 @@ InitPchPlatformPolicy (
       mSystemConfiguration.PchUsb20       = 1;
       mSystemConfiguration.PchUsb30Mode   = 0;
       mSystemConfiguration.UsbXhciSupport = 0;
-      DEBUG ((EFI_D_INFO, "EHCI is enabled as default. SOC 0x%x\n", SocStepping));
+      DEBUG ((DEBUG_INFO, "EHCI is enabled as default. SOC 0x%x\n", SocStepping));
     } else {
     	//
       //  For A1 and later, XHCI is enabled as default.
@@ -138,7 +138,7 @@ InitPchPlatformPolicy (
       mSystemConfiguration.PchUsb20       = 0;
       mSystemConfiguration.PchUsb30Mode   = 1;
       mSystemConfiguration.UsbXhciSupport = 1;
-      DEBUG ((EFI_D_INFO, "XHCI is enabled as default. SOC 0x%x\n", SocStepping));
+      DEBUG ((DEBUG_INFO, "XHCI is enabled as default. SOC 0x%x\n", SocStepping));
     }
     //
     //overwrite the setting
@@ -228,7 +228,7 @@ InitPchPlatformPolicy (
   DxePlatformPchPolicy->UsbConfig->Usb30OverCurrentPins[0]  = PchUsbOverCurrentPinSkip;//PchUsbOverCurrentPin0;
 
   DxePlatformPchPolicy->EhciPllCfgEnable = mSystemConfiguration.EhciPllCfgEnable;
-  DEBUG ((EFI_D_INFO, "InitPchPlatformPolicy() DxePlatformPchPolicy->EhciPllCfgEnable = 0x%x \n",DxePlatformPchPolicy->EhciPllCfgEnable));
+  DEBUG ((DEBUG_INFO, "InitPchPlatformPolicy() DxePlatformPchPolicy->EhciPllCfgEnable = 0x%x \n",DxePlatformPchPolicy->EhciPllCfgEnable));
     DxePlatformPchPolicy->PciExpressConfig->PcieDynamicGating                                 = mSystemConfiguration.PcieDynamicGating;
   for (PortIndex = 0; PortIndex < PCH_PCIE_MAX_ROOT_PORTS; PortIndex++) {
     DxePlatformPchPolicy->PciExpressConfig->RootPort[PortIndex].Enable                        = mSystemConfiguration.IchPciExp[PortIndex];
@@ -334,7 +334,7 @@ InitPchPlatformPolicy (
   switch (PchStepping()) {
     case PchA0: // A0 and A1
     case PchA1:
-      DEBUG ((EFI_D_ERROR, "Auto Detect: SOC A0/A1: SCC eMMC 4.41 Configuration\n"));
+      DEBUG ((DEBUG_ERROR, "Auto Detect: SOC A0/A1: SCC eMMC 4.41 Configuration\n"));
       DxePlatformPchPolicy->SccConfig->eMMCEnabled            = 1;
       DxePlatformPchPolicy->SccConfig->eMMC45Enabled          = 0;
       DxePlatformPchPolicy->SccConfig->eMMC45DDR50Enabled     = 0;
@@ -343,7 +343,7 @@ InitPchPlatformPolicy (
       break;
     case PchB0: // B0 and later
     default:
-      DEBUG ((EFI_D_ERROR, "Auto Detect: SOC B0 and later: SCC eMMC 4.5 Configuration\n"));
+      DEBUG ((DEBUG_ERROR, "Auto Detect: SOC B0 and later: SCC eMMC 4.5 Configuration\n"));
       DxePlatformPchPolicy->SccConfig->eMMCEnabled            = 0;
       DxePlatformPchPolicy->SccConfig->eMMC45Enabled          = mSystemConfiguration.LpsseMMC45Enabled;
       DxePlatformPchPolicy->SccConfig->eMMC45DDR50Enabled     = mSystemConfiguration.LpsseMMC45DDR50Enabled;
@@ -352,7 +352,7 @@ InitPchPlatformPolicy (
       break;
   }
  } else if (mSystemConfiguration.eMMCBootMode == 2) { // eMMC 4.41
-    DEBUG ((EFI_D_ERROR, "Force to SCC eMMC 4.41 Configuration\n"));
+    DEBUG ((DEBUG_ERROR, "Force to SCC eMMC 4.41 Configuration\n"));
     DxePlatformPchPolicy->SccConfig->eMMCEnabled            = 1;
     DxePlatformPchPolicy->SccConfig->eMMC45Enabled          = 0;
     DxePlatformPchPolicy->SccConfig->eMMC45DDR50Enabled     = 0;
@@ -360,7 +360,7 @@ InitPchPlatformPolicy (
     DxePlatformPchPolicy->SccConfig->eMMC45RetuneTimerValue = 0;
 
  } else if (mSystemConfiguration.eMMCBootMode == 3) { // eMMC 4.5
-      DEBUG ((EFI_D_ERROR, "Force to eMMC 4.5 Configuration\n"));
+      DEBUG ((DEBUG_ERROR, "Force to eMMC 4.5 Configuration\n"));
       DxePlatformPchPolicy->SccConfig->eMMCEnabled            = 0;
       DxePlatformPchPolicy->SccConfig->eMMC45Enabled          = mSystemConfiguration.LpsseMMC45Enabled;
       DxePlatformPchPolicy->SccConfig->eMMC45DDR50Enabled     = mSystemConfiguration.LpsseMMC45DDR50Enabled;
@@ -368,7 +368,7 @@ InitPchPlatformPolicy (
       DxePlatformPchPolicy->SccConfig->eMMC45RetuneTimerValue = mSystemConfiguration.LpsseMMC45RetuneTimerValue;
 
  } else { // Disable eMMC controllers
-      DEBUG ((EFI_D_ERROR, "Disable eMMC controllers\n"));
+      DEBUG ((DEBUG_ERROR, "Disable eMMC controllers\n"));
       DxePlatformPchPolicy->SccConfig->eMMCEnabled            = 0;
       DxePlatformPchPolicy->SccConfig->eMMC45Enabled          = 0;
       DxePlatformPchPolicy->SccConfig->eMMC45DDR50Enabled     = 0;
@@ -431,7 +431,7 @@ InitPchPlatformPolicy (
                   );
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG ((EFI_D_INFO, "InitPchPlatformPolicy() - End\n"));
+  DEBUG ((DEBUG_INFO, "InitPchPlatformPolicy() - End\n"));
 }
 
 

--- a/Platform/Intel/Vlv2TbltDevicePkg/PlatformDxe/Platform.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/PlatformDxe/Platform.c
@@ -181,7 +181,7 @@ SaveSetupRecoveryVar(
   EDKII_VARIABLE_LOCK_PROTOCOL *VariableLock = NULL;
 
 
-  DEBUG ((EFI_D_INFO, "SaveSetupRecoveryVar() Entry \n"));
+  DEBUG ((DEBUG_INFO, "SaveSetupRecoveryVar() Entry \n"));
   SizeOfNvStore = sizeof(SYSTEM_CONFIGURATION);
   RecoveryNvData = AllocateZeroPool (sizeof(SYSTEM_CONFIGURATION));
   if (NULL == RecoveryNvData) {
@@ -275,10 +275,10 @@ TristateLpcGpioConfig (
     mmio_padval= IO_BASE_ADDRESS + Gpio_Mmio_Offset + R_PCH_CFIO_PAD_VAL   + Gpio_Conf_Data[index].offset * 16;
 
 #ifdef EFI_DEBUG
-    DEBUG ((EFI_D_INFO, "%s, ", Gpio_Conf_Data[index].pad_name));
+    DEBUG ((DEBUG_INFO, "%s, ", Gpio_Conf_Data[index].pad_name));
 
 #endif
-    DEBUG ((EFI_D_INFO, "Usage = %d, Func# = %d, IntType = %d, Pull Up/Down = %d, MMIO Base = 0x%08x, ",
+    DEBUG ((DEBUG_INFO, "Usage = %d, Func# = %d, IntType = %d, Pull Up/Down = %d, MMIO Base = 0x%08x, ",
       Gpio_Conf_Data[index].usage,
       Gpio_Conf_Data[index].func,
       Gpio_Conf_Data[index].int_type,
@@ -308,7 +308,7 @@ TristateLpcGpioConfig (
     }
 
 
-    DEBUG ((EFI_D_INFO, "Set PAD_VAL = 0x%08x, ", pad_val.dw));
+    DEBUG ((DEBUG_INFO, "Set PAD_VAL = 0x%08x, ", pad_val.dw));
 
     MmioWrite32(mmio_padval, pad_val.dw);
 
@@ -374,7 +374,7 @@ TristateLpcGpioConfig (
       conf0_val.dw |= (Gpio_Conf_Data[index].int_type & 0x0f)<<24;
     }
 
-    DEBUG ((EFI_D_INFO, "Set CONF0 = 0x%08x\n", conf0_val.dw));
+    DEBUG ((DEBUG_INFO, "Set CONF0 = 0x%08x\n", conf0_val.dw));
 
     //
     // Write back the targeted GPIO config value according to platform (board) GPIO setting
@@ -430,7 +430,7 @@ SpiBiosProtectionFunction(
     //
     //Already locked. we could take no action here
     //
-    DEBUG((EFI_D_INFO, "PR0 already locked down. Stop configuring PR0.\n"));
+    DEBUG((DEBUG_INFO, "PR0 already locked down. Stop configuring PR0.\n"));
     return;
   }
 
@@ -458,7 +458,7 @@ SpiBiosProtectionFunction(
   // Verify if it's really locked.
   //
   if ((MmioRead16 (SpiBase + R_PCH_SPI_HSFS) & B_PCH_SPI_HSFS_FLOCKDN) == 0) {
-    DEBUG((EFI_D_ERROR, "Failed to lock down PRx.\n"));
+    DEBUG((DEBUG_ERROR, "Failed to lock down PRx.\n"));
   }
   return;
 
@@ -492,7 +492,7 @@ InitPciDevPME (
   //
   PchSataPciCfg32Or (R_PCH_SATA_PMCS, B_PCH_SATA_PMCS_PMEE);
 
-  DEBUG ((EFI_D_INFO, "InitPciDevPME mSystemConfiguration.EhciPllCfgEnable = 0x%x \n",mSystemConfiguration.EhciPllCfgEnable));
+  DEBUG ((DEBUG_INFO, "InitPciDevPME mSystemConfiguration.EhciPllCfgEnable = 0x%x \n",mSystemConfiguration.EhciPllCfgEnable));
  if (mSystemConfiguration.EhciPllCfgEnable != 1) {
   //
   //Program EHCI PME_EN
@@ -516,9 +516,9 @@ InitPciDevPME (
                       PCI_FUNCTION_NUMBER_PCH_EHCI,
                       0
                     );
-    DEBUG ((EFI_D_INFO, "ConfigureAdditionalPm() EhciPciMmBase = 0x%x \n",EhciPciMmBase));
+    DEBUG ((DEBUG_INFO, "ConfigureAdditionalPm() EhciPciMmBase = 0x%x \n",EhciPciMmBase));
     Buffer32 = MmioRead32(EhciPciMmBase + R_PCH_EHCI_PWR_CNTL_STS);
-    DEBUG ((EFI_D_INFO, "ConfigureAdditionalPm() R_PCH_EHCI_PWR_CNTL_STS = 0x%x \n",Buffer32));
+    DEBUG ((DEBUG_INFO, "ConfigureAdditionalPm() R_PCH_EHCI_PWR_CNTL_STS = 0x%x \n",Buffer32));
   }
 }
 
@@ -575,7 +575,7 @@ TristateLpcGpioS0i3Config (
       mmio_val = 0;
       mmio_val = MmioRead32(mmio_reg);
 
-      DEBUG ((EFI_D_INFO, "Set MMIO=0x%08x  PAD_VAL = 0x%08x,\n", mmio_reg, mmio_val));
+      DEBUG ((DEBUG_INFO, "Set MMIO=0x%08x  PAD_VAL = 0x%08x,\n", mmio_reg, mmio_val));
     }
 
      return EFI_SUCCESS;
@@ -623,7 +623,7 @@ EnableAcpiCallback (
                PCI_FUNCTION_NUMBER_PCH_LPC) + R_PCH_LPC_ACPI_BASE
                ) & B_PCH_LPC_ACPI_BASE_BAR;
 
-  DEBUG ((EFI_D_INFO, "EnableAcpiCallback: AcpiBase = %x\n", AcpiBase));
+  DEBUG ((DEBUG_INFO, "EnableAcpiCallback: AcpiBase = %x\n", AcpiBase));
 
   //
   // Disable SW SMI Timer, SMI from USB & Intel Specific USB 2
@@ -741,7 +741,7 @@ InitializePlatform (
 
   Status = SaveSetupRecoveryVar();
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "InitializePlatform() Save SetupRecovery variable failed \n"));
+    DEBUG ((DEBUG_ERROR, "InitializePlatform() Save SetupRecovery variable failed \n"));
   }
 
   VarSize = sizeof(SYSTEM_CONFIGURATION);

--- a/Platform/Intel/Vlv2TbltDevicePkg/PlatformDxe/Rtc.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/PlatformDxe/Rtc.c
@@ -141,7 +141,7 @@ AdjustDefaultRtcTimeCallback (
     EfiTime.TimeZone = EFI_UNSPECIFIED_TIMEZONE;
     EfiTime.Daylight = 1; 
 
-    DEBUG ((EFI_D_INFO, "Day:%d Month:%d Year:%d \n", (UINT32)EfiTime.Day, (UINT32)EfiTime.Month, (UINT32)EfiTime.Year));
+    DEBUG ((DEBUG_INFO, "Day:%d Month:%d Year:%d \n", (UINT32)EfiTime.Day, (UINT32)EfiTime.Month, (UINT32)EfiTime.Year));
 
     //
     // Reset time value according to new RTC configuration

--- a/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/BootMode.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/BootMode.c
@@ -1,10 +1,12 @@
 /** @file
 
   Copyright (c) 2004  - 2014, Intel Corporation. All rights reserved.<BR>
-                                                                                   
+                                                                                   
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-                                                                                   
+                                                                                   
+
 
 Module Name:
 
@@ -306,7 +308,7 @@ UpdateBootMode (
       break;
     default:
       strBootMode = L"Unknown boot mode";
-  } // switch (BootMode)
+  } // swiDEBUG_ootMode)
 
   DEBUG ((EFI_D_ERROR, "Setting BootMode to %s\n", strBootMode));
   Status = (*PeiServices)->SetBootMode(

--- a/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/MemoryCallback.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/MemoryCallback.c
@@ -68,27 +68,27 @@ EndOfPeiPpiNotifyCallback (
 
   UpdateDefaultSetupValue (PlatformInfo);
 
-  DEBUG ((EFI_D_ERROR, "Memory TOLM: %X\n", PlatformInfo->MemData.MemTolm));
-  DEBUG ((EFI_D_ERROR, "PCIE OSBASE: %lX\n", PlatformInfo->PciData.PciExpressBase));
+  DEBUG ((DEBUG_ERROR, "Memory TOLM: %X\n", PlatformInfo->MemData.MemTolm));
+  DEBUG ((DEBUG_ERROR, "PCIE OSBASE: %lX\n", PlatformInfo->PciData.PciExpressBase));
   DEBUG (
-    (EFI_D_ERROR,
+    (DEBUG_ERROR,
     "PCIE   BASE: %lX     Size : %X\n",
     PlatformInfo->PciData.PciExpressBase,
     PlatformInfo->PciData.PciExpressSize)
     );
   DEBUG (
-    (EFI_D_ERROR,
+    (DEBUG_ERROR,
     "PCI32  BASE: %X     Limit: %X\n",
     PlatformInfo->PciData.PciResourceMem32Base,
     PlatformInfo->PciData.PciResourceMem32Limit)
     );
   DEBUG (
-    (EFI_D_ERROR,
+    (DEBUG_ERROR,
     "PCI64  BASE: %lX     Limit: %lX\n",
     PlatformInfo->PciData.PciResourceMem64Base,
     PlatformInfo->PciData.PciResourceMem64Limit)
     );
-  DEBUG ((EFI_D_ERROR, "UC    START: %lX     End  : %lX\n", PlatformInfo->MemData.MemMir0, PlatformInfo->MemData.MemMir1));
+  DEBUG ((DEBUG_ERROR, "UC    START: %lX     End  : %lX\n", PlatformInfo->MemData.MemMir0, PlatformInfo->MemData.MemMir1));
 
   LowUncableBase = PlatformInfo->MemData.MemMaxTolm;
   LowUncableBase &= (0x0FFF00000);
@@ -185,7 +185,7 @@ MemoryDiscoveredPpiNotifyCallback (
     RootComplexBar,
     0x1000
     );
-  DEBUG ((EFI_D_INFO, "RootComplexBar     : 0x%x\n", RootComplexBar));
+  DEBUG ((DEBUG_INFO, "RootComplexBar     : 0x%x\n", RootComplexBar));
 
   PmcBase = MmPci32( 0, DEFAULT_PCI_BUS_NUMBER_PCH, PCI_DEVICE_NUMBER_PCH_LPC, 0, R_PCH_LPC_PMC_BASE ) & B_PCH_LPC_PMC_BASE_BAR;
   BuildResourceDescriptorHob (
@@ -194,7 +194,7 @@ MemoryDiscoveredPpiNotifyCallback (
     PmcBase,
     0x1000
     );
-  DEBUG ((EFI_D_INFO, "PmcBase            : 0x%x\n", PmcBase));
+  DEBUG ((DEBUG_INFO, "PmcBase            : 0x%x\n", PmcBase));
 
   IoBase = MmPci32( 0, DEFAULT_PCI_BUS_NUMBER_PCH, PCI_DEVICE_NUMBER_PCH_LPC, 0, R_PCH_LPC_IO_BASE ) & B_PCH_LPC_IO_BASE_BAR;
   BuildResourceDescriptorHob (
@@ -203,7 +203,7 @@ MemoryDiscoveredPpiNotifyCallback (
     IoBase,
     0x4000
     );
-  DEBUG ((EFI_D_INFO, "IoBase             : 0x%x\n", IoBase));
+  DEBUG ((DEBUG_INFO, "IoBase             : 0x%x\n", IoBase));
 
   IlbBase = MmPci32( 0, DEFAULT_PCI_BUS_NUMBER_PCH, PCI_DEVICE_NUMBER_PCH_LPC, 0, R_PCH_LPC_ILB_BASE ) & B_PCH_LPC_ILB_BASE_BAR;
   BuildResourceDescriptorHob (
@@ -212,7 +212,7 @@ MemoryDiscoveredPpiNotifyCallback (
     IlbBase,
     0x1000
     );
-  DEBUG ((EFI_D_INFO, "IlbBase            : 0x%x\n", IlbBase));
+  DEBUG ((DEBUG_INFO, "IlbBase            : 0x%x\n", IlbBase));
 
   SpiBase = MmPci32( 0, DEFAULT_PCI_BUS_NUMBER_PCH, PCI_DEVICE_NUMBER_PCH_LPC, 0, R_PCH_LPC_SPI_BASE ) & B_PCH_LPC_SPI_BASE_BAR;
   BuildResourceDescriptorHob (
@@ -221,7 +221,7 @@ MemoryDiscoveredPpiNotifyCallback (
     SpiBase,
     0x1000
     );
-  DEBUG ((EFI_D_INFO, "SpiBase            : 0x%x\n", SpiBase));
+  DEBUG ((DEBUG_INFO, "SpiBase            : 0x%x\n", SpiBase));
 
   MphyBase = MmPci32( 0, DEFAULT_PCI_BUS_NUMBER_PCH, PCI_DEVICE_NUMBER_PCH_LPC, 0, R_PCH_LPC_MPHY_BASE ) & B_PCH_LPC_MPHY_BASE_BAR;
   BuildResourceDescriptorHob (
@@ -230,7 +230,7 @@ MemoryDiscoveredPpiNotifyCallback (
     MphyBase,
     0x100000
     );
-  DEBUG ((EFI_D_INFO, "MphyBase           : 0x%x\n", MphyBase));
+  DEBUG ((DEBUG_INFO, "MphyBase           : 0x%x\n", MphyBase));
 
   //
   // Local APIC
@@ -241,7 +241,7 @@ MemoryDiscoveredPpiNotifyCallback (
     LOCAL_APIC_ADDRESS,
     0x1000
   );
-  DEBUG ((EFI_D_INFO, "LOCAL_APIC_ADDRESS : 0x%x\n", LOCAL_APIC_ADDRESS));
+  DEBUG ((DEBUG_INFO, "LOCAL_APIC_ADDRESS : 0x%x\n", LOCAL_APIC_ADDRESS));
 
   //
   // IO APIC
@@ -252,7 +252,7 @@ MemoryDiscoveredPpiNotifyCallback (
     IO_APIC_ADDRESS,
     0x1000
   );
-  DEBUG ((EFI_D_INFO, "IO_APIC_ADDRESS    : 0x%x\n", IO_APIC_ADDRESS));
+  DEBUG ((DEBUG_INFO, "IO_APIC_ADDRESS    : 0x%x\n", IO_APIC_ADDRESS));
 
   //
   // Adding the PCIE Express area to the E820 memory table as type 2 memory.
@@ -263,7 +263,7 @@ MemoryDiscoveredPpiNotifyCallback (
     PlatformInfo->PciData.PciExpressBase,
     PlatformInfo->PciData.PciExpressSize
     );
-  DEBUG ((EFI_D_INFO, "PciExpressBase     : 0x%x\n", PlatformInfo->PciData.PciExpressBase));
+  DEBUG ((DEBUG_INFO, "PciExpressBase     : 0x%x\n", PlatformInfo->PciData.PciExpressBase));
 
   //
   // Adding the Flashpart to the E820 memory table as type 2 memory.
@@ -274,7 +274,7 @@ MemoryDiscoveredPpiNotifyCallback (
     FixedPcdGet32 (PcdFlashAreaBaseAddress),
     FixedPcdGet32 (PcdFlashAreaSize)
     );
-  DEBUG ((EFI_D_INFO, "FLASH_BASE_ADDRESS : 0x%x\n", FixedPcdGet32 (PcdFlashAreaBaseAddress)));
+  DEBUG ((DEBUG_INFO, "FLASH_BASE_ADDRESS : 0x%x\n", FixedPcdGet32 (PcdFlashAreaBaseAddress)));
 
   //
   // Create a CPU hand-off information

--- a/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/MemoryPeim.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/MemoryPeim.c
@@ -117,7 +117,7 @@ SetPeiCacheMode (
     //
     // Clear the CAR Settings (Default Cache Type => UC)
     //
-    DEBUG ((EFI_D_INFO, "Reset cache attribute and disable CAR. \n"));
+    DEBUG ((DEBUG_INFO, "Reset cache attribute and disable CAR. \n"));
     CachePpi->ResetCache(
                 (EFI_PEI_SERVICES**)PeiServices,
                 CachePpi
@@ -239,7 +239,7 @@ SetPeiCacheMode (
     if (MtrrSetting.Variables.Mtrr[Index].Base == 0){
       break;
     }
-    DEBUG ((EFI_D_INFO, "Base=%lx, Mask=%lx\n",MtrrSetting.Variables.Mtrr[Index].Base ,MtrrSetting.Variables.Mtrr[Index].Mask));
+    DEBUG ((DEBUG_INFO, "Base=%lx, Mask=%lx\n",MtrrSetting.Variables.Mtrr[Index].Base ,MtrrSetting.Variables.Mtrr[Index].Mask));
   }
 
   //
@@ -341,8 +341,8 @@ PublishMemoryTypeInfo (
             (void **)&Variable
              );
   if (EFI_ERROR(Status)) {
-    DEBUG((EFI_D_ERROR, "WARNING: Locating Pei variable failed 0x%x \n", Status));
-    DEBUG((EFI_D_ERROR, "Build Hob from default\n"));
+    DEBUG((DEBUG_ERROR, "WARNING: Locating Pei variable failed 0x%x \n", Status));
+    DEBUG((DEBUG_ERROR, "Build Hob from default\n"));
     //
     // Build the default GUID'd HOB for DXE
     //
@@ -373,7 +373,7 @@ PublishMemoryTypeInfo (
   	//
     //build default
     //
-    DEBUG((EFI_D_ERROR, "Build Hob from default\n"));
+    DEBUG((DEBUG_ERROR, "Build Hob from default\n"));
     BuildGuidDataHob (
       &gEfiMemoryTypeInformationGuid,
       mDefaultMemoryTypeInformation,
@@ -384,7 +384,7 @@ PublishMemoryTypeInfo (
   	//
     // Build the GUID'd HOB for DXE from variable
     //
-    DEBUG((EFI_D_ERROR, "Build Hob from variable \n"));
+    DEBUG((DEBUG_ERROR, "Build Hob from variable \n"));
     BuildGuidDataHob (
       &gEfiMemoryTypeInformationGuid,
       MemoryData,

--- a/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/PchInitPeim.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/PchInitPeim.c
@@ -472,7 +472,7 @@ UARTInit (
     }
 
 
-    DEBUG ((EFI_D_ERROR, "EnableInternalUart\n"));
+    DEBUG ((DEBUG_ERROR, "EnableInternalUart\n"));
   } else {
   	//
     // If SIO UART interface selected
@@ -608,7 +608,7 @@ PchPolicySetupInit (
   //
   //Todo: confirm if we need update to PCH_PLATFORM_POLICY_PPI_REVISION_5
   //
-  DEBUG ((EFI_D_ERROR, "PchPolicySetupInit() - Start\n"));
+  DEBUG ((DEBUG_ERROR, "PchPolicySetupInit() - Start\n"));
 
   Status = (*PeiServices)->AllocatePool (PeiServices, sizeof (EFI_PEI_PPI_DESCRIPTOR), (void **)&PchPlatformPolicyPpiDesc);
   ASSERT_EFI_ERROR (Status);
@@ -712,7 +712,7 @@ PchPolicySetupInit (
               );
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG ((EFI_D_ERROR, "PchPolicySetupInit() - End\n"));
+  DEBUG ((DEBUG_ERROR, "PchPolicySetupInit() - End\n"));
 }
 
 EFI_STATUS
@@ -726,7 +726,7 @@ InstallPeiPchUsbPolicy (
   PCH_USB_POLICY_PPI      *PeiPchUsbPolicyPpi;
   PCH_USB_CONFIG          *UsbConfig;
 
-  DEBUG ((EFI_D_INFO, "InstallPeiPchUsbPolicy...\n"));
+  DEBUG ((DEBUG_INFO, "InstallPeiPchUsbPolicy...\n"));
 
   //
   // Allocate descriptor and PPI structures.  Since these are dynamically updated

--- a/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/PlatformEarlyInit.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/PlatformEarlyInit.c
@@ -130,8 +130,8 @@ GetWakeupEventAndSaveToHob (
     WakeEventData = SMBIOS_WAKEUP_TYPE_UNKNOWN;
   }
 
-  DEBUG ((EFI_D_ERROR, "ACPI Wake Status Register: %04x\n", Pm1Sts));
-  DEBUG ((EFI_D_ERROR, "ACPI Wake Event Data: %02x\n", WakeEventData));
+  DEBUG ((DEBUG_ERROR, "ACPI Wake Status Register: %04x\n", Pm1Sts));
+  DEBUG ((DEBUG_ERROR, "ACPI Wake Event Data: %02x\n", WakeEventData));
 
   return EFI_SUCCESS;
 }
@@ -230,13 +230,13 @@ VlvPolicyInit (
 
   mVlvPolicyPpi->PlatformData.FastBoot = SystemConfiguration->FastBoot;
   mVlvPolicyPpi->PlatformData.DynSR = 1;
-  DEBUG ((EFI_D_ERROR, "Setup Option ISPEn: 0x%x\n", SystemConfiguration->ISPEn));
+  DEBUG ((DEBUG_ERROR, "Setup Option ISPEn: 0x%x\n", SystemConfiguration->ISPEn));
   mVlvPolicyPpi->ISPEn                      = SystemConfiguration->ISPEn;
-  DEBUG ((EFI_D_ERROR, "Setup Option ISPDevSel: 0x%x\n", SystemConfiguration->ISPDevSel));
+  DEBUG ((DEBUG_ERROR, "Setup Option ISPDevSel: 0x%x\n", SystemConfiguration->ISPDevSel));
   mVlvPolicyPpi->ISPPciDevConfig            = SystemConfiguration->ISPDevSel;
   if (SystemConfiguration->ISPEn == 0) {
     mVlvPolicyPpi->ISPPciDevConfig          = 0;
-    DEBUG ((EFI_D_ERROR, "Update Setup Option ISPDevSel: 0x%x\n", mVlvPolicyPpi->ISPPciDevConfig));
+    DEBUG ((DEBUG_ERROR, "Update Setup Option ISPDevSel: 0x%x\n", mVlvPolicyPpi->ISPPciDevConfig));
   }
   Status = (*PeiServices)->InstallPpi(
                              PeiServices,
@@ -254,9 +254,9 @@ ConfigureSoCGpio (
   )
 {
 
-    DEBUG ((EFI_D_ERROR, "ConfigureSoCGpio------------start\n"));
+    DEBUG ((DEBUG_ERROR, "ConfigureSoCGpio------------start\n"));
     if (SystemConfiguration->eMMCBootMode== 1) {// Auto detection mode
-     DEBUG ((EFI_D_ERROR, "Auto detection mode------------start\n"));
+     DEBUG ((DEBUG_ERROR, "Auto detection mode------------start\n"));
 
      //
      //Silicon Steppings
@@ -264,28 +264,28 @@ ConfigureSoCGpio (
      switch (PchStepping()) {
        case PchA0:  // SOC A0 and A1
        case PchA1:
-         DEBUG ((EFI_D_ERROR, "SOC A0/A1: eMMC 4.41 GPIO Configuration\n"));
+         DEBUG ((DEBUG_ERROR, "SOC A0/A1: eMMC 4.41 GPIO Configuration\n"));
          SystemConfiguration->LpsseMMCEnabled            = 1;
          SystemConfiguration->LpsseMMC45Enabled          = 0;
          break;
        case PchB0:  // SOC B0 and later
        default:
-         DEBUG ((EFI_D_ERROR, "SOC B0 and later: eMMC 4.5 GPIO Configuration\n"));
+         DEBUG ((DEBUG_ERROR, "SOC B0 and later: eMMC 4.5 GPIO Configuration\n"));
          SystemConfiguration->LpsseMMCEnabled            = 0;
          SystemConfiguration->LpsseMMC45Enabled          = 1;
          break;
      }
     } else if (SystemConfiguration->eMMCBootMode == 2) { // eMMC 4.41
-        DEBUG ((EFI_D_ERROR, "Force to eMMC 4.41 GPIO Configuration\n"));
+        DEBUG ((DEBUG_ERROR, "Force to eMMC 4.41 GPIO Configuration\n"));
         SystemConfiguration->LpsseMMCEnabled            = 1;
         SystemConfiguration->LpsseMMC45Enabled          = 0;
     } else if (SystemConfiguration->eMMCBootMode == 3) { // eMMC 4.5
-         DEBUG ((EFI_D_ERROR, "Force to eMMC 4.5 GPIO Configuration\n"));
+         DEBUG ((DEBUG_ERROR, "Force to eMMC 4.5 GPIO Configuration\n"));
          SystemConfiguration->LpsseMMCEnabled            = 0;
          SystemConfiguration->LpsseMMC45Enabled          = 1;
 
     } else { // Disable eMMC controllers
-         DEBUG ((EFI_D_ERROR, "Disable eMMC GPIO controllers\n"));
+         DEBUG ((DEBUG_ERROR, "Disable eMMC GPIO controllers\n"));
          SystemConfiguration->LpsseMMCEnabled            = 0;
          SystemConfiguration->LpsseMMC45Enabled          = 0;
     }
@@ -352,7 +352,7 @@ ConfigureSoCGpio (
 //
   IoWrite32 (GPIO_BASE_ADDRESS + R_PCH_GPIO_SC_USE_SEL,
            (IoRead32(GPIO_BASE_ADDRESS + R_PCH_GPIO_SC_USE_SEL) & (UINT32)~BIT0));
-  DEBUG ((EFI_D_ERROR, "ConfigureSoCGpio------------end\n"));
+  DEBUG ((DEBUG_ERROR, "ConfigureSoCGpio------------end\n"));
   return EFI_SUCCESS;
 }
 
@@ -383,7 +383,7 @@ ConfigureLpssAndSccGpio (
   GPIO NCORE -  write 0x01001002 to IOBASE + 0x0F00
   GPIO SSUS -    write 0x01001002 to IOBASE + 0x1700
   */
-    DEBUG ((EFI_D_ERROR, "ConfigureLpssAndSccGpio------------start\n"));
+    DEBUG ((DEBUG_ERROR, "ConfigureLpssAndSccGpio------------start\n"));
 
   /*
   19.1.1  PWM0
@@ -414,11 +414,11 @@ ConfigureLpssAndSccGpio (
     MmioWrite32 (IO_BASE_ADDRESS + 0x0020, 0x2003CC81); // uart1
     MmioWrite32 (IO_BASE_ADDRESS + 0x0010, 0x2003CC81);
   if (SystemConfiguration->LpssHsuart0FlowControlEnabled== 0) {
-    DEBUG ((EFI_D_ERROR, "LpssHsuart0FlowControlEnabled[0]\n"));
+    DEBUG ((DEBUG_ERROR, "LpssHsuart0FlowControlEnabled[0]\n"));
     MmioWrite32 (IO_BASE_ADDRESS + 0x0000, 0x2003CC80);
     MmioWrite32 (IO_BASE_ADDRESS + 0x0040, 0x2003CC80);
   } else {
-    DEBUG ((EFI_D_ERROR, "LpssHsuart0FlowControlEnabled[1]\n"));
+    DEBUG ((DEBUG_ERROR, "LpssHsuart0FlowControlEnabled[1]\n"));
     MmioWrite32 (IO_BASE_ADDRESS + 0x0000, 0x2003CC81);
     MmioWrite32 (IO_BASE_ADDRESS + 0x0040, 0x2003CC01);//W/A HSD 4752617 0x2003CC81
     }
@@ -440,11 +440,11 @@ ConfigureLpssAndSccGpio (
     MmioWrite32 (IO_BASE_ADDRESS + 0x0070, 0x2003CC81);
 
   if (SystemConfiguration->LpssHsuart1FlowControlEnabled== 0) {
-    DEBUG ((EFI_D_ERROR, "LpssHsuart1FlowControlEnabled[0]\n"));
+    DEBUG ((DEBUG_ERROR, "LpssHsuart1FlowControlEnabled[0]\n"));
     MmioWrite32 (IO_BASE_ADDRESS + 0x0090, 0x2003CC80); // UART2_RTS_B
     MmioWrite32 (IO_BASE_ADDRESS + 0x0080, 0x2003CC80); // UART2_CTS_B
   } else {
-    DEBUG ((EFI_D_ERROR, "LpssHsuart1FlowControlEnabled[1]\n"));
+    DEBUG ((DEBUG_ERROR, "LpssHsuart1FlowControlEnabled[1]\n"));
     MmioWrite32 (IO_BASE_ADDRESS + 0x0090, 0x2003CC81); // uart2
     MmioWrite32 (IO_BASE_ADDRESS + 0x0080, 0x2003CC01); //W/A HSD 4752617 0x2003CC81
   }
@@ -591,7 +591,7 @@ ConfigureLpssAndSccGpio (
   }
 
 
-     DEBUG ((EFI_D_ERROR, "ConfigureLpssAndSccGpio------------end\n"));
+     DEBUG ((DEBUG_ERROR, "ConfigureLpssAndSccGpio------------end\n"));
     return EFI_SUCCESS;
 }
 
@@ -600,7 +600,7 @@ ConfigureLpeGpio (
   IN SYSTEM_CONFIGURATION  *SystemConfiguration
   )
 {
-  DEBUG ((EFI_D_ERROR, "ConfigureLpeGpio------------start\n"));
+  DEBUG ((DEBUG_ERROR, "ConfigureLpeGpio------------start\n"));
 
   if (SystemConfiguration->PchAzalia == 0) {
     MmioAndThenOr32 (IO_BASE_ADDRESS + 0x220, (UINT32)~(0x7), (UINT32) (0x01));
@@ -613,7 +613,7 @@ ConfigureLpeGpio (
     MmioAndThenOr32 (IO_BASE_ADDRESS + 0x540, (UINT32)~(0x7), (UINT32) (0x01));
   }
 
-  DEBUG ((EFI_D_ERROR, "ConfigureLpeGpio------------end\n"));
+  DEBUG ((DEBUG_ERROR, "ConfigureLpeGpio------------end\n"));
 
   return EFI_SUCCESS;
 }

--- a/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/PlatformSsaInitPeim.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/PlatformSsaInitPeim.c
@@ -1,10 +1,12 @@
 /** @file
 
   Copyright (c) 2004  - 2014, Intel Corporation. All rights reserved.<BR>
-                                                                                   
+                                                                                   
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-                                                                                   
+                                                                                   
+
 
 Module Name:
 
@@ -27,8 +29,8 @@ PlatformSsaInit (
   IN SYSTEM_CONFIGURATION        *SystemConfiguration,
   IN CONST EFI_PEI_SERVICES          **PeiServices
   )
-{
-
+{DEBUG_
+DEBUG_
   DEBUG ((EFI_D_ERROR, "PlatformSsaInit() - Start\n"));
   DEBUG ((EFI_D_ERROR, "PlatformSsaInit() - SystemConfiguration->ISPDevSel 0x%x\n",SystemConfiguration->ISPDevSel));
   if(SystemConfiguration->ISPDevSel == 0x02)
@@ -39,7 +41,7 @@ PlatformSsaInit (
     MmioWrite16 (
       (ILB_BASE_ADDRESS + R_PCH_ILB_D3IR),
       V_PCH_ILB_DXXIR_IAR_PIRQH   // For IUNIT
-    );
+    );DEBUG_
     MmioRead16(ILB_BASE_ADDRESS + R_PCH_ILB_D3IR); // Read Posted Writes Register
     DEBUG ((EFI_D_ERROR, "PlatformSsaInit() - Device 3 Interrupt Route Done\n"));
   }
@@ -50,7 +52,7 @@ PlatformSsaInit (
   MmioWrite16 (
     (ILB_BASE_ADDRESS + R_PCH_ILB_D2IR),
     V_PCH_ILB_DXXIR_IAR_PIRQA   // For IGD
-  );
+  );DEBUG_
   MmioRead16(ILB_BASE_ADDRESS + R_PCH_ILB_D2IR); // Read Posted Writes Register
   DEBUG ((EFI_D_ERROR, "PlatformSsaInit() - Device 2 Interrupt Route Done\n"));
 

--- a/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/Recovery.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/PlatformInitPei/Recovery.c
@@ -1,10 +1,12 @@
 /** @file
 
   Copyright (c) 2004  - 2014, Intel Corporation. All rights reserved.<BR>
-                                                                                   
+                                                                                   
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-                                                                                   
+                                                                                   
+
 
 Module Name:
 
@@ -168,7 +170,7 @@ PlatformRecoveryModule (
   DeviceRecoveryModule    = NULL;
 
   FoundCapsule = FALSE;
-  FoundFvMain = FALSE;
+  FoundFvMDEBUG_FALSE;DEBUG_
 
   DEBUG ((EFI_D_ERROR | EFI_D_LOAD, "Recovery Entry\n"));
 
@@ -185,7 +187,7 @@ PlatformRecoveryModule (
                                NULL,
                                &DeviceRecoveryModule
                                );
-
+DEBUG_DEBUG_
     if (!EFI_ERROR (Status)) {
       DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Device Recovery PPI located\n"));
       NumberOfImageProviders++;
@@ -194,7 +196,7 @@ PlatformRecoveryModule (
                                        (EFI_PEI_SERVICES**)PeiServices,
                                        DeviceRecoveryModule,
                                        &NumberRecoveryCapsules
-                                       );
+              DEBUG_       DEBUG_      );
 
       DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Number Of Recovery Capsules: %d\n", NumberRecoveryCapsules));
 
@@ -224,7 +226,7 @@ PlatformRecoveryModule (
 
     if (EFI_ERROR (Status)) {
       return Status;
-    }
+    }DEBUG_DEBUG_
 
     DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Recovery Capsule Size: %d\n", RecoveryCapsuleSize));
 
@@ -246,7 +248,7 @@ PlatformRecoveryModule (
                                EfiBootServicesCode,
                                (RecoveryCapsuleSize - 1) / 0x1000 + 1,
                                &Address
-                               );
+            DEBUG_       DEBUG_);
 
     DEBUG ((EFI_D_INFO | EFI_D_LOAD, "AllocatePage Returns: %r\n", Status));
 
@@ -270,7 +272,7 @@ PlatformRecoveryModule (
                                      DeviceRecoveryModule,
                                      0,
                                      Buffer
-                                     );
+            DEBUG_       DEBUG_      );
 
     DEBUG ((EFI_D_INFO | EFI_D_LOAD, "LoadRecoveryCapsule Returns: %r\n", Status));
 
@@ -283,7 +285,7 @@ PlatformRecoveryModule (
     //
     Status = (*PeiServices)->GetHobList (PeiServices, &Hob.Raw);
     HobOld.Raw  = Hob.Raw;
-    while (!END_OF_HOB_LIST (Hob)) {
+    while (!END_DEBUG__LIST (DEBUG_{
       if (Hob.Header->HobType == EFI_HOB_TYPE_FV) {
         DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Hob FV Length: %x\n", Hob.FirmwareVolume->Length));
         //
@@ -292,7 +294,7 @@ PlatformRecoveryModule (
         if (Hob.FirmwareVolume->Length > 0x50000) {
           HobUpdate = TRUE;
           //
-          // This looks like the Hob we are interested in
+          // This DEBUG_like thDEBUG_we are interested in
           //
           DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Hob Updated\n"));
           Hob.FirmwareVolume->BaseAddress = (UINTN) Buffer;
@@ -320,7 +322,7 @@ PlatformRecoveryModule (
     if (FoundFvMain) {
       //
       // build FV Hob if it is not built before
-      //
+      //DEBUG_DEBUG_
       if (!HobUpdate) {
         DEBUG ((EFI_D_INFO | EFI_D_LOAD, "FV Hob is not found, Build FV Hob then..\n"));
 
@@ -354,7 +356,7 @@ PlatformRecoveryModule (
                         NULL,
                         NULL
                         );
-    }
+    }DEBUG_DEBUG_
   }
   DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Recovery Module Returning: %r\n", Status));
   return Status;

--- a/Platform/Intel/Vlv2TbltDevicePkg/PlatformPei/Platform.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/PlatformPei/Platform.c
@@ -205,7 +205,7 @@ DetermineTurbotBoard (
   UINT32 SSUSOffset = 0x2000;
   UINT32 IoBase = 0;
 
-  DEBUG ((EFI_D_ERROR, "DetermineTurbotBoard() Entry\n"));
+  DEBUG ((DEBUG_ERROR, "DetermineTurbotBoard() Entry\n"));
   PciD31F0RegBase = MmPciAddress (0,
                       0,
                       PCI_DEVICE_NUMBER_PCH_LPC,
@@ -217,7 +217,7 @@ DetermineTurbotBoard (
   MmioConf0 = IoBase + SSUSOffset + PConf0Offset;
   MmioPadval = IoBase + SSUSOffset + PValueOffset;
   //0xFED0E200/0xFED0E208 is pad_Conf/pad_val register address of GPIO_S5_4
-  DEBUG ((EFI_D_ERROR, "MmioConf0[0x%x], MmioPadval[0x%x]\n", MmioConf0, MmioPadval));
+  DEBUG ((DEBUG_ERROR, "MmioConf0[0x%x], MmioPadval[0x%x]\n", MmioConf0, MmioPadval));
   
   MmioWrite32 (MmioConf0, 0x2003CC00);  
 
@@ -228,7 +228,7 @@ DetermineTurbotBoard (
 
   GpioValue = MmioRead32 (MmioPadval);
 
-  DEBUG ((EFI_D_ERROR, "Gpio_S5_4 value is 0x%x\n", GpioValue));
+  DEBUG ((DEBUG_ERROR, "Gpio_S5_4 value is 0x%x\n", GpioValue));
   return (GpioValue & 0x1);
 }
 
@@ -245,10 +245,10 @@ FtpmPolicyInit (
   SEC_FTPM_POLICY_PPI             *mFtpmPolicyPpi;
 
 
-  DEBUG((EFI_D_INFO, "FtpmPolicyInit Entry \n"));
+  DEBUG((DEBUG_INFO, "FtpmPolicyInit Entry \n"));
 
   if (NULL == PeiServices ||  NULL == pSystemConfiguration) {
-    DEBUG((EFI_D_ERROR, "Input error. \n"));
+    DEBUG((DEBUG_ERROR, "Input error. \n"));
     return EFI_INVALID_PARAMETER;
   }
   
@@ -275,7 +275,7 @@ FtpmPolicyInit (
   mFtpmPolicyPpiDesc->Ppi = mFtpmPolicyPpi;
 
 
-  DEBUG((EFI_D_INFO, "pSystemConfiguration->fTPM = 0x%x \n", pSystemConfiguration->fTPM)); 
+  DEBUG((DEBUG_INFO, "pSystemConfiguration->fTPM = 0x%x \n", pSystemConfiguration->fTPM)); 
   if(pSystemConfiguration->fTPM == 1) {
     mFtpmPolicyPpi->fTPMEnable = TRUE;
   } else {
@@ -288,7 +288,7 @@ FtpmPolicyInit (
                              );
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG((EFI_D_INFO, "FtpmPolicyInit done \n"));
+  DEBUG((DEBUG_INFO, "FtpmPolicyInit done \n"));
   
   return EFI_SUCCESS;
 }
@@ -370,7 +370,7 @@ MfgMemoryTest (
   //
   //Output Message for MFG
   //
-  DEBUG ((EFI_D_ERROR, "MFGMODE SET\n"));
+  DEBUG ((DEBUG_ERROR, "MFGMODE SET\n"));
 
   //
   //Writting the pattern in defined location.
@@ -403,9 +403,9 @@ MfgMemoryTest (
     // If xorData is nonzero, this particular memAddr has a failure.
 	  //
     if (xorData != 0x00000000) {
-      DEBUG ((EFI_D_ERROR, "Expected value....: %x\n", DataPatternForMemoryTest[i]));
-      DEBUG ((EFI_D_ERROR, "ReadData value....: %x\n", readData));
-      DEBUG ((EFI_D_ERROR, "Pattern failure at....: %x\n", memAddr));
+      DEBUG ((DEBUG_ERROR, "Expected value....: %x\n", DataPatternForMemoryTest[i]));
+      DEBUG ((DEBUG_ERROR, "ReadData value....: %x\n", readData));
+      DEBUG ((DEBUG_ERROR, "Pattern failure at....: %x\n", memAddr));
       TestFlag = 1;
     }
     memAddr = memAddr + 4;
@@ -418,7 +418,7 @@ MfgMemoryTest (
   //
   //Output Message for MFG
   //
-  DEBUG ((EFI_D_ERROR, "MFGMODE MEMORY TEST PASSED\n"));
+  DEBUG ((DEBUG_ERROR, "MFGMODE MEMORY TEST PASSED\n"));
   return EFI_SUCCESS;
 }
 
@@ -776,14 +776,14 @@ PeiInitPlatform (
     GGC = ((2 << 3) | 0x200);
     PciCfg16Write(EC_BASE, 0, 2, 0, 0x50, GGC);
     GGC = PciCfg16Read(EC_BASE, 0, 2, 0, 0x50);
-    DEBUG((EFI_D_INFO , "GGC: 0x%08x GMSsize:0x%08x\n", GGC, (GGC & (BIT7|BIT6|BIT5|BIT4|BIT3))>>3));
+    DEBUG((DEBUG_INFO , "GGC: 0x%08x GMSsize:0x%08x\n", GGC, (GGC & (BIT7|BIT6|BIT5|BIT4|BIT3))>>3));
   } else {
     if (SystemConfiguration.Igd == 1 && SystemConfiguration.PrimaryVideoAdaptor != 2) {
       GGC = (SystemConfiguration.IgdDvmt50PreAlloc << 3) |
             (SystemConfiguration.GTTSize == GTT_SIZE_1MB ? 0x100: 0x200);
       PciCfg16Write(EC_BASE, 0, 2, 0, 0x50, GGC);
       GGC = PciCfg16Read(EC_BASE, 0, 2, 0, 0x50);
-      DEBUG((EFI_D_INFO , "GGC: 0x%08x GMSsize:0x%08x\n", GGC, (GGC & (BIT7|BIT6|BIT5|BIT4|BIT3))>>3));
+      DEBUG((DEBUG_INFO , "GGC: 0x%08x GMSsize:0x%08x\n", GGC, (GGC & (BIT7|BIT6|BIT5|BIT4|BIT3))>>3));
     }
   }
 
@@ -797,10 +797,10 @@ PeiInitPlatform (
   // 0 -> Disable , 1 -> Enable
   //
   if(SystemConfiguration.CfioPnpSettings == 1) {
-    DEBUG((EFI_D_INFO, "CheckCfioPnpSettings: CFIO Pnp Settings Enabled\n"));
+    DEBUG((DEBUG_INFO, "CheckCfioPnpSettings: CFIO Pnp Settings Enabled\n"));
     PlatformInfo.CfioEnabled = 1;
   } else {
-    DEBUG((EFI_D_INFO, "CheckCfioPnpSettings: CFIO Pnp Settings Disabled\n"));
+    DEBUG((DEBUG_INFO, "CheckCfioPnpSettings: CFIO Pnp Settings Disabled\n"));
     PlatformInfo.CfioEnabled = 0;
   }
 
@@ -819,7 +819,7 @@ PeiInitPlatform (
   Status = UpdateBootMode (PeiServices);
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG((EFI_D_INFO, "Setup MMIO size ... \n\n"));
+  DEBUG((DEBUG_INFO, "Setup MMIO size ... \n\n"));
 
   //
   // Setup MMIO size
@@ -917,10 +917,10 @@ ReadPlatformIds (
     CompatibleBoard = DetermineTurbotBoard();
    if (1 == CompatibleBoard) {
      PlatformInfoHob->BoardId    = BOARD_ID_MINNOW2_TURBOT;
-     DEBUG ((EFI_D_INFO,  "I'm MinnowBoard Turbot!\n"));
+     DEBUG ((DEBUG_INFO,  "I'm MinnowBoard Turbot!\n"));
    } else {       
      PlatformInfoHob->BoardId    = BOARD_ID_MINNOW2;
-     DEBUG ((EFI_D_INFO,  "I'm MinnowBoard Max!\n"));
+     DEBUG ((DEBUG_INFO,  "I'm MinnowBoard Max!\n"));
    }
     
 

--- a/Platform/Intel/Vlv2TbltDevicePkg/PlatformSetupDxe/SetupInfoRecords.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/PlatformSetupDxe/SetupInfoRecords.c
@@ -410,7 +410,7 @@ PrepareSetupInformation (
              ReleaseTime
              );
 
-  DEBUG ((EFI_D_ERROR, "GetBiosVersionDateTime :%s %s %s \n", Version, ReleaseDate, ReleaseTime));
+  DEBUG ((DEBUG_ERROR, "GetBiosVersionDateTime :%s %s %s \n", Version, ReleaseDate, ReleaseTime));
   if (!EFI_ERROR (Status)) {
     UINTN         Length = 0;
     CHAR16        *BuildDateTime;
@@ -423,11 +423,11 @@ PrepareSetupInformation (
     StrCatS (BuildDateTime, Length + 2, ReleaseTime);
 
     TokenToUpdate = (STRING_REF)STR_BIOS_VERSION_VALUE;
-    DEBUG ((EFI_D_ERROR, "update STR_BIOS_VERSION_VALUE\n"));
+    DEBUG ((DEBUG_ERROR, "update STR_BIOS_VERSION_VALUE\n"));
     HiiSetString(mHiiHandle, TokenToUpdate, Version, NULL);
 
     TokenToUpdate = (STRING_REF)STR_BIOS_BUILD_TIME_VALUE;
-    DEBUG ((EFI_D_ERROR, "update STR_BIOS_BUILD_TIME_VALUE\n"));
+    DEBUG ((DEBUG_ERROR, "update STR_BIOS_BUILD_TIME_VALUE\n"));
     HiiSetString(mHiiHandle, TokenToUpdate, BuildDateTime, NULL);
   }
 

--- a/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscBaseBoardManufacturerFunction.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscBaseBoardManufacturerFunction.c
@@ -148,7 +148,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscBaseBoardManufacturer)
   if (SerialNumStrLen > SMBIOS_STRING_MAX_LENGTH) {
     return EFI_UNSUPPORTED;
   }
-  DEBUG ((EFI_D_ERROR, "MAC Address: %S\n", MacStr)); 
+  DEBUG ((DEBUG_ERROR, "MAC Address: %S\n", MacStr)); 
   
   TokenToGet = STRING_TOKEN (STR_MISC_BASE_BOARD_ASSET_TAG);
   AssertTag = SmbiosMiscGetString (TokenToGet);

--- a/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscBiosVendorFunction.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscBiosVendorFunction.c
@@ -182,7 +182,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscBiosVendor)
   SetMem(BiosReleaseDate, sizeof(BiosReleaseDate), 0);
   SetMem(BiosReleaseTime, sizeof(BiosReleaseTime), 0);
   Status = GetBiosVersionDateTime (BiosVersion, BiosReleaseDate, BiosReleaseTime);
-  DEBUG ((EFI_D_ERROR, "GetBiosVersionDateTime :%s %s %s \n", BiosVersion, BiosReleaseDate, BiosReleaseTime));
+  DEBUG ((DEBUG_ERROR, "GetBiosVersionDateTime :%s %s %s \n", BiosVersion, BiosReleaseDate, BiosReleaseTime));
   if (StrLen (BiosVersion) > 0) {
     TokenToUpdate = STRING_TOKEN (STR_MISC_BIOS_VERSION);
     HiiSetString (mHiiHandle, TokenToUpdate, BiosVersion, NULL);

--- a/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscOemType0x90Function.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscOemType0x90Function.c
@@ -291,7 +291,7 @@ AddSmbiosT0x90Callback (
   UINTN                 OptionalStrSize;
   EFI_SMBIOS_PROTOCOL               *SmbiosProtocol;
 
-  DEBUG ((EFI_D_INFO, "Executing SMBIOS T0x90 callback.\n"));
+  DEBUG ((DEBUG_INFO, "Executing SMBIOS T0x90 callback.\n"));
 
   gBS->CloseEvent (Event);    // Unload this event.
 
@@ -426,7 +426,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscOemType0x90)
   //
   if (CallbackIsInstalledT0x90 == FALSE) {
     CallbackIsInstalledT0x90 = TRUE;        	// Prevent more than 1 callback.
-    DEBUG ((EFI_D_INFO, "Create Smbios T0x90 callback.\n"));
+    DEBUG ((DEBUG_INFO, "Create Smbios T0x90 callback.\n"));
 
   //
   // gEfiDxeSmmReadyToLockProtocolGuid is ready

--- a/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscOemType0x94Function.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscOemType0x94Function.c
@@ -827,7 +827,7 @@ AddSmbiosT0x94Callback (
 
   ForType94InputData        = (EFI_MISC_OEM_TYPE_0x94 *)Context;
 
-  DEBUG ((EFI_D_INFO, "Executing SMBIOS T0x94 callback.\n"));
+  DEBUG ((DEBUG_INFO, "Executing SMBIOS T0x94 callback.\n"));
 
   gBS->CloseEvent (Event);    // Unload this event.
 

--- a/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscSubclassDriverEntryPoint.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscSubclassDriverEntryPoint.c
@@ -126,7 +126,7 @@ MiscSubclassDriverEntryPoint (
     }
   }
   
-  DEBUG ((EFI_D_ERROR, "PlatformInfoHob->BoardId [0x%x]\n", mPlatformInfo->BoardId));
+  DEBUG ((DEBUG_ERROR, "PlatformInfoHob->BoardId [0x%x]\n", mPlatformInfo->BoardId));
   
   //
   // Retrieve the pointer to the UEFI HII String Protocol
@@ -145,7 +145,7 @@ MiscSubclassDriverEntryPoint (
                      );
 
   if (EFI_ERROR(EfiStatus)) {
-    DEBUG((EFI_D_ERROR, "Could not locate SMBIOS protocol.  %r\n", EfiStatus));
+    DEBUG((DEBUG_ERROR, "Could not locate SMBIOS protocol.  %r\n", EfiStatus));
     return EfiStatus;
   }
 
@@ -168,7 +168,7 @@ MiscSubclassDriverEntryPoint (
         );
 
       if (EFI_ERROR(EfiStatus)) {
-        DEBUG((EFI_D_ERROR, "Misc smbios store error.  Index=%d, ReturnStatus=%r\n", Index, EfiStatus));
+        DEBUG((DEBUG_ERROR, "Misc smbios store error.  Index=%d, ReturnStatus=%r\n", Index, EfiStatus));
         return EfiStatus;
       }
     }

--- a/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscSystemManufacturerFunction.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscSystemManufacturerFunction.c
@@ -102,59 +102,59 @@ AddSmbiosManuCallback (
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_PRODUCT_NAME), Buffer, NULL);
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s",L"A0");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_VERSION), Buffer, NULL);
-      DEBUG ((EFI_D_ERROR, "A0 Stepping Detected\n"));
+      DEBUG ((DEBUG_ERROR, "A0 Stepping Detected\n"));
       break;
     case PchA1:
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s%s", PlatformNameBuffer, L"A1 PLATFORM");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_PRODUCT_NAME), Buffer, NULL);
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s",L"A1");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_VERSION), Buffer, NULL);
-      DEBUG ((EFI_D_ERROR, "A1 Stepping Detected\n"));
+      DEBUG ((DEBUG_ERROR, "A1 Stepping Detected\n"));
       break;
     case PchB0:
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s%s", PlatformNameBuffer, L"B0 PLATFORM");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_PRODUCT_NAME), Buffer, NULL);
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s",L"B0");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_VERSION), Buffer, NULL);
-      DEBUG ((EFI_D_ERROR, "B0 Stepping Detected\n"));
+      DEBUG ((DEBUG_ERROR, "B0 Stepping Detected\n"));
       break;
     case PchB1:
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s%s", PlatformNameBuffer, L"B1 PLATFORM");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_PRODUCT_NAME), Buffer, NULL);
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s",L"B1");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_VERSION), Buffer, NULL);
-      DEBUG ((EFI_D_ERROR, "B1 Stepping Detected\n"));
+      DEBUG ((DEBUG_ERROR, "B1 Stepping Detected\n"));
       break;
     case PchB2:
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s%s", PlatformNameBuffer, L"B2 PLATFORM");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_PRODUCT_NAME), Buffer, NULL);
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s",L"B2");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_VERSION), Buffer, NULL);
-      DEBUG ((EFI_D_ERROR, "B2 Stepping Detected\n"));
+      DEBUG ((DEBUG_ERROR, "B2 Stepping Detected\n"));
       break;
     case PchB3:
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s%s", PlatformNameBuffer, L"B3 PLATFORM");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_PRODUCT_NAME), Buffer, NULL);
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s",L"B3");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_VERSION), Buffer, NULL);
-      DEBUG ((EFI_D_ERROR, "B3 Stepping Detected\n"));
+      DEBUG ((DEBUG_ERROR, "B3 Stepping Detected\n"));
       break;
     case PchC0:
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s%s", PlatformNameBuffer, L"C0 PLATFORM");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_PRODUCT_NAME), Buffer, NULL);
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s",L"C0");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_VERSION), Buffer, NULL);
-      DEBUG ((EFI_D_ERROR, "C0 Stepping Detected\n"));
+      DEBUG ((DEBUG_ERROR, "C0 Stepping Detected\n"));
       break;
    case PchD0:
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s%s", PlatformNameBuffer, L"D0 PLATFORM");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_PRODUCT_NAME), Buffer, NULL);
       UnicodeSPrint (Buffer, sizeof (Buffer),L"%s",L"D0");
       HiiSetString(mHiiHandle,STRING_TOKEN(STR_MISC_SYSTEM_VERSION), Buffer, NULL);
-      DEBUG ((EFI_D_ERROR, "D0 Stepping Detected\n"));
+      DEBUG ((DEBUG_ERROR, "D0 Stepping Detected\n"));
       break;
     default:
-      DEBUG ((EFI_D_ERROR, "Unknow Stepping Detected\n"));
+      DEBUG ((DEBUG_ERROR, "Unknow Stepping Detected\n"));
       break;
     }
 
@@ -344,7 +344,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscSystemManufacturer)
 
   if (CallbackIsInstalledManu == FALSE) {
     CallbackIsInstalledManu = TRUE;        	// Prevent more than 1 callback.
-    DEBUG ((EFI_D_INFO, "Create Smbios Manu callback.\n"));
+    DEBUG ((DEBUG_INFO, "Create Smbios Manu callback.\n"));
 
     //
     // gEfiDxeSmmReadyToLockProtocolGuid is ready

--- a/Platform/Intel/Vlv2TbltDevicePkg/VlvPlatformInitDxe/IgdOpRegion.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/VlvPlatformInitDxe/IgdOpRegion.c
@@ -564,7 +564,7 @@ GetVBiosVbtCallback (
         //
         // Video BIOS not found, use VBT from FV
         //
-        DEBUG ((EFI_D_ERROR, "VBT data found\n"));
+        DEBUG ((DEBUG_ERROR, "VBT data found\n"));
         (gBS->CopyMem) (
                 mIgdOpRegion.OpRegion->VBT.GVD1,
                 VbtFileBuffer,
@@ -583,7 +583,7 @@ GetVBiosVbtCallback (
     }
   }
 
-  DEBUG ((EFI_D_ERROR, "VBIOS found at 0x%X\n", VBiosPtr));
+  DEBUG ((DEBUG_ERROR, "VBIOS found at 0x%X\n", VBiosPtr));
   VBiosVbtPtr = (VBIOS_VBT_STRUCTURE *) ((UINT8 *) VBiosPtr + VBiosPtr->VbtOffset);
 
   if ((*((UINT32 *) (VBiosVbtPtr->HeaderSignature))) != VBT_SIGNATURE) {
@@ -699,7 +699,7 @@ IgdOpRegionInit (
          sizeof(gSVER)
          );
 #endif
-  DEBUG ((EFI_D_ERROR, "System BIOS ID is %a\n", mIgdOpRegion.OpRegion->Header.SVER));
+  DEBUG ((DEBUG_ERROR, "System BIOS ID is %a\n", mIgdOpRegion.OpRegion->Header.SVER));
 
 
   mIgdOpRegion.OpRegion->Header.MBOX = HEADER_MBOX_SUPPORT;

--- a/Platform/Intel/Vlv2TbltDevicePkg/VlvPlatformInitDxe/VlvPlatformInit.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/VlvPlatformInitDxe/VlvPlatformInit.c
@@ -2,10 +2,12 @@
 /*++
 
 Copyright (c)  1999  - 2014, Intel Corporation. All rights reserved
-                                                                                   
+                                                                                   
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-                                                                                   
+                                                                                   
+
 
 
 Module Name:
@@ -271,13 +273,13 @@ VlvPlatformInitEntryPoint (
   ASSERT_EFI_ERROR (Status);
 
   //
-  // GtPostInit Initialization
+  // GtPosDEBUG_Initialization
   //
   DEBUG ((EFI_D_ERROR, "Initializing GT PowerManagement and other GT POST related\n"));
   IgdPmHook (ImageHandle, DxePlatformSaPolicy);
 
   //
-  // IgdOpRegion Install Initialization
+  // IgdOpDEBUG_ Install Initialization
   //
   DEBUG ((EFI_D_ERROR, "Initializing IGD OpRegion\n"));
   IgdOpRegionInit ();

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/WhiskeylakeURvp/Library/BoardInitLib/PeiWhiskeylakeURvpDetect.c
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/WhiskeylakeURvp/Library/BoardInitLib/PeiWhiskeylakeURvpDetect.c
@@ -50,7 +50,7 @@ WhiskeylakeURvpBoardDetect (
     return EFI_SUCCESS;
   }
 
-  DEBUG ((EFI_D_INFO, "WhiskeylakeURvpDetectionCallback\n"));
+  DEBUG ((DEBUG_INFO, "WhiskeylakeURvpDetectionCallback\n"));
 
   if (WhiskeylakeURvp()) {
     LibPcdSetSku (BoardIdWhiskeyLakeRvp);

--- a/Platform/Intel/WhitleyOpenBoardPkg/Aowanda/Uba/TypeAowanda/Dxe/IioCfgUpdateDxe/IioCfgUpdateDxe.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Aowanda/Uba/TypeAowanda/Dxe/IioCfgUpdateDxe/IioCfgUpdateDxe.c
@@ -53,7 +53,7 @@ IioCfgUpdateEntry (
   EFI_STATUS                    Status;
   UBA_CONFIG_DATABASE_PROTOCOL  *UbaConfigProtocol = NULL;
 
-  DEBUG ((EFI_D_INFO, "UBA:IioCfgUpdate-TypeAowanda\n"));
+  DEBUG ((DEBUG_INFO, "UBA:IioCfgUpdate-TypeAowanda\n"));
   Status = gBS->LocateProtocol (
                   &gUbaConfigDatabaseProtocolGuid,
                   NULL,

--- a/Platform/Intel/WhitleyOpenBoardPkg/Aowanda/Uba/TypeAowanda/Pei/AcpiTablePcds.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Aowanda/Uba/TypeAowanda/Pei/AcpiTablePcds.c
@@ -41,7 +41,7 @@ TypeAowandaPlatformUpdateAcpiTablePcds (
   // #
   Size   = AsciiStrSize (AcpiName10nm);
   Status = PcdSetPtrS (PcdOemSkuAcpiName, &Size, AcpiName10nm);
-  DEBUG ((DEBUG_INFO, "%a TypeAowanda ICX\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a TypeAowanda ICX\n", __func__));
   ASSERT_EFI_ERROR (Status);
 
   Size   = AsciiStrSize (OemTableIdXhci);

--- a/Platform/Intel/WhitleyOpenBoardPkg/Aowanda/Uba/TypeAowanda/Pei/PcdData.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Aowanda/Uba/TypeAowanda/Pei/PcdData.c
@@ -57,7 +57,7 @@ GpioGetRiserId (
   RevId = 0;
   DynamicSiLibraryPpi = NULL;
 
-  DEBUG((DEBUG_INFO, "%a Entry...\n", __FUNCTION__));
+  DEBUG((DEBUG_INFO, "%a Entry...\n", __func__));
 
   Status = PeiServicesLocatePpi (&gDynamicSiLibraryPpiGuid, 0, NULL, (VOID **) &DynamicSiLibraryPpi);
   if (EFI_ERROR (Status)) {

--- a/Platform/Intel/WhitleyOpenBoardPkg/Aowanda/Uba/TypeAowanda/Pei/PcdData.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Aowanda/Uba/TypeAowanda/Pei/PcdData.c
@@ -57,7 +57,7 @@ GpioGetRiserId (
   RevId = 0;
   DynamicSiLibraryPpi = NULL;
 
-  DEBUG((EFI_D_INFO, "%a Entry...\n", __FUNCTION__));
+  DEBUG((DEBUG_INFO, "%a Entry...\n", __FUNCTION__));
 
   Status = PeiServicesLocatePpi (&gDynamicSiLibraryPpiGuid, 0, NULL, (VOID **) &DynamicSiLibraryPpi);
   if (EFI_ERROR (Status)) {
@@ -71,7 +71,7 @@ GpioGetRiserId (
     //
     for (i = 0; i < EDSFFRiserIdGpioPadsNum; i++){
       Status = DynamicSiLibraryPpi->GpioGetInputValueByPchId (PCH_LEGACY_ID, mEDSFFRiserId[i], &Data32);
-      DEBUG((EFI_D_INFO,"GpioGetInputValueByPchId[%x] mEDSFFRiserId Status = %r\n", i, Status));
+      DEBUG((DEBUG_INFO,"GpioGetInputValueByPchId[%x] mEDSFFRiserId Status = %r\n", i, Status));
       if (EFI_ERROR(Status)) {
         return Status;
       }
@@ -85,7 +85,7 @@ GpioGetRiserId (
     //
     for (i = 0; i < PCIeRiserIdGpioPadsNum; i++){
       Status = DynamicSiLibraryPpi->GpioGetInputValueByPchId (PCH_LEGACY_ID, mPCIeRiserId[i], &Data32);
-      DEBUG((EFI_D_INFO,"GpioGetInputValueByPchId[%x] PCIe Riser Status = %r\n", i, Status));
+      DEBUG((DEBUG_INFO,"GpioGetInputValueByPchId[%x] PCIe Riser Status = %r\n", i, Status));
       if (EFI_ERROR(Status)) {
         return Status;
       }

--- a/Platform/Intel/WhitleyOpenBoardPkg/BoardPortTemplate/Uba/TypeBoardPortTemplate/Pei/AcpiTablePcds.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/BoardPortTemplate/Uba/TypeBoardPortTemplate/Pei/AcpiTablePcds.c
@@ -40,7 +40,7 @@ TypeBoardPortTemplatePlatformUpdateAcpiTablePcds (
   //#
   Size = AsciiStrSize (AcpiName10nm);
   Status = PcdSetPtrS (PcdOemSkuAcpiName , &Size, AcpiName10nm);
-  DEBUG ((DEBUG_INFO, "%a TypeBoardPortTemplate ICX\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a TypeBoardPortTemplate ICX\n", __func__));
   ASSERT_EFI_ERROR (Status);
 
   Size = AsciiStrSize (OemTableIdXhci);

--- a/Platform/Intel/WhitleyOpenBoardPkg/Cpu/Dxe/PlatformCpuPolicy/PlatformCpuPolicy.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Cpu/Dxe/PlatformCpuPolicy/PlatformCpuPolicy.c
@@ -67,14 +67,14 @@ PlatformCpuSmbiosData (
   CpuSocketNames = AllocatePool (CpuSocketCount * sizeof (UINTN));
 
   if (CpuSocketNames == NULL) {
-    DEBUG ((EFI_D_ERROR, "\nEFI_OUT_OF_RESOURCES!!! AllocatePool() returned NULL pointer.\n"));
+    DEBUG ((DEBUG_ERROR, "\nEFI_OUT_OF_RESOURCES!!! AllocatePool() returned NULL pointer.\n"));
     ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
     return;
   }
 
   CpuAssetTags = AllocatePool (CpuSocketCount * sizeof (UINTN));
   if (CpuAssetTags == NULL) {
-    DEBUG ((EFI_D_ERROR, "\nEFI_OUT_OF_RESOURCES!!! AllocatePool() returned NULL pointer.\n"));
+    DEBUG ((DEBUG_ERROR, "\nEFI_OUT_OF_RESOURCES!!! AllocatePool() returned NULL pointer.\n"));
     ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
     gBS->FreePool (CpuSocketNames);
     return;
@@ -122,7 +122,7 @@ CheckAndReAssignSocketId(
   if (EFI_ERROR(Status)) {
     return;
   }
-  DEBUG ((EFI_D_INFO, "::SockeId Pcd at %08x, size %x\n", PcdGetPtr(PcdCpuSocketId), PcdSize));
+  DEBUG ((DEBUG_INFO, "::SockeId Pcd at %08x, size %x\n", PcdGetPtr(PcdCpuSocketId), PcdSize));
 
   for(i = 0; i < MAX_SOCKET; i++) {
     if (mIioUds->PlatformData.CpuQpiInfo[i].Valid) {
@@ -164,7 +164,7 @@ CheckAndReAssignSocketId(
         break;
 
      default:
-        DEBUG ((EFI_D_INFO, "::Need more info to make sure we can support!!!\n"));
+        DEBUG ((DEBUG_INFO, "::Need more info to make sure we can support!!!\n"));
         break;
 
     } //end switch
@@ -247,7 +247,7 @@ PlatformCpuPolicyEntryPoint (
   CopyMem (&SetupData.PchSetup, PcdGetPtr(PcdPchSetup), sizeof(PCH_SETUP));
 
   Sp7.Data = DynamicSiLibraryProtocol->ReadScratchpad7 ();
-  DEBUG ((EFI_D_INFO, "AYP Debug scratchpad7: %x Stepping %x\n", Sp7.Bits.AepDimmPresent, CpuFamilyModelStepping & 0x0f));
+  DEBUG ((DEBUG_INFO, "AYP Debug scratchpad7: %x Stepping %x\n", Sp7.Bits.AepDimmPresent, CpuFamilyModelStepping & 0x0f));
   if ((Sp7.Bits.AepDimmPresent == 1) && ((CpuFamilyModelStepping & 0x0f) < 0x04) && ((CpuFamilyModelStepping >> 4) == CPU_FAMILY_SKX)) {
     SetupData.SocketConfig.PowerManagementConfig.PackageCState = 0;
   }

--- a/Platform/Intel/WhitleyOpenBoardPkg/Features/Acpi/AcpiPlatform/AcpiPlatform.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Features/Acpi/AcpiPlatform/AcpiPlatform.c
@@ -57,7 +57,7 @@ AcpiOnPciEnumCmplCallback (
   }
   gBS->CloseEvent (Event);
 
-  DEBUG ((DEBUG_INFO, "[ACPI] %a\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "[ACPI] %a\n", __func__));
   AcpiVtdTablesInstall ();
 }
 
@@ -69,7 +69,7 @@ AcpiOnEndOfDxeCallback (
   IN VOID       *Context
   )
 {
-  DEBUG ((DEBUG_INFO, "[ACPI] %a\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "[ACPI] %a\n", __func__));
   //
   // Installing ACPI Tables: NFIT, PCAT
   //
@@ -92,7 +92,7 @@ AcpiOnExitBootServicesCallback (
 
   gBS->CloseEvent (Event);
 
-  DEBUG ((DEBUG_INFO, "[ACPI] %a\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "[ACPI] %a\n", __func__));
   //
   // Enable SCI
   //
@@ -212,7 +212,7 @@ AcpiOnReadyToBootCallback (
     return;
   }
   mFirstNotify = TRUE;
-  DEBUG ((DEBUG_INFO, "[ACPI] %a\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "[ACPI] %a\n", __func__));
 
   Status = GetEntireConfig (&SetupData);
   ASSERT_EFI_ERROR (Status);

--- a/Platform/Intel/WhitleyOpenBoardPkg/Features/Pci/Dxe/PciHostBridge/PciHostBridge.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Features/Pci/Dxe/PciHostBridge/PciHostBridge.c
@@ -681,7 +681,7 @@ BridgeAllocateResources (
                 break;
 
               default:
-                DEBUG ((EFI_D_ERROR, "[PCI] ERROR: Unhandled resource type (%d)\n", Index));
+                DEBUG ((DEBUG_ERROR, "[PCI] ERROR: Unhandled resource type (%d)\n", Index));
                 break;
             } // End switch (Index)
 
@@ -1529,7 +1529,7 @@ GetProposedResources (
             ptr->AddrLen                = 0;
             break;
             default:
-              DEBUG ((EFI_D_INFO, "default case.\n"));  //Auto added. Please review.
+              DEBUG ((DEBUG_INFO, "default case.\n"));  //Auto added. Please review.
               break;
           }
 

--- a/Platform/Intel/WhitleyOpenBoardPkg/Features/Pci/Dxe/PciPlatform/PciPlatform.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Features/Pci/Dxe/PciPlatform/PciPlatform.c
@@ -84,7 +84,7 @@ InternalGetSystemBoardInfo (
                   );
 
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR,"  [GetSystemBoardInfo] Locate UbaConfigProtocol fail!\n"));
+    DEBUG ((DEBUG_ERROR,"  [GetSystemBoardInfo] Locate UbaConfigProtocol fail!\n"));
     return Status;
   }
 
@@ -97,7 +97,7 @@ InternalGetSystemBoardInfo (
                                 );
 
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR," [GetSystemBoardInfo] Get Data fail!\n"));
+    DEBUG ((DEBUG_ERROR," [GetSystemBoardInfo] Get Data fail!\n"));
     return Status;
   }
 
@@ -268,7 +268,7 @@ GetPciRom (
   Status = InternalGetSystemBoardInfo (&SystemBoardInfo);
   ASSERT_EFI_ERROR (Status);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "[GetPciRom] Get system board info fail!\n"));
+    DEBUG ((DEBUG_ERROR, "[GetPciRom] Get system board info fail!\n"));
     return Status;
   }
 
@@ -344,7 +344,7 @@ GetPciRom (
         Pcir->DeviceId = DeviceId;
       }
     } else {
-      DEBUG ((EFI_D_ERROR, "MS-HD5770 video adapter detected but PciIo->RomImage == NULL!\n"));
+      DEBUG ((DEBUG_ERROR, "MS-HD5770 video adapter detected but PciIo->RomImage == NULL!\n"));
     }
   }
 

--- a/Platform/Intel/WhitleyOpenBoardPkg/Features/Pci/Dxe/PciPlatform/PciPlatformHooks.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Features/Pci/Dxe/PciPlatform/PciPlatformHooks.c
@@ -720,7 +720,7 @@ PlatformPrepController (
                                         &DummyData
                                         );
               PCIDEBUG ("%a: For B(0x%x)-D(0x%x)-F(0x%x),Pci.Write() returns with %r\n",
-                        __FUNCTION__, SecBus, Device, Func, Status);
+                        __func__, SecBus, Device, Func, Status);
 
               if (EFI_ERROR (Status)) {
                 //

--- a/Platform/Intel/WhitleyOpenBoardPkg/Features/Pci/Dxe/PciPlatform/PciPlatformHooks.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Features/Pci/Dxe/PciPlatform/PciPlatformHooks.c
@@ -309,13 +309,13 @@ PciPlatformInitPciIovData (
       return Status;
     }
     DEBUG ((
-          EFI_D_INFO,
+          DEBUG_INFO,
           " Initialized SR-IOV Platform Data: PCIIovPolicy = 0x%x; SystemPageSize = 0x%x;\n",
           PciIovPolicy, SystemPageSize
           ));
   } else {
     DEBUG ((
-          EFI_D_INFO,
+          DEBUG_INFO,
           " Using default values for SystemPageSize;\n"
           ));
   }

--- a/Platform/Intel/WhitleyOpenBoardPkg/JunctionCity/Uba/TypeJunctionCity/Pei/AcpiTablePcds.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/JunctionCity/Uba/TypeJunctionCity/Pei/AcpiTablePcds.c
@@ -41,7 +41,7 @@ TypeJunctionCityPlatformUpdateAcpiTablePcds (
   //#
   Size = AsciiStrSize (AcpiName10nm);
   Status = PcdSetPtrS (PcdOemSkuAcpiName , &Size, AcpiName10nm);
-  DEBUG ((DEBUG_INFO, "%a TypeJunctionCity ICX\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a TypeJunctionCity ICX\n", __func__));
   ASSERT_EFI_ERROR (Status);
 
   Size = AsciiStrSize (OemTableIdXhci);

--- a/Platform/Intel/WhitleyOpenBoardPkg/Library/AcpiPlatformTableLib/AcpiPlatformLibHmat.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Library/AcpiPlatformTableLib/AcpiPlatformLibHmat.c
@@ -721,7 +721,7 @@ GetProcessorDomains (
       NodeId = (NodeId * HmatData->VirtualNumOfCluster) + (Index % HmatData->VirtualNumOfCluster);
 
       DEBUG ((DEBUG_INFO, "%a: SocketId: 0x%x SncNumOfCluster: 0x%x ImcInterBitmap:0x%x and  NodeId:0x%x\n",
-          __FUNCTION__, mSystemMemoryMap->Element[Index].SocketId, HmatData->SncNumOfCluster, mSystemMemoryMap->Element[Index].ImcInterBitmap, NodeId));
+          __func__, mSystemMemoryMap->Element[Index].SocketId, HmatData->SncNumOfCluster, mSystemMemoryMap->Element[Index].ImcInterBitmap, NodeId));
     } else {
       NodeId = SocketLogicalId;
     }
@@ -917,7 +917,7 @@ PatchHmatMsars (
         }
         ProcessorNodeId = (ProcessorNodeId * HmatData->VirtualNumOfCluster) + (Index % HmatData->VirtualNumOfCluster);
         DEBUG ((DEBUG_INFO, "%a: SocketId: 0x%x SncNumOfCluster: 0x%x ImcInterBitmap:0x%x and  NodeId:0x%x \n",
-          __FUNCTION__, mSystemMemoryMap->Element[Index].SocketId, HmatData->SncNumOfCluster, mSystemMemoryMap->Element[Index].ImcInterBitmap, ProcessorNodeId));
+          __func__, mSystemMemoryMap->Element[Index].SocketId, HmatData->SncNumOfCluster, mSystemMemoryMap->Element[Index].ImcInterBitmap, ProcessorNodeId));
       } else {
         ProcessorNodeId = SocketLogicalId;
       }

--- a/Platform/Intel/WhitleyOpenBoardPkg/Library/BoardInitLib/BoardInitPreMemLib.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Library/BoardInitLib/BoardInitPreMemLib.c
@@ -150,7 +150,7 @@ EarlyPlatformPchInit (
   //
   Data8 = IoRead8 (PCH_TCO_BASE_ADDRESS + R_TCO_IO_TCO2_STS);
   if ((Data8 & B_TCO_IO_TCO2_STS_SECOND_TO) == B_TCO_IO_TCO2_STS_SECOND_TO) {
-    DEBUG ((EFI_D_INFO, "EarlyPlatformPchInit - TCO Second TO status bit is set. This might be a TCO reboot\n"));
+    DEBUG ((DEBUG_INFO, "EarlyPlatformPchInit - TCO Second TO status bit is set. This might be a TCO reboot\n"));
   }
 
   //
@@ -178,7 +178,7 @@ EarlyPlatformPchInit (
   // Enable LPC decode at 0xCA0 for BMC
   //
   DynamicSiLibraryPpi->PchLpcGenIoRangeSet ((IPMI_DEFAULT_SMM_IO_BASE & 0xFF0), 0x10);
-  DEBUG ((EFI_D_INFO, "[IPMI_DEBUG]: PchLpcGenIoRangeSet 0x%x!\n", IPMI_DEFAULT_SMM_IO_BASE));
+  DEBUG ((DEBUG_INFO, "[IPMI_DEBUG]: PchLpcGenIoRangeSet 0x%x!\n", IPMI_DEFAULT_SMM_IO_BASE));
 
   DEBUG((DEBUG_INFO, "EarlyPlatformPchInit - End\n"));
 }

--- a/Platform/Intel/WhitleyOpenBoardPkg/Library/PeiFspWrapperHobProcessLib/FspWrapperHobProcessLib.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Library/PeiFspWrapperHobProcessLib/FspWrapperHobProcessLib.c
@@ -140,7 +140,7 @@ TransferHobData (
 
   GuidHob = GetNextGuidHob (InfoGuid, HobStart);
   if (GuidHob == NULL) {
-    DEBUG ((EFI_D_ERROR, "Transfer Hob Can't Find %a\n", Info));
+    DEBUG ((DEBUG_ERROR, "Transfer Hob Can't Find %a\n", Info));
     return;
   }
 
@@ -170,7 +170,7 @@ CopyHobData (
 
   GuidHob = GetNextGuidHob (InfoGuid, HobStart);
   if (GuidHob == NULL) {
-    DEBUG ((EFI_D_ERROR, "Transfer Hob Can't Find %a\n", Info));
+    DEBUG ((DEBUG_ERROR, "Transfer Hob Can't Find %a\n", Info));
     return;
   }
 
@@ -179,7 +179,7 @@ CopyHobData (
 
   OrgGuidHob = GetFirstGuidHob (InfoGuid);
   if (OrgGuidHob == NULL) {
-    DEBUG ((EFI_D_ERROR, "Copy Hob Can't Find org %a\n", Info));
+    DEBUG ((DEBUG_ERROR, "Copy Hob Can't Find org %a\n", Info));
   }
 
   OrgData = GET_GUID_HOB_DATA (OrgGuidHob);
@@ -190,7 +190,7 @@ CopyHobData (
   }
   CopyMem (OrgData, Data, DataSize);
 
-  DEBUG ((EFI_D_ERROR, "CopyHobData %a Hob from %x to %x, Size: %x\n", Info, Data, OrgData, DataSize));
+  DEBUG ((DEBUG_ERROR, "CopyHobData %a Hob from %x to %x, Size: %x\n", Info, Data, OrgData, DataSize));
 }
 
 
@@ -204,7 +204,7 @@ TransferPcd (
 
   GuidHob = GetNextGuidHob (&gSaveHostToMemoryGuid, HobStart);
   if (GuidHob == NULL) {
-    DEBUG ((EFI_D_ERROR, "Transfer Hob Can't Find gSaveHostToMemoryGuid\n"));
+    DEBUG ((DEBUG_ERROR, "Transfer Hob Can't Find gSaveHostToMemoryGuid\n"));
     return;
   }
 

--- a/Platform/Intel/WhitleyOpenBoardPkg/Library/PeiUbaPlatLib/PeiUbaGpioPlatformConfigLib.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Library/PeiUbaPlatLib/PeiUbaGpioPlatformConfigLib.c
@@ -456,12 +456,12 @@ GpioConfigForMFGMode (
     return EFI_UNSUPPORTED;
   }
 
-  DEBUG ((EFI_D_INFO, "Start ConfigureGpio() for BootMode Detection.\n"));
+  DEBUG ((DEBUG_INFO, "Start ConfigureGpio() for BootMode Detection.\n"));
 
   Status = DynamicSiLibraryPpi->GpioSetPadConfig (GpioPlatformConfig.GpioMfgPad.GpioPad, &GpioPlatformConfig.GpioMfgPad.GpioConfig);
 
   ASSERT_EFI_ERROR (Status);
-  DEBUG ((EFI_D_INFO, "End ConfigureGpio() for BootMode Detection.\n"));
+  DEBUG ((DEBUG_INFO, "End ConfigureGpio() for BootMode Detection.\n"));
   return Status;
 }
 

--- a/Platform/Intel/WhitleyOpenBoardPkg/Library/PlatformClocksLib/Pei/PlatformClocksLib.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Library/PlatformClocksLib/Pei/PlatformClocksLib.c
@@ -120,7 +120,7 @@ ConfigureClockGenerator (
       );
       if(Status != EFI_SUCCESS)
       {
-        DEBUG ((EFI_D_ERROR, "SMBUS reading error\n"));
+        DEBUG ((DEBUG_ERROR, "SMBUS reading error\n"));
 
       }
 
@@ -178,7 +178,7 @@ ConfigureClockGenerator (
 
      if(Status != EFI_SUCCESS)
      {
-       DEBUG ((EFI_D_ERROR, "SMBUS writing error\n"));
+       DEBUG ((DEBUG_ERROR, "SMBUS writing error\n"));
      }
 
      SmbErrorsCounter ++;

--- a/Platform/Intel/WhitleyOpenBoardPkg/Platform/Dxe/PlatformType/PlatformTypes.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Platform/Dxe/PlatformType/PlatformTypes.c
@@ -154,11 +154,11 @@ AssertPostGpio (
   GPIO_B20 = PcdGet32 (PcdOemSkuAssertPostGPIO);
   Data32 = PcdGet32(PcdOemSkuAssertPostGPIOValue);
   if (GPIO_B20 == 0xFFFFFFFF) {
-    DEBUG ((EFI_D_ERROR, "GPIO Pcd is invalid, so abort the GPIO Set and just return! \n"));
+    DEBUG ((DEBUG_ERROR, "GPIO Pcd is invalid, so abort the GPIO Set and just return! \n"));
     return;
   }
   DynamicSiLibraryProtocol->GpioSetOutputValue (GPIO_B20, Data32);
-  DEBUG ((EFI_D_INFO, "System Post Complete GPIO has been set ! \n"));
+  DEBUG ((DEBUG_INFO, "System Post Complete GPIO has been set ! \n"));
 }
 
 /**
@@ -225,7 +225,7 @@ PlatformTypeInit (
   PlatformName = AllocateZeroPool (PlatformNameSize);
   ASSERT (PlatformName != NULL);
   if (PlatformName == NULL) {
-    DEBUG ((EFI_D_ERROR, "Failed to allocate memory\n"));
+    DEBUG ((DEBUG_ERROR, "Failed to allocate memory\n"));
     return EFI_OUT_OF_RESOURCES;
   }
   //
@@ -234,7 +234,7 @@ PlatformTypeInit (
   GuidHob       = GetFirstGuidHob (&gEfiPlatformInfoGuid);
   ASSERT (GuidHob != NULL);
   if (GuidHob == NULL) {
-    DEBUG ((EFI_D_ERROR, "gEfiPlatformInfoGuid not found\n"));
+    DEBUG ((DEBUG_ERROR, "gEfiPlatformInfoGuid not found\n"));
     return EFI_NOT_FOUND;
   }
   PlatformInfoHobData  = GET_GUID_HOB_DATA(GuidHob);
@@ -272,12 +272,12 @@ PlatformTypeInit (
   PcdPlatformName = PcdGetPtr (PcdOemSkuPlatformName);
   ASSERT(PlatformNameSize >= PcdPlatformNameSize);
   if (PlatformNameSize < PcdPlatformNameSize) {
-    DEBUG ((EFI_D_ERROR, "Invalid buffer size\n"));
+    DEBUG ((DEBUG_ERROR, "Invalid buffer size\n"));
     return EFI_BUFFER_TOO_SMALL;
   }
   ASSERT(PcdPlatformName != NULL);
   if (PcdPlatformName == NULL) {
-    DEBUG ((EFI_D_ERROR, "Invalid PCD detected\n"));
+    DEBUG ((DEBUG_ERROR, "Invalid PCD detected\n"));
     return EFI_NOT_FOUND;
   }
   CopyMem (PlatformName, PcdPlatformName, PcdPlatformNameSize);
@@ -286,7 +286,7 @@ PlatformTypeInit (
 
   Status = GetPchName (PlatformInfoHobData);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Failed to get PCH name: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Failed to get PCH name: %r\n", Status));
     return Status;
   }
 
@@ -311,7 +311,7 @@ PlatformTypeInit (
   GuidHob    = GetFirstGuidHob (&UniversalDataGuid);
   ASSERT (GuidHob != NULL);
   if (GuidHob == NULL) {
-    DEBUG ((EFI_D_ERROR, "UniversalDataGuid not found\n"));
+    DEBUG ((DEBUG_ERROR, "UniversalDataGuid not found\n"));
     return EFI_NOT_FOUND;
   }
   UdsHobPtr = GET_GUID_HOB_DATA(GuidHob);

--- a/Platform/Intel/WhitleyOpenBoardPkg/Platform/Dxe/S3NvramSave/S3NvramSave.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Platform/Dxe/S3NvramSave/S3NvramSave.c
@@ -37,12 +37,12 @@ VerifySysHostStructureSize (
 
   if (PcdGet32 (PcdPeiSyshostMemorySize) != sizeof (SYSHOST)) {
 
-    DEBUG ((EFI_D_ERROR, "ERROR: In DXE sizeof SysHost = %d, in PEI sizeof SysHost = %d\n",
+    DEBUG ((DEBUG_ERROR, "ERROR: In DXE sizeof SysHost = %d, in PEI sizeof SysHost = %d\n",
       sizeof (SYSHOST),
       PcdGet32 (PcdPeiSyshostMemorySize)
       ));
 
-    DEBUG ((EFI_D_ERROR, "Size of SysHost must match in PEI and DXE\n"));
+    DEBUG ((DEBUG_ERROR, "Size of SysHost must match in PEI and DXE\n"));
     ASSERT (FALSE);
 
   }

--- a/Platform/Intel/WhitleyOpenBoardPkg/Platform/Pei/EmulationPlatformInit/EmulationPlatformInit.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Platform/Pei/EmulationPlatformInit/EmulationPlatformInit.c
@@ -51,7 +51,7 @@ EmulationPlatformInitEntry (
   //
   EmulationSetting = BuildGuidHob (&gEmulationHobGuid, sizeof (EMULATION_SETTING));
   if (EmulationSetting == NULL) {
-    DEBUG((EFI_D_ERROR, "Emulation BuildGuidDataHob fail!\n"));
+    DEBUG((DEBUG_ERROR, "Emulation BuildGuidDataHob fail!\n"));
     return EFI_OUT_OF_RESOURCES;
   }
 

--- a/Platform/Intel/WhitleyOpenBoardPkg/Platform/Pei/PlatformInfo/PlatformInfo.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Platform/Pei/PlatformInfo/PlatformInfo.c
@@ -355,7 +355,7 @@ GetGsxBoardID(
     //
     // Unhable to read GSX HW error Hang the system
     //
-    DEBUG ((EFI_D_ERROR, "ERROR: GSX HW is unavailable, SYSTEM HANG\n"));
+    DEBUG ((DEBUG_ERROR, "ERROR: GSX HW is unavailable, SYSTEM HANG\n"));
     CpuDeadLoop ();
   }
 }
@@ -423,7 +423,7 @@ PdrGetPlatformInfo (
     //
     // Reading PIT from SPI PDR Failed or a unknown platform identified
     //
-    DEBUG ((EFI_D_ERROR, "PIT from SPI PDR reports Platform ID as %x. This is unknown ID. Assuming Greencity Platform!\n", PlatformInfoHob->BoardId));
+    DEBUG ((DEBUG_ERROR, "PIT from SPI PDR reports Platform ID as %x. This is unknown ID. Assuming Greencity Platform!\n", PlatformInfoHob->BoardId));
     PlatformInfoHob->BoardId = TypePlatformUnknown;
     Status = EFI_INCOMPATIBLE_VERSION;
   }
@@ -512,12 +512,12 @@ GetPlatformInfo (
 
   Status = GpioGetBoardId (&BoardId);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Error: Can't read GPIO to get Board ID!\n"));
+    DEBUG ((DEBUG_ERROR, "Error: Can't read GPIO to get Board ID!\n"));
     return Status;
   }
   Status = GpioGetBoardRevId (&BoardRev);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "Error: Can't read GPIO to get Board ID!\n"));
+    DEBUG ((DEBUG_ERROR, "Error: Can't read GPIO to get Board ID!\n"));
     return Status;
   }
   PlatformInfoHob->TypeRevisionId = BoardRev;
@@ -644,7 +644,7 @@ PlatformInfoInit (
 
   PciCfgPpi = (**PeiServices).PciCfg;
   if (PciCfgPpi == NULL) {
-    DEBUG ((EFI_D_ERROR, "\nError! PlatformInfoInit() - PeiServices is a NULL Pointer!!!\n"));
+    DEBUG ((DEBUG_ERROR, "\nError! PlatformInfoInit() - PeiServices is a NULL Pointer!!!\n"));
     ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
     return EFI_INVALID_PARAMETER;
   }
@@ -679,7 +679,7 @@ PlatformInfoInit (
 
   if (EFI_ERROR (Status))
   {
-        DEBUG((EFI_D_ERROR, "LocatePpi Error in PlatformInfo.c !\n"));
+        DEBUG((DEBUG_ERROR, "LocatePpi Error in PlatformInfo.c !\n"));
   }
 
   Status = GetIioPlatformSetupPolicy (&PlatformInfoHob);

--- a/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/Common/Dxe/SystemBoardInfoDxe/SystemBoardInfoDxe.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/Common/Dxe/SystemBoardInfoDxe/SystemBoardInfoDxe.c
@@ -181,7 +181,7 @@ SystemBoardInfoEntry (
   EFI_STATUS                                Status;
   UBA_CONFIG_DATABASE_PROTOCOL             *UbaConfigProtocol = NULL;
 
-  DEBUG((EFI_D_INFO, "UBA:System Board Info Table.\n"));
+  DEBUG((DEBUG_INFO, "UBA:System Board Info Table.\n"));
   Status = gBS->LocateProtocol (
                   &gUbaConfigDatabaseProtocolGuid,
                   NULL,

--- a/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/Common/Pei/IioPortBifurcationVer1.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/Common/Pei/IioPortBifurcationVer1.c
@@ -373,7 +373,7 @@ CalculatePEXPHideFromIouBif_SKX (
 
   if (IioIndex >= MaxIIO || Iou >= NELEMENTS (IioGlobalData->SetupData.ConfigIOU[IioIndex])) {
 
-    DEBUG ((DEBUG_ERROR, "[IIO] ERROR: %a: IIO instance %d or IOU %d out of range", __FUNCTION__, IioIndex, Iou));
+    DEBUG ((DEBUG_ERROR, "[IIO] ERROR: %a: IIO instance %d or IOU %d out of range", __func__, IioIndex, Iou));
     ASSERT (FALSE);
     return;
   }

--- a/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/Common/Pei/IioPortBifurcationVer1.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/Common/Pei/IioPortBifurcationVer1.c
@@ -115,7 +115,7 @@ GetBw5Id (
   }
 
   if (Status != EFI_SUCCESS || Smbus == NULL) {
-    DEBUG ((EFI_D_INFO, "!!!!Get SMBus protocol error %x\n", Status));
+    DEBUG ((DEBUG_INFO, "!!!!Get SMBus protocol error %x\n", Status));
   } else {
 
     // Read Socket 0 HP Controller
@@ -162,7 +162,7 @@ GetBw5Id (
                                &SmbusLength,
                                &SmbusData );
            if (!EFI_ERROR(Status)){
-             DEBUG ((EFI_D_INFO, "SmbusData Port0/1 %x\n", SmbusData));
+             DEBUG ((DEBUG_INFO, "SmbusData Port0/1 %x\n", SmbusData));
              //
              // Mask the Input Port0/1 register data [15:0] to get BW5 ID.
              //
@@ -345,7 +345,7 @@ EnableHotPlug_SKX (
     IioGlobalData->SetupData.VppPort[Port]= VppPort;
     IioGlobalData->SetupData.VppAddress[Port] = VppAddress;
   } else {
-      DEBUG((EFI_D_ERROR, "PCIE HOT Plug. Missing VPP values on slot table\n"));
+      DEBUG((DEBUG_ERROR, "PCIE HOT Plug. Missing VPP values on slot table\n"));
   }
 }
 
@@ -484,9 +484,9 @@ DumpPort_SKX(
 )
 {
   UINT8 Index;
-  DEBUG((EFI_D_INFO, "IDX, Port Hide, Slot Impl, Slot Number, HotPlug, PcieSSD, VppPort, VppAddress, Interlock\n"));
+  DEBUG((DEBUG_INFO, "IDX, Port Hide, Slot Impl, Slot Number, HotPlug, PcieSSD, VppPort, VppAddress, Interlock\n"));
   for (Index = Port; Index < (Port + NumberOfPorts); Index++ ) {
-  DEBUG((EFI_D_INFO, "%3d|   %2d    |    %2d    |   %3d      |   %3d  |  %3d  |  0x%02x  |  0x%02x     |  %2d      \n", \
+  DEBUG((DEBUG_INFO, "%3d|   %2d    |    %2d    |   %3d      |   %3d  |  %3d  |  0x%02x  |  0x%02x     |  %2d      \n", \
                        Index, \
                        IioGlobalData->SetupData.PEXPHIDE[Index],  \
                        IioGlobalData->SetupData.SLOTIMP[Index],   \
@@ -517,13 +517,13 @@ DumpIioConfiguration_SKX(
   MaxPortNumberPerSocket = IioGlobalData->IioVar.IioOutData.MaxPciePortNumberPerSocket[iio];
   PortIndex = iio * MaxPortNumberPerSocket;
   /// First dump the socket number;
-  DEBUG((EFI_D_INFO, "Socket number: %d \n", iio));
+  DEBUG((DEBUG_INFO, "Socket number: %d \n", iio));
 
   /// Dump DMI configuration:
   if ((iio == 0) && (PortIndex == 0)){
-      DEBUG((EFI_D_INFO, "PORT 0: DMI Port\n"));
+      DEBUG((DEBUG_INFO, "PORT 0: DMI Port\n"));
   } else {
-      DEBUG((EFI_D_INFO, "PORT 0: DMI Port working as PCIE\n"));
+      DEBUG((DEBUG_INFO, "PORT 0: DMI Port working as PCIE\n"));
       DumpPort_SKX(IioGlobalData, PortIndex, 1);
   }
   IouPorts=4;
@@ -536,30 +536,30 @@ DumpIioConfiguration_SKX(
         case Iio_Iou0:
           Bifurcation = IioGlobalData->SetupData.ConfigIOU[iio][0];
           PortIndex += PORT_1A_INDEX;
-          DEBUG((EFI_D_INFO, "IUO0: Root Port 1, Bifurcation: %d\n", Bifurcation));
+          DEBUG((DEBUG_INFO, "IUO0: Root Port 1, Bifurcation: %d\n", Bifurcation));
           break;
         case Iio_Iou1:
           Bifurcation = IioGlobalData->SetupData.ConfigIOU[iio][1];
           PortIndex += PORT_2A_INDEX;
-          DEBUG((EFI_D_INFO, "IUO1: Root Port 2, Bifurcation: %d\n", Bifurcation));
+          DEBUG((DEBUG_INFO, "IUO1: Root Port 2, Bifurcation: %d\n", Bifurcation));
           break;
         case Iio_Iou2:
           Bifurcation = IioGlobalData->SetupData.ConfigIOU[iio][2];
           PortIndex += PORT_3A_INDEX;
-          DEBUG((EFI_D_INFO, "IUO2: Root Port 3, Bifurcation: %d\n", Bifurcation));
+          DEBUG((DEBUG_INFO, "IUO2: Root Port 3, Bifurcation: %d\n", Bifurcation));
           break;
         case Iio_Iou3:
           Bifurcation = IioGlobalData->SetupData.ConfigIOU[iio][3];
           PortIndex += PORT_4A_INDEX;
-          DEBUG((EFI_D_INFO, "IOU3, Bifurcation: %d\n", Bifurcation));
+          DEBUG((DEBUG_INFO, "IOU3, Bifurcation: %d\n", Bifurcation));
           break;
         case Iio_Iou4:
           Bifurcation = IioGlobalData->SetupData.ConfigIOU[iio][4];
           PortIndex += PORT_5A_INDEX;
-          DEBUG((EFI_D_INFO, "IOU4, Bifurcation: %d\n", Bifurcation));
+          DEBUG((DEBUG_INFO, "IOU4, Bifurcation: %d\n", Bifurcation));
           break;
         default:
-          DEBUG((EFI_D_INFO, "Iou no detected = %d",Iou));
+          DEBUG((DEBUG_INFO, "Iou no detected = %d",Iou));
           break;
         }
       DumpPort_SKX(IioGlobalData, PortIndex, IouPorts);
@@ -717,7 +717,7 @@ SlotImplemented_SKX (
       }
       break;
     default:
-      DEBUG ((EFI_D_INFO, "default case.\n"));  //Auto added. Please review.
+      DEBUG ((DEBUG_INFO, "default case.\n"));  //Auto added. Please review.
       break;
   }
   DEBUG ((DEBUG_INFO, "SlotImplemented_SKX:  = %x\n", SlotImp));
@@ -844,10 +844,10 @@ OverrideDefaultBifSlots_SKX (
 
   Status = DynamicSiLibraryPpi->GpioGetInputValueByPchId (PCH_LEGACY_ID, GPIO_SKL_H_GPP_B3, &QATGpio);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "Get GPIO_SKL_H_GPP_B3 Failed\n"));
+    DEBUG ((DEBUG_INFO, "Get GPIO_SKL_H_GPP_B3 Failed\n"));
     return;
   }
-  DEBUG ((EFI_D_INFO, "QAT GPIO: %d\n", QATGpio));
+  DEBUG ((DEBUG_INFO, "QAT GPIO: %d\n", QATGpio));
 
   if ((IioGlobalData->IioVar.IioVData.SkuPersonality[0] == TYPE_FPGA) &&\
       (IioGlobalData->IioVar.IioVData.SkuPersonality[1] == TYPE_FPGA)) {
@@ -877,33 +877,33 @@ OverrideDefaultBifSlots_SKX (
     //
     Status = DynamicSiLibraryPpi->GpioGetInputValueByPchId (PCH_LEGACY_ID, GPIO_SKL_H_GPP_B4, &RiserBit);  // PresentSignal
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Get GPIO_SKL_H_GPP_B4 Failed\n"));
+      DEBUG ((DEBUG_INFO, "Get GPIO_SKL_H_GPP_B4 Failed\n"));
       return;
     }
     RightRiser.Bits.PresentSignal = (UINT8) RiserBit;
 
     Status = DynamicSiLibraryPpi->GpioGetInputValueByPchId (PCH_LEGACY_ID, GPIO_SKL_H_GPP_C15, &RiserBit);  // HotPlugConf
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Get GPIO_SKL_H_GPP_C15 Failed\n"));
+      DEBUG ((DEBUG_INFO, "Get GPIO_SKL_H_GPP_C15 Failed\n"));
       return;
     }
     RightRiser.Bits.HPConf = (UINT8) RiserBit;
 
     Status = DynamicSiLibraryPpi->GpioGetInputValueByPchId (PCH_LEGACY_ID, GPIO_SKL_H_GPP_C16, &RiserBit);  // WingConf
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Get GPIO_SKL_H_GPP_C16 Failed\n"));
+      DEBUG ((DEBUG_INFO, "Get GPIO_SKL_H_GPP_C16 Failed\n"));
       return;
     }
     RightRiser.Bits.WingConf = (UINT8) RiserBit;
 
     Status = DynamicSiLibraryPpi->GpioGetInputValueByPchId (PCH_LEGACY_ID, GPIO_SKL_H_GPP_C17, &RiserBit);  // Slot9En
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Get GPIO_SKL_H_GPP_C17 Failed\n"));
+      DEBUG ((DEBUG_INFO, "Get GPIO_SKL_H_GPP_C17 Failed\n"));
       return;
     }
     RightRiser.Bits.Slot9En = (UINT8) RiserBit;
 
-    DEBUG ((EFI_D_INFO, "GPIO Right riser information: PresentSignal=%x, HotPlugConf=%x, WingConf=%x, Slot9En=%x\n",
+    DEBUG ((DEBUG_INFO, "GPIO Right riser information: PresentSignal=%x, HotPlugConf=%x, WingConf=%x, Slot9En=%x\n",
             RightRiser.Bits.PresentSignal, RightRiser.Bits.HPConf, RightRiser.Bits.WingConf, RightRiser.Bits.Slot9En));
 
     //
@@ -911,33 +911,33 @@ OverrideDefaultBifSlots_SKX (
     //
     Status = DynamicSiLibraryPpi->GpioGetInputValueByPchId (PCH_LEGACY_ID, GPIO_SKL_H_GPP_B5, &RiserBit);  // PresentSignal
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Get GPIO_SKL_H_GPP_B5 Failed\n"));
+      DEBUG ((DEBUG_INFO, "Get GPIO_SKL_H_GPP_B5 Failed\n"));
       return;
     }
     LeftRiser.Bits.PresentSignal = (UINT8) RiserBit;
 
     Status = DynamicSiLibraryPpi->GpioGetInputValueByPchId (PCH_LEGACY_ID, GPIO_SKL_H_GPP_C18, &RiserBit);  // HotPlugConf
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Get GPIO_SKL_H_GPP_C18 Failed\n"));
+      DEBUG ((DEBUG_INFO, "Get GPIO_SKL_H_GPP_C18 Failed\n"));
       return;
     }
     LeftRiser.Bits.HPConf = (UINT8) RiserBit;
 
     Status = DynamicSiLibraryPpi->GpioGetInputValueByPchId (PCH_LEGACY_ID, GPIO_SKL_H_GPP_C19, &RiserBit);  // WingConf
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Get GPIO_SKL_H_GPP_C19 Failed\n"));
+      DEBUG ((DEBUG_INFO, "Get GPIO_SKL_H_GPP_C19 Failed\n"));
       return;
     }
     LeftRiser.Bits.WingConf = (UINT8) RiserBit;
 
     Status = DynamicSiLibraryPpi->GpioGetInputValueByPchId (PCH_LEGACY_ID, GPIO_SKL_H_GPP_B21, &RiserBit);  // Slot9En
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Get GPIO_SKL_H_GPP_B21 Failed\n"));
+      DEBUG ((DEBUG_INFO, "Get GPIO_SKL_H_GPP_B21 Failed\n"));
       return;
     }
     LeftRiser.Bits.Slot9En = (UINT8) RiserBit;
 
-    DEBUG ((EFI_D_INFO, "GPIO Left riser information: PresentSignal=%x, HotPlugConf=%x, WingConf=%x, Slot9En=%x\n",
+    DEBUG ((DEBUG_INFO, "GPIO Left riser information: PresentSignal=%x, HotPlugConf=%x, WingConf=%x, Slot9En=%x\n",
             LeftRiser.Bits.PresentSignal, LeftRiser.Bits.HPConf, LeftRiser.Bits.WingConf, LeftRiser.Bits.Slot9En));
   }
 
@@ -1038,7 +1038,7 @@ OverrideDefaultBifSlots_SKX (
   /// Broadway overrides.
   if (BroadwayTable != NULL) {
     GetBw5Id (IioGlobalData, Bw5id);
-    DEBUG ((EFI_D_INFO,"Broadway Config: 0x%02x, 0x%02x, 0x%02x, 0x%02x\n", Bw5id[Bw5_Addr_0].Data, Bw5id[Bw5_Addr_1].Data, Bw5id[Bw5_Addr_2].Data, Bw5id[Bw5_Addr_3].Data));
+    DEBUG ((DEBUG_INFO,"Broadway Config: 0x%02x, 0x%02x, 0x%02x, 0x%02x\n", Bw5id[Bw5_Addr_0].Data, Bw5id[Bw5_Addr_1].Data, Bw5id[Bw5_Addr_2].Data, Bw5id[Bw5_Addr_3].Data));
     for (Index = 0; Index < 3; Index ++) {
       //
       // Check if BW5 is present before override IOUx Bifurcation
@@ -1209,7 +1209,7 @@ SetBifurcations_SKX(
           IioGlobalData->SetupData.ConfigIOU[Socket][4] = BifurcationTable[Index].Bifurcation;
           break;
         default:
-          DEBUG ((EFI_D_ERROR, "Invalid bifurcation table: Bad Iou (%d)", Iou));
+          DEBUG ((DEBUG_ERROR, "Invalid bifurcation table: Bad Iou (%d)", Iou));
           ASSERT(Iou);
           break;
       }

--- a/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeCooperCityRP/Pei/PcdData.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeCooperCityRP/Pei/PcdData.c
@@ -35,7 +35,7 @@ TypeCooperCityRPPlatformUpdateVrIdAddress (
   Size = sizeof (MEM_SVID_MAP);
   MemSvidMap = (MEM_SVID_MAP *) PcdGetPtr (PcdMemSrvidMap);
   if (MemSvidMap == NULL) {
-    DEBUG ((EFI_D_ERROR, "UpdateVrIdAddress() - PcdMemSrvidMap == NULL\n"));
+    DEBUG ((DEBUG_ERROR, "UpdateVrIdAddress() - PcdMemSrvidMap == NULL\n"));
     return;
   }
   /*
@@ -218,7 +218,7 @@ TypeCooperCityRPPlatformPcdUpdateCallback (
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "Uba Callback: PlatformPcdUpdateCallback is called!\n"));
+  DEBUG ((DEBUG_INFO, "Uba Callback: PlatformPcdUpdateCallback is called!\n"));
   Status = TypeCooperCityRPPlatformUpdateAcpiTablePcds ();
 
   //# Board Type Bit Mask

--- a/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeWilsonCityRP/Dxe/UsbOcUpdateDxe/UsbOcUpdateDxe.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeWilsonCityRP/Dxe/UsbOcUpdateDxe/UsbOcUpdateDxe.c
@@ -106,7 +106,7 @@ UsbOcUpdateEntry (
   EFI_STATUS                          Status;
   UBA_CONFIG_DATABASE_PROTOCOL        *UbaConfigProtocol = NULL;
 
-  DEBUG((EFI_D_INFO, "UBA:UsbOcUpdate-TypeWilsonCityRP\n"));
+  DEBUG((DEBUG_INFO, "UBA:UsbOcUpdate-TypeWilsonCityRP\n"));
   Status = gBS->LocateProtocol (
                   &gUbaConfigDatabaseProtocolGuid,
                   NULL,

--- a/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeWilsonCityRP/Pei/AcpiTablePcds.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeWilsonCityRP/Pei/AcpiTablePcds.c
@@ -40,7 +40,7 @@ TypeWilsonCityRPPlatformUpdateAcpiTablePcds (
   //#
   Size = AsciiStrSize (AcpiName10nm);
   Status = PcdSetPtrS (PcdOemSkuAcpiName , &Size, AcpiName10nm);
-  DEBUG ((DEBUG_INFO, "%a TypeWilsonCityRP ICX\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a TypeWilsonCityRP ICX\n", __func__));
   ASSERT_EFI_ERROR (Status);
 
   Size = AsciiStrSize (OemTableIdXhci);

--- a/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeWilsonCityRP/Pei/AcpiTablePcds.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeWilsonCityRP/Pei/AcpiTablePcds.c
@@ -27,7 +27,7 @@ TypeWilsonCityRPPlatformUpdateAcpiTablePcds (
 
   EFI_HOB_GUID_TYPE                     *GuidHob;
 
-  DEBUG ((EFI_D_INFO, "Uba Callback: PlatformUpdateAcpiTablePcds entered\n"));
+  DEBUG ((DEBUG_INFO, "Uba Callback: PlatformUpdateAcpiTablePcds entered\n"));
 
   GuidHob = GetFirstGuidHob (&gEfiPlatformInfoGuid);
   ASSERT (GuidHob != NULL);

--- a/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeWilsonCityRP/Pei/PcdData.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeWilsonCityRP/Pei/PcdData.c
@@ -36,7 +36,7 @@ TypeWilsonCityRPPlatformUpdateImonAddress (
   Size = sizeof (VCC_IMON);
   VccImon = (VCC_IMON *) PcdGetPtr (PcdImonAddr);
   if (VccImon == NULL) {
-    DEBUG ((EFI_D_ERROR, "UpdateImonAddress() - PcdImonAddr == NULL\n"));
+    DEBUG ((DEBUG_ERROR, "UpdateImonAddress() - PcdImonAddr == NULL\n"));
     return;
   }
 
@@ -63,7 +63,7 @@ TypeWilsonCityRPPlatformUpdateVrIdAddress (
   Size = sizeof (MEM_SVID_MAP);
   MemSvidMap = (MEM_SVID_MAP *) PcdGetPtr (PcdMemSrvidMap);
   if (MemSvidMap == NULL) {
-    DEBUG ((EFI_D_ERROR, "UpdateVrIdAddress() - PcdMemSrvidMap == NULL\n"));
+    DEBUG ((DEBUG_ERROR, "UpdateVrIdAddress() - PcdMemSrvidMap == NULL\n"));
     return;
   }
   /*
@@ -232,7 +232,7 @@ TypeWilsonCityRPPlatformPcdUpdateCallback (
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "Uba Callback: PlatformPcdUpdateCallback is called!\n"));
+  DEBUG ((DEBUG_INFO, "Uba Callback: PlatformPcdUpdateCallback is called!\n"));
   Status = TypeWilsonCityRPPlatformUpdateAcpiTablePcds ();
   //# BMC Pcie Port Number
   PcdSet8S (PcdOemSkuBmcPciePortNumber, 5);

--- a/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeWilsonCityRP/Pei/PeiBoardInitLib.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeWilsonCityRP/Pei/PeiBoardInitLib.c
@@ -45,7 +45,7 @@ TypeWilsonCityRPPeiBoardInitLibConstructor (
 
   if (PlatformInfo->BoardId == TypeWilsonCityRP) {
 
-    DEBUG ((EFI_D_INFO, "PEI UBA init BoardId 0x%X: WilsonCityRP\n", PlatformInfo->BoardId));
+    DEBUG ((DEBUG_INFO, "PEI UBA init BoardId 0x%X: WilsonCityRP\n", PlatformInfo->BoardId));
 
     // Socket 0 has SMT DIMM connector, Socket 1 has PTH DIMM connector
     for (SocketIndex = 0; SocketIndex < MAX_SOCKET; SocketIndex++) {

--- a/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeWilsonCitySMT/Pei/AcpiTablePcds.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Uba/UbaMain/TypeWilsonCitySMT/Pei/AcpiTablePcds.c
@@ -38,7 +38,7 @@ TypeWilsonCitySMTPlatformUpdateAcpiTablePcds (
   //#
   Size = AsciiStrSize (AcpiName10nm);
   Status = PcdSetPtrS (PcdOemSkuAcpiName , &Size, AcpiName10nm);
-  DEBUG ((DEBUG_INFO, "%a TypeWilsonCitySMT ICX\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a TypeWilsonCitySMT ICX\n", __func__));
   ASSERT_EFI_ERROR (Status);
 
   Size = AsciiStrSize (OemTableIdXhci);

--- a/Platform/Intel/WhitleyOpenBoardPkg/Universal/PeiInterposerToSvidMap/PeiInterposerToSvidMap.c
+++ b/Platform/Intel/WhitleyOpenBoardPkg/Universal/PeiInterposerToSvidMap/PeiInterposerToSvidMap.c
@@ -49,7 +49,7 @@ MapInterposerToSvid (
   BOOLEAN                 InterposerPresent = FALSE;
   DYNAMIC_SI_LIBARY_PPI   *DynamicSiLibraryPpi = NULL;
 
-  DEBUG ((EFI_D_INFO, "MapInterposerToSvid   Entry\n"));
+  DEBUG ((DEBUG_INFO, "MapInterposerToSvid   Entry\n"));
 
   Status = PeiServicesLocatePpi (&gDynamicSiLibraryPpiGuid, 0, NULL, (VOID **) &DynamicSiLibraryPpi);
   if (EFI_ERROR (Status)) {
@@ -59,7 +59,7 @@ MapInterposerToSvid (
 
   GuidHob = GetFirstGuidHob (&gEfiPlatformInfoGuid);
   if (GuidHob == NULL) {
-    DEBUG ((EFI_D_INFO, "No Platform Info HOB Detected Exiting...\n"));
+    DEBUG ((DEBUG_INFO, "No Platform Info HOB Detected Exiting...\n"));
     return EFI_SUCCESS;
   } else {
     MemInterposerMap = (INTERPOSER_MAP *) PcdGetPtr (PcdMemInterposerMap);
@@ -67,7 +67,7 @@ MapInterposerToSvid (
       return EFI_SUCCESS;
     }
     Size = sizeof (MEM_SVID_MAP);
-    DEBUG ((EFI_D_INFO, "Allocate memory for MemSvidMap PCD\n"));
+    DEBUG ((DEBUG_INFO, "Allocate memory for MemSvidMap PCD\n"));
     Status = PeiServicesAllocatePool (Size, (VOID **) &MemSvidMap);
     ASSERT_EFI_ERROR (Status);
     ZeroMem (MemSvidMap, Size);
@@ -90,7 +90,7 @@ MapInterposerToSvid (
             MemSvidMap->Socket[Socket].Mc[CurrentMcId] = SvidValue;
             InterposerPresent = TRUE;
           }
-          DEBUG ((EFI_D_INFO, "Current MC id = %d, Original MC id = %d, SVID = %d\n", CurrentMcId, OriginalMcId, SvidValue));
+          DEBUG ((DEBUG_INFO, "Current MC id = %d, Original MC id = %d, SVID = %d\n", CurrentMcId, OriginalMcId, SvidValue));
         }
       }
     }
@@ -98,10 +98,10 @@ MapInterposerToSvid (
   if (InterposerPresent) {
     PcdSetPtrS (PcdMemSrvidMap, &Size, (VOID *) MemSvidMap);
   } else {
-    DEBUG ((EFI_D_INFO, "No Interposer Present....\n"));
+    DEBUG ((DEBUG_INFO, "No Interposer Present....\n"));
   }
 
-  DEBUG ((EFI_D_INFO, "MapInterposerToSvid   Exit\n"));
+  DEBUG ((DEBUG_INFO, "MapInterposerToSvid   Exit\n"));
   return EFI_SUCCESS;
 }
 
@@ -127,11 +127,11 @@ InterposerToSvidMapEntry (
   )
 {
   EFI_STATUS Status = EFI_SUCCESS;
-  DEBUG ((EFI_D_INFO, "InterposerToSvidMap   Entry\n"));
+  DEBUG ((DEBUG_INFO, "InterposerToSvidMap   Entry\n"));
 
   Status = PeiServicesNotifyPpi (&mMapInterposerToSvidNotifyList);
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG ((EFI_D_INFO, "InterposerToSvidMap   Exit\n"));
+  DEBUG ((DEBUG_INFO, "InterposerToSvidMap   Exit\n"));
   return EFI_SUCCESS;;
 }

--- a/Platform/Loongson/LoongArchQemuPkg/Library/NorFlashQemuLib/NorFlashQemuLib.c
+++ b/Platform/Loongson/LoongArchQemuPkg/Library/NorFlashQemuLib/NorFlashQemuLib.c
@@ -66,7 +66,7 @@ VirtNorFlashPlatformGetDevices (
     DEBUG ((
       DEBUG_ERROR,
       "%a: GetNodeProperty () failed (Status == %r)\n",
-      __FUNCTION__,
+      __func__,
       Status
       ));
     return Status;
@@ -78,7 +78,7 @@ VirtNorFlashPlatformGetDevices (
     DEBUG ((
       DEBUG_ERROR,
       "%a: reg node size(%d) is too small \n",
-      __FUNCTION__,
+      __func__,
       PropSize
       ));
     return EFI_NOT_FOUND;

--- a/Platform/Loongson/LoongArchQemuPkg/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/Platform/Loongson/LoongArchQemuPkg/Library/PlatformBootManagerLib/PlatformBm.c
@@ -121,7 +121,7 @@ FilterAndProcess (
     //
     // This is not an error, just an informative condition.
     //
-    DEBUG ((DEBUG_VERBOSE, "%a: %g: %r\n", __FUNCTION__, ProtocolGuid,
+    DEBUG ((DEBUG_VERBOSE, "%a: %g: %r\n", __func__, ProtocolGuid,
       Status));
     return;
   }
@@ -188,7 +188,7 @@ IsPciDisplay (
   Status = PciIo->Pci.Read (PciIo, EfiPciIoWidthUint32, 0 /* Offset */,
                         sizeof Pci / sizeof (UINT32), &Pci);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: %s: %r\n", __FUNCTION__, ReportText, Status));
+    DEBUG ((DEBUG_ERROR, "%a: %s: %r\n", __func__, ReportText, Status));
     return FALSE;
   }
 
@@ -220,7 +220,7 @@ Connect (
                   FALSE   // Recursive
                   );
   DEBUG ((EFI_ERROR (Status) ? DEBUG_ERROR : DEBUG_VERBOSE, "%a: %s: %r\n",
-    __FUNCTION__, ReportText, Status));
+    __func__, ReportText, Status));
 }
 
 /**
@@ -245,25 +245,25 @@ AddOutput (
   DevicePath = DevicePathFromHandle (Handle);
   if (DevicePath == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: %s: handle %p: device path not found\n",
-      __FUNCTION__, ReportText, Handle));
+      __func__, ReportText, Handle));
     return;
   }
 
   Status = EfiBootManagerUpdateConsoleVariable (ConOut, DevicePath, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ConOut: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ConOut: %r\n", __func__,
       ReportText, Status));
     return;
   }
 
   Status = EfiBootManagerUpdateConsoleVariable (ErrOut, DevicePath, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ErrOut: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ErrOut: %r\n", __func__,
       ReportText, Status));
     return;
   }
 
-  DEBUG ((DEBUG_VERBOSE, "%a: %s: added to ConOut and ErrOut\n", __FUNCTION__,
+  DEBUG ((DEBUG_VERBOSE, "%a: %s: added to ConOut and ErrOut\n", __func__,
     ReportText));
 }
 /**
@@ -452,7 +452,7 @@ RemoveStaleFvFileOptions (
       DEBUG ((
         EFI_ERROR (Status) ? DEBUG_WARN : DEBUG_VERBOSE,
         "%a: removing stale Boot#%04x %s: %r\n",
-        __FUNCTION__,
+        __func__,
         (UINT32)BootOptions[Index].OptionNumber,
         DevicePathString == NULL ? L"<unavailable>" : DevicePathString,
         Status

--- a/Platform/Loongson/LoongArchQemuPkg/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/Platform/Loongson/LoongArchQemuPkg/Library/PlatformBootManagerLib/PlatformBm.c
@@ -450,7 +450,7 @@ RemoveStaleFvFileOptions (
       DevicePathString = ConvertDevicePathToText (BootOptions[Index].FilePath,
                            FALSE, FALSE);
       DEBUG ((
-        EFI_ERROR (Status) ? EFI_D_WARN : DEBUG_VERBOSE,
+        EFI_ERROR (Status) ? DEBUG_WARN : DEBUG_VERBOSE,
         "%a: removing stale Boot#%04x %s: %r\n",
         __FUNCTION__,
         (UINT32)BootOptions[Index].OptionNumber,

--- a/Platform/Loongson/LoongArchQemuPkg/Library/PlatformBootManagerLib/QemuKernel.c
+++ b/Platform/Loongson/LoongArchQemuPkg/Library/PlatformBootManagerLib/QemuKernel.c
@@ -70,7 +70,7 @@ TryRunningQemuKernel (
     DEBUG ((
       DEBUG_ERROR,
       "%a: QemuStartKernelImage(): %r\n",
-      __FUNCTION__,
+      __func__,
       Status
       ));
   }

--- a/Platform/Loongson/LoongArchQemuPkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.c
+++ b/Platform/Loongson/LoongArchQemuPkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.c
@@ -454,7 +454,7 @@ QemuFwCfgInitialize (
         break;
       } else {
         DEBUG ((DEBUG_ERROR, "%a: Failed to parse FDT QemuCfg node\n",
-          __FUNCTION__));
+          __func__));
         break;
       }
     }

--- a/Platform/Loongson/LoongArchQemuPkg/Library/ResetSystemAcpiLib/BaseResetSystemAcpiGed.c
+++ b/Platform/Loongson/LoongArchQemuPkg/Library/ResetSystemAcpiLib/BaseResetSystemAcpiGed.c
@@ -136,7 +136,7 @@ ResetSystemLibConstructor (
 
   Status = GetPowerManagerByParseAcpiInfo ();
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "%a:%d\n",  __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_INFO, "%a:%d\n",  __func__, __LINE__));
   }
 
   ASSERT (mPowerManager.SleepControlRegAddr);

--- a/Platform/Loongson/LoongArchQemuPkg/Library/ResetSystemAcpiLib/DxeResetSystemAcpiGed.c
+++ b/Platform/Loongson/LoongArchQemuPkg/Library/ResetSystemAcpiLib/DxeResetSystemAcpiGed.c
@@ -45,7 +45,7 @@ SetMemoryAttributesRunTime (
 
   Status = gDS->GetMemorySpaceDescriptor (Address, &Descriptor);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "%a: GetMemorySpaceDescriptor failed\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: GetMemorySpaceDescriptor failed\n", __func__));
     return Status;
   }
 
@@ -57,7 +57,7 @@ SetMemoryAttributesRunTime (
                   EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
                   );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_INFO, "%a: AddMemorySpace failed\n", __FUNCTION__));
+      DEBUG ((DEBUG_INFO, "%a: AddMemorySpace failed\n", __func__));
       return Status;
     }
 
@@ -67,7 +67,7 @@ SetMemoryAttributesRunTime (
                   EFI_MEMORY_RUNTIME
                   );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_INFO, "%a:%d SetMemorySpaceAttributes failed\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_INFO, "%a:%d SetMemorySpaceAttributes failed\n", __func__, __LINE__));
       return Status;
     }
   } else if (!(Descriptor.Attributes & EFI_MEMORY_RUNTIME)) {
@@ -78,7 +78,7 @@ SetMemoryAttributesRunTime (
                   );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_INFO, "%a:%d SetMemorySpaceAttributes failed\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_INFO, "%a:%d SetMemorySpaceAttributes failed\n", __func__, __LINE__));
       return Status;
     }
   }
@@ -192,27 +192,27 @@ AcpiNotificationEvent (
     return ;
   }
 
-  DEBUG ((DEBUG_INFO, "%a: sleepControl %llx\n", __FUNCTION__, mPowerManager.SleepControlRegAddr));
+  DEBUG ((DEBUG_INFO, "%a: sleepControl %llx\n", __func__, mPowerManager.SleepControlRegAddr));
   ASSERT (mPowerManager.SleepControlRegAddr);
   Status =  SetMemoryAttributesRunTime (mPowerManager.SleepControlRegAddr);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "%a:%d\n",  __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_INFO, "%a:%d\n",  __func__, __LINE__));
     return ;
   }
 
-  DEBUG ((DEBUG_INFO, "%a: sleepStatus %llx\n", __FUNCTION__, mPowerManager.SleepStatusRegAddr));
+  DEBUG ((DEBUG_INFO, "%a: sleepStatus %llx\n", __func__, mPowerManager.SleepStatusRegAddr));
   ASSERT (mPowerManager.SleepStatusRegAddr);
   Status =  SetMemoryAttributesRunTime (mPowerManager.SleepStatusRegAddr);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "%a:%d\n",  __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_INFO, "%a:%d\n",  __func__, __LINE__));
     return ;
   }
 
-  DEBUG ((DEBUG_INFO, "%a: ResetReg %llx\n", __FUNCTION__, mPowerManager.ResetRegAddr));
+  DEBUG ((DEBUG_INFO, "%a: ResetReg %llx\n", __func__, mPowerManager.ResetRegAddr));
   ASSERT (mPowerManager.ResetRegAddr);
   Status =  SetMemoryAttributesRunTime (mPowerManager.ResetRegAddr);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "%a:%d\n",  __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_INFO, "%a:%d\n",  __func__, __LINE__));
   }
   return ;
 }

--- a/Platform/Loongson/LoongArchQemuPkg/PlatformPei/Platform.c
+++ b/Platform/Loongson/LoongArchQemuPkg/PlatformPei/Platform.c
@@ -289,7 +289,7 @@ GetRtcAddress (
         break;
       } else {
         DEBUG ((DEBUG_ERROR, "%a: Failed to parse FDT rtc node\n",
-          __FUNCTION__));
+          __func__));
         break;
       }
     }
@@ -383,7 +383,7 @@ SystemMemorySizeInitialization (
 
   QemuFwCfgSelectItem (QemuFwCfgItemRamSize);
   RamSize= QemuFwCfgRead64 ();
-  DEBUG ((DEBUG_INFO, "%a: QEMU reports %dM system memory\n", __FUNCTION__,
+  DEBUG ((DEBUG_INFO, "%a: QEMU reports %dM system memory\n", __func__,
     RamSize/1024/1024));
 
   //

--- a/Platform/Marvell/Armada70x0Db/NonDiscoverableInitLib/NonDiscoverableInitLib.c
+++ b/Platform/Marvell/Armada70x0Db/NonDiscoverableInitLib/NonDiscoverableInitLib.c
@@ -38,7 +38,7 @@ ConfigurePins (
 
   Status = MvGpioGetProtocol (DriverType, &GpioProtocol);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Unable to find GPIO protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Unable to find GPIO protocol\n", __func__));
     return Status;
   }
 

--- a/Platform/Marvell/Armada80x0Db/NonDiscoverableInitLib/NonDiscoverableInitLib.c
+++ b/Platform/Marvell/Armada80x0Db/NonDiscoverableInitLib/NonDiscoverableInitLib.c
@@ -76,7 +76,7 @@ XhciInit (
 
   Status = MvGpioGetProtocol (MV_GPIO_DRIVER_TYPE_PCA95XX, &GpioProtocol);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Unable to find GPIO protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Unable to find GPIO protocol\n", __func__));
     return Status;
   }
 

--- a/Platform/Marvell/Cn913xDb/NonDiscoverableInitLib/NonDiscoverableInitLib.c
+++ b/Platform/Marvell/Cn913xDb/NonDiscoverableInitLib/NonDiscoverableInitLib.c
@@ -38,7 +38,7 @@ ConfigurePins (
 
   Status = MvGpioGetProtocol (DriverType, &GpioProtocol);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Unable to find GPIO protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Unable to find GPIO protocol\n", __func__));
     return Status;
   }
 

--- a/Platform/NXP/LS1046aFrwyPkg/Library/ArmPlatformLib/ArmPlatformLibMem.c
+++ b/Platform/NXP/LS1046aFrwyPkg/Library/ArmPlatformLib/ArmPlatformLibMem.c
@@ -40,7 +40,7 @@ ArmPlatformGetVirtualMemoryMap (
                                      MAX_VIRTUAL_MEMORY_MAP_DESCRIPTORS);
 
   if (VirtualMemoryTable == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Error: Failed AllocatePool()\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Error: Failed AllocatePool()\n", __func__));
     return;
   }
 

--- a/Platform/NXP/LX2160aRdbPkg/Drivers/PlatformDxe/PlatformDxe.c
+++ b/Platform/NXP/LX2160aRdbPkg/Drivers/PlatformDxe/PlatformDxe.c
@@ -62,7 +62,7 @@ SetPciControllerPcdOptions (
       PcdSetBoolS (PcdPciHideRootPort, TRUE);
       break;
     default:
-      DEBUG ((DEBUG_ERROR, "%a: Invalid SoC Version 0x%x \n", __FUNCTION__,
+      DEBUG ((DEBUG_ERROR, "%a: Invalid SoC Version 0x%x \n", __func__,
               SVR_MAJOR(Svr)));
       return EFI_INVALID_PARAMETER;
     }

--- a/Platform/NXP/LX2160aRdbPkg/Library/ArmPlatformLib/ArmPlatformLibMem.c
+++ b/Platform/NXP/LX2160aRdbPkg/Library/ArmPlatformLib/ArmPlatformLibMem.c
@@ -41,7 +41,7 @@ ArmPlatformGetVirtualMemoryMap (
                                      MAX_VIRTUAL_MEMORY_MAP_DESCRIPTORS);
 
   if (VirtualMemoryTable == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Error: Failed AllocatePool()\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Error: Failed AllocatePool()\n", __func__));
     return;
   }
 

--- a/Platform/RISC-V/PlatformPkg/Library/Edk2OpensbiPlatformWrapperLib/Edk2OpensbiPlatformWrapperLib.c
+++ b/Platform/RISC-V/PlatformPkg/Library/Edk2OpensbiPlatformWrapperLib/Edk2OpensbiPlatformWrapperLib.c
@@ -43,7 +43,7 @@ SecSetEdk2FwMemoryRegions (
   fw_memregs.flags = SBI_DOMAIN_MEMREGION_EXECUTABLE | SBI_DOMAIN_MEMREGION_READABLE;
   Ret              = sbi_domain_root_add_memregion ((CONST struct sbi_domain_memregion *)&fw_memregs);
   if (Ret != 0) {
-    DEBUG ((DEBUG_ERROR, "%a: Add firmware regions of FW Domain fail\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Add firmware regions of FW Domain fail\n", __func__));
   }
 
   //
@@ -54,7 +54,7 @@ SecSetEdk2FwMemoryRegions (
   fw_memregs.flags = SBI_DOMAIN_MEMREGION_READABLE | SBI_DOMAIN_MEMREGION_WRITEABLE;
   Ret              = sbi_domain_root_add_memregion ((CONST struct sbi_domain_memregion *)&fw_memregs);
   if (Ret != 0) {
-    DEBUG ((DEBUG_ERROR, "%a: Add firmware regions of variable FW Domain fail\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Add firmware regions of variable FW Domain fail\n", __func__));
   }
 
   return Ret;
@@ -76,7 +76,7 @@ SecPostOpenSbiPlatformEarlyInit (
 
   if (!ColdBoot) {
     HartId = current_hartid ();
-    DEBUG ((DEBUG_INFO, "%a: Non boot hart %d.\n", __FUNCTION__, HartId));
+    DEBUG ((DEBUG_INFO, "%a: Non boot hart %d.\n", __func__, HartId));
     return 0;
   }
 
@@ -91,7 +91,7 @@ SecPostOpenSbiPlatformEarlyInit (
   // Boot HART is already in the process of OpenSBI initialization.
   // We can let other HART to keep booting.
   //
-  DEBUG ((DEBUG_INFO, "%a: Set boot hart done.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Set boot hart done.\n", __func__));
   atomic_write (&BootHartDone, (UINT64)TRUE);
   return 0;
 }
@@ -117,11 +117,11 @@ SecPostOpenSbiPlatformFinalInit (
 
   if (!ColdBoot) {
     HartId = current_hartid ();
-    DEBUG ((DEBUG_INFO, "%a: Non boot hart %d.\n", __FUNCTION__, HartId));
+    DEBUG ((DEBUG_INFO, "%a: Non boot hart %d.\n", __func__, HartId));
     return 0;
   }
 
-  DEBUG ((DEBUG_INFO, "%a: Entry, preparing to jump to PEI Core\n\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry, preparing to jump to PEI Core\n\n", __func__));
 
   SbiScratch      = sbi_scratch_thishart_ptr ();
   SbiPlatform     = (struct sbi_platform *)sbi_platform_ptr (SbiScratch);
@@ -130,7 +130,7 @@ SecPostOpenSbiPlatformFinalInit (
   //
   // Print out scratch address of each hart
   //
-  DEBUG ((DEBUG_INFO, "%a: OpenSBI scratch address for each hart:\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: OpenSBI scratch address for each hart:\n", __func__));
   for (HartId = 0; HartId < SBI_HARTMASK_MAX_BITS; HartId++) {
     if (sbi_platform_hart_invalid (SbiPlatform, HartId)) {
       continue;
@@ -159,14 +159,14 @@ SecPostOpenSbiPlatformFinalInit (
       DEBUG ((
         DEBUG_INFO,
         "%a: OpenSBI Hart %d Firmware Context Hart-specific at address: 0x%x\n",
-        __FUNCTION__,
+        __func__,
         HartId,
         FirmwareContext->HartSpecific[HartId]
         ));
     }
   }
 
-  DEBUG ((DEBUG_INFO, "%a: Will jump to PEI Core in OpenSBI with \n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Will jump to PEI Core in OpenSBI with \n", __func__));
   DEBUG ((DEBUG_INFO, "  sbi_scratch = %x\n", SbiScratch));
   DEBUG ((DEBUG_INFO, "  sbi_platform = %x\n", SbiPlatform));
   DEBUG ((DEBUG_INFO, "  FirmwareContext = %x\n", FirmwareContext));
@@ -189,7 +189,7 @@ Edk2OpensbiPlatformEarlyInit (
 {
   INT32  ReturnCode;
 
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.early_init) {
     ReturnCode = platform_ops.early_init (ColdBoot);
@@ -219,7 +219,7 @@ Edk2OpensbiPlatformFinalInit (
 {
   INT32  ReturnCode;
 
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.final_init) {
     ReturnCode = platform_ops.final_init (ColdBoot);
@@ -244,7 +244,7 @@ Edk2OpensbiPlatformEarlyExit (
   VOID
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.early_exit) {
     return platform_ops.early_exit ();
@@ -260,7 +260,7 @@ Edk2OpensbiPlatformFinalExit (
   VOID
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.early_exit) {
     return platform_ops.early_exit ();
@@ -316,7 +316,7 @@ Edk2OpensbiPlatformDomainsInit (
   VOID
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.domains_init) {
     return platform_ops.domains_init ();
@@ -336,7 +336,7 @@ Edk2OpensbiPlatformSerialInit (
   VOID
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.console_init) {
     return platform_ops.console_init ();
@@ -357,7 +357,7 @@ Edk2OpensbiPlatformIrqchipInit (
   IN BOOLEAN  ColdBoot
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.irqchip_init) {
     return platform_ops.irqchip_init (ColdBoot);
@@ -375,7 +375,7 @@ Edk2OpensbiPlatformIrqchipExit (
   VOID
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.irqchip_exit) {
     return platform_ops.irqchip_exit ();
@@ -394,7 +394,7 @@ Edk2OpensbiPlatformIpiInit (
   IN  BOOLEAN  ColdBoot
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.ipi_init) {
     return platform_ops.ipi_init (ColdBoot);
@@ -412,7 +412,7 @@ Edk2OpensbiPlatformIpiExit (
   VOID
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.ipi_exit) {
     return platform_ops.ipi_exit ();
@@ -430,7 +430,7 @@ Edk2OpensbiPlatformTlbrFlushLimit (
   VOID
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.get_tlbr_flush_limit) {
     return platform_ops.get_tlbr_flush_limit ();
@@ -451,7 +451,7 @@ Edk2OpensbiPlatformTimerInit (
   IN BOOLEAN  ColdBoot
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.timer_init) {
     return platform_ops.timer_init (ColdBoot);
@@ -469,7 +469,7 @@ Edk2OpensbiPlatformTimerExit (
   VOID
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.timer_exit) {
     return platform_ops.timer_exit ();
@@ -488,7 +488,7 @@ Edk2OpensbiPlatformVendorExtCheck (
   IN long  ExtId
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.vendor_ext_check) {
     return platform_ops.vendor_ext_check (ExtId);
@@ -518,7 +518,7 @@ Edk2OpensbiPlatformVendorExtProvider (
   IN struct sbi_trap_info        *OutTrap
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (platform_ops.vendor_ext_provider) {
     return platform_ops.vendor_ext_provider (

--- a/Platform/RISC-V/PlatformPkg/Universal/FdtPeim/FdtPeim.c
+++ b/Platform/RISC-V/PlatformPkg/Universal/FdtPeim/FdtPeim.c
@@ -44,17 +44,17 @@ PeimPassFdt (
   GetFirmwareContextPointer (&FirmwareContext);
 
   if (FirmwareContext == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: OpenSBI Firmware Context is NULL\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: OpenSBI Firmware Context is NULL\n", __func__));
     return EFI_UNSUPPORTED;
   }
 
   FdtPointer = (VOID *)FirmwareContext->FlattenedDeviceTree;
   if (FdtPointer == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Invalid FDT pointer\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Invalid FDT pointer\n", __func__));
     return EFI_UNSUPPORTED;
   }
 
-  DEBUG ((DEBUG_ERROR, "%a: Build FDT HOB - FDT at address: 0x%x \n", __FUNCTION__, FdtPointer));
+  DEBUG ((DEBUG_ERROR, "%a: Build FDT HOB - FDT at address: 0x%x \n", __func__, FdtPointer));
   Base = FdtPointer;
   ASSERT (Base != NULL);
   ASSERT (fdt_check_header (Base) == 0);

--- a/Platform/RISC-V/PlatformPkg/Universal/Pei/PlatformPei/MemDetect.c
+++ b/Platform/RISC-V/PlatformPkg/Universal/Pei/PlatformPei/MemDetect.c
@@ -52,7 +52,7 @@ PublishPeiMemory (
   MemoryBase = 0x80000000UL + 0x1000000UL;
   MemorySize = 0x40000000UL - 0x1000000UL; // 1GB - 16MB
 
-  DEBUG ((DEBUG_INFO, "%a: MemoryBase:0x%x MemorySize:%x\n", __FUNCTION__, MemoryBase, MemorySize));
+  DEBUG ((DEBUG_INFO, "%a: MemoryBase:0x%x MemorySize:%x\n", __func__, MemoryBase, MemorySize));
 
   //
   // Publish this memory to the PEI Core

--- a/Platform/RISC-V/PlatformPkg/Universal/Sec/SecMain.c
+++ b/Platform/RISC-V/PlatformPkg/Universal/Sec/SecMain.c
@@ -167,10 +167,10 @@ FindFfsFileAndSection (
   UINT32                Size;
   EFI_PHYSICAL_ADDRESS  EndOfFile;
 
-  DEBUG ((DEBUG_INFO, "%a: DBT FV at 0x%x\n", __FUNCTION__, Fv));
+  DEBUG ((DEBUG_INFO, "%a: DBT FV at 0x%x\n", __func__, Fv));
 
   if (Fv->Signature != EFI_FVH_SIGNATURE) {
-    DEBUG ((DEBUG_ERROR, "%a: FV at %p does not have FV header signature\n", __FUNCTION__, Fv));
+    DEBUG ((DEBUG_ERROR, "%a: FV at %p does not have FV header signature\n", __func__, Fv));
     return EFI_VOLUME_CORRUPTED;
   }
 
@@ -183,20 +183,20 @@ FindFfsFileAndSection (
   for (EndOfFile = CurrentAddress + Fv->HeaderLength; ; ) {
     CurrentAddress = (EndOfFile + 7) & ~(7ULL);
     if (CurrentAddress > EndOfFirmwareVolume) {
-      DEBUG ((DEBUG_ERROR, "%a: FV corrupted\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: FV corrupted\n", __func__));
       return EFI_VOLUME_CORRUPTED;
     }
 
     File = (EFI_FFS_FILE_HEADER *)(UINTN)CurrentAddress;
     Size = *(UINT32 *)File->Size & 0xffffff;
     if (Size < (sizeof (*File) + sizeof (EFI_COMMON_SECTION_HEADER))) {
-      DEBUG ((DEBUG_ERROR, "%a: FV corrupted\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: FV corrupted\n", __func__));
       return EFI_VOLUME_CORRUPTED;
     }
 
     EndOfFile = CurrentAddress + Size;
     if (EndOfFile > EndOfFirmwareVolume) {
-      DEBUG ((DEBUG_ERROR, "%a: FV corrupted\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: FV corrupted\n", __func__));
       return EFI_VOLUME_CORRUPTED;
     }
 
@@ -204,7 +204,7 @@ FindFfsFileAndSection (
     // Look for the request file type
     //
     if (File->Type != FileType) {
-      DEBUG ((DEBUG_INFO, "%a: (File->Type != FileType), find next FFS\n", __FUNCTION__));
+      DEBUG ((DEBUG_INFO, "%a: (File->Type != FileType), find next FFS\n", __func__));
       continue;
     }
 
@@ -215,16 +215,16 @@ FindFfsFileAndSection (
                FoundSection
                );
     if (!EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_INFO, "%a: Get firmware file section\n", __FUNCTION__));
+      DEBUG ((DEBUG_INFO, "%a: Get firmware file section\n", __func__));
       return Status;
     }
 
     if (Status == EFI_VOLUME_CORRUPTED) {
-      DEBUG ((DEBUG_ERROR, "%a: FV corrupted\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: FV corrupted\n", __func__));
       return Status;
     }
 
-    DEBUG ((DEBUG_INFO, "%a: Find next FFS\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Find next FFS\n", __func__));
   }
 }
 
@@ -262,12 +262,12 @@ FindPeiCoreImageBaseInFv (
                &Section
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Unable to find PEI Core image\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Unable to find PEI Core image\n", __func__));
       return Status;
     }
   }
 
-  DEBUG ((DEBUG_INFO, "%a: PeiCoreImageBase found\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: PeiCoreImageBase found\n", __func__));
   *PeiCoreImageBase = (EFI_PHYSICAL_ADDRESS)(UINTN)(Section + 1);
   return EFI_SUCCESS;
 }
@@ -287,7 +287,7 @@ FindPeiCoreImageBase (
 {
   *PeiCoreImageBase = 0;
 
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
   FindPeiCoreImageBaseInFv (*BootFv, PeiCoreImageBase);
 }
 
@@ -311,7 +311,7 @@ FindAndReportEntryPoints (
   EFI_STATUS            Status;
   EFI_PHYSICAL_ADDRESS  PeiCoreImageBase;
 
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   FindPeiCoreImageBase (BootFirmwareVolumePtr, &PeiCoreImageBase);
   //
@@ -322,7 +322,7 @@ FindAndReportEntryPoints (
     *PeiCoreEntryPoint = 0;
   }
 
-  DEBUG ((DEBUG_INFO, "%a: PeCoffLoaderGetEntryPoint success: %x\n", __FUNCTION__, *PeiCoreEntryPoint));
+  DEBUG ((DEBUG_INFO, "%a: PeCoffLoaderGetEntryPoint success: %x\n", __func__, *PeiCoreEntryPoint));
 
   return;
 }
@@ -364,7 +364,7 @@ SbiEcallFirmwareHandler (
       break;
     default:
       Ret = SBI_ENOTSUPP;
-      DEBUG ((DEBUG_ERROR, "%a: Called SBI firmware ecall with invalid function ID\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Called SBI firmware ecall with invalid function ID\n", __func__));
       ASSERT (FALSE);
   }
 
@@ -452,7 +452,7 @@ PeiCore (
       DEBUG_ERROR,
       "%a: OpenSBI platform table version 0x%x is newer than OpenSBI version 0x%x.\n"
       "There maybe be some backward compatable issues.\n",
-      __FUNCTION__,
+      __func__,
       ThisSbiPlatform->opensbi_version,
       OPENSBI_VERSION
       ));
@@ -462,7 +462,7 @@ PeiCore (
   DEBUG ((
     DEBUG_INFO,
     "%a: OpenSBI platform table at address: 0x%x\nFirmware Context is located at 0x%x\n",
-    __FUNCTION__,
+    __func__,
     ThisSbiPlatform,
     &FirmwareContext
     ));
@@ -481,7 +481,7 @@ PeiCore (
   //
   // Set supervisor translation mode to Bare mode
   //
-  DEBUG ((DEBUG_INFO, "%a: Set Supervisor address mode to Bare-mode.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Set Supervisor address mode to Bare-mode.\n", __func__));
   RiscVSetSupervisorAddressTranslationRegister ((UINT64)RISCV_SATP_MODE_OFF << RISCV_SATP_MODE_BIT_POSITION);
 
   //
@@ -489,7 +489,7 @@ PeiCore (
   //
   Scratch->next_addr = (UINTN)(PeiCoreEntryPoint);
   Scratch->next_mode = PRV_S;
-  DEBUG ((DEBUG_INFO, "%a: Initializing OpenSBI library for booting hart %d\n", __FUNCTION__, BootHartId));
+  DEBUG ((DEBUG_INFO, "%a: Initializing OpenSBI library for booting hart %d\n", __func__, BootHartId));
   sbi_init (Scratch);
 }
 
@@ -716,13 +716,13 @@ SecCoreStartUpWithStack (
     NonBootHartMessageLockValue = atomic_xchg (&NonBootHartMessageLock, TRUE);
   }
 
-  DEBUG ((DEBUG_INFO, "%a: Non boot hart %d initialization.\n", __FUNCTION__, HartId));
+  DEBUG ((DEBUG_INFO, "%a: Non boot hart %d initialization.\n", __func__, HartId));
   if (Scratch->next_arg1 == (unsigned long)NULL) {
     DEBUG ((DEBUG_ERROR, "Platform Device Tree is not found\n"));
     ASSERT (FALSE);
   }
 
-  DEBUG ((DEBUG_INFO, "%a: Non boot hart %d DTB is at 0x%x.\n", __FUNCTION__, HartId, Scratch->next_arg1));
+  DEBUG ((DEBUG_INFO, "%a: Non boot hart %d DTB is at 0x%x.\n", __func__, HartId, Scratch->next_arg1));
   NonBootHartMessageLockValue = atomic_xchg (&NonBootHartMessageLock, FALSE);
   //
   // Non boot hart wiil be halted waiting for SBI_HART_STARTING.

--- a/Platform/RaspberryPi/Drivers/ArasanMmcHostDxe/ArasanMmcHostDxe.c
+++ b/Platform/RaspberryPi/Drivers/ArasanMmcHostDxe/ArasanMmcHostDxe.c
@@ -375,7 +375,7 @@ MMCSendCommand (
   if (PollRegisterWithMask (MMCHS_PRES_STATE,
     CmdSendOKMask, 0) == EFI_TIMEOUT) {
     DEBUG ((DEBUG_ERROR, "%a(%u): not ready for MMC_CMD%u PresState 0x%x MmcStatus 0x%x\n",
-      __FUNCTION__, __LINE__, MMC_CMD_NUM (MmcCmd),
+      __func__, __LINE__, MMC_CMD_NUM (MmcCmd),
       MmioRead32 (MMCHS_PRES_STATE), MmioRead32 (MMCHS_INT_STAT)));
     Status = EFI_TIMEOUT;
     goto Exit;
@@ -418,7 +418,7 @@ MMCSendCommand (
       //
       if (MmcCmd != CMD_IO_SEND_OP_COND) {
         DEBUG ((DEBUG_ERROR, "%a(%u): MMC_CMD%u ERRI MmcStatus 0x%x\n",
-          __FUNCTION__, __LINE__, MMC_CMD_NUM (MmcCmd), MmcStatus));
+          __func__, __LINE__, MMC_CMD_NUM (MmcCmd), MmcStatus));
       }
 
       SoftReset (SRC);
@@ -441,7 +441,7 @@ MMCSendCommand (
 
   if (RetryCount == MAX_RETRY_COUNT) {
     DEBUG ((DEBUG_ERROR, "%a(%u): MMC_CMD%u completion TIMEOUT PresState 0x%x MmcStatus 0x%x\n",
-      __FUNCTION__, __LINE__, MMC_CMD_NUM (MmcCmd),
+      __func__, __LINE__, MMC_CMD_NUM (MmcCmd),
       MmioRead32 (MMCHS_PRES_STATE), MmcStatus));
     Status = EFI_TIMEOUT;
     goto Exit;
@@ -691,15 +691,15 @@ MMCReadBlockData (
   UINTN Count;
 
   DEBUG ((DEBUG_VERBOSE, "%a(%u): LBA: 0x%x, Length: 0x%x, Buffer: 0x%x)\n",
-    __FUNCTION__, __LINE__, Lba, Length, Buffer));
+    __func__, __LINE__, Lba, Length, Buffer));
 
   if (Buffer == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a(%u): NULL Buffer\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "%a(%u): NULL Buffer\n", __func__, __LINE__));
     return EFI_INVALID_PARAMETER;
   }
 
   if (Length % sizeof (UINT32) != 0) {
-    DEBUG ((DEBUG_ERROR, "%a(%u): bad Length %u\n", __FUNCTION__, __LINE__, Length));
+    DEBUG ((DEBUG_ERROR, "%a(%u): bad Length %u\n", __func__, __LINE__, Length));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -730,7 +730,7 @@ MMCReadBlockData (
 
     if (RetryCount == MAX_RETRY_COUNT) {
       DEBUG ((DEBUG_ERROR, "%a(%u): %lu/%lu MMCHS_INT_STAT: %08x\n",
-        __FUNCTION__, __LINE__, Length - RemLength, Length, MmcStatus));
+        __func__, __LINE__, Length - RemLength, Length, MmcStatus));
       return EFI_TIMEOUT;
     }
 
@@ -755,15 +755,15 @@ MMCWriteBlockData (
   UINTN Count;
 
   DEBUG ((DEBUG_VERBOSE, "%a(%u): LBA: 0x%x, Length: 0x%x, Buffer: 0x%x)\n",
-    __FUNCTION__, __LINE__, Lba, Length, Buffer));
+    __func__, __LINE__, Lba, Length, Buffer));
 
   if (Buffer == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a(%u): NULL Buffer\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "%a(%u): NULL Buffer\n", __func__, __LINE__));
     return EFI_INVALID_PARAMETER;
   }
 
   if (Length % sizeof (UINT32) != 0) {
-    DEBUG ((DEBUG_ERROR, "%a(%u): bad Length %u\n", __FUNCTION__, __LINE__, Length));
+    DEBUG ((DEBUG_ERROR, "%a(%u): bad Length %u\n", __func__, __LINE__, Length));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -794,7 +794,7 @@ MMCWriteBlockData (
 
     if (RetryCount == MAX_RETRY_COUNT) {
       DEBUG ((DEBUG_ERROR, "%a(%u): %lu/%lu MMCHS_INT_STAT: %08x\n",
-        __FUNCTION__, __LINE__, Length - RemLength, Length, MmcStatus));
+        __func__, __LINE__, Length - RemLength, Length, MmcStatus));
       return EFI_TIMEOUT;
     }
 

--- a/Platform/RaspberryPi/Drivers/ConfigDxe/ConfigDxe.c
+++ b/Platform/RaspberryPi/Drivers/ConfigDxe/ConfigDxe.c
@@ -428,7 +428,7 @@ SetupVariables (
     //
     Status = mFwProtocol->GetMacAddress (mMacAddress.Addr);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_WARN, "%a: failed to retrieve MAC address\n", __FUNCTION__));
+      DEBUG ((DEBUG_WARN, "%a: failed to retrieve MAC address\n", __func__));
     }
   }
 

--- a/Platform/RaspberryPi/Drivers/ConfigDxe/XhciQuirk.c
+++ b/Platform/RaspberryPi/Drivers/ConfigDxe/XhciQuirk.c
@@ -70,7 +70,7 @@ PciIoNotificationEvent (
                                &DeviceNumber, &FunctionNumber);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_WARN, "%a: failed to get SBDF for xHCI controller: %r\n",
-            __FUNCTION__, Status));
+            __func__, Status));
     return;
   }
 
@@ -81,7 +81,7 @@ PciIoNotificationEvent (
   Status = FwProtocol->NotifyXhciReset(BusNumber, DeviceNumber, FunctionNumber);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_WARN, "%a: couldn't signal xHCI firmware load: %r\n",
-            __FUNCTION__, Status));
+            __func__, Status));
   }
 }
 

--- a/Platform/RaspberryPi/Drivers/DisplayDxe/Screenshot.c
+++ b/Platform/RaspberryPi/Drivers/DisplayDxe/Screenshot.c
@@ -122,7 +122,7 @@ FindWritableFs (
 
     Status = SimpleFs->OpenVolume (SimpleFs, &Fs);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a OpenVolume[%u] returned %r\n", __FUNCTION__, Index, Status));
+      DEBUG ((DEBUG_ERROR, "%a OpenVolume[%u] returned %r\n", __func__, Index, Status));
       continue;
     }
 
@@ -130,7 +130,7 @@ FindWritableFs (
                    EFI_FILE_MODE_CREATE | EFI_FILE_MODE_READ |
                    EFI_FILE_MODE_WRITE, 0);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a Open[%u] returned %r\n", __FUNCTION__, Index, Status));
+      DEBUG ((DEBUG_ERROR, "%a Open[%u] returned %r\n", __func__, Index, Status));
       continue;
     }
 
@@ -285,7 +285,7 @@ ProcessScreenshotHandler (
                              &Handle
                            );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: couldn't register key notification: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: couldn't register key notification: %r\n", __func__, Status));
     return Status;
   }
 
@@ -355,7 +355,7 @@ RegisterScreenshotHandlers (
                   OnTextInExInstall, NULL,
                   &TextInExInstallEvent);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: couldn't create protocol install event: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: couldn't create protocol install event: %r\n", __func__, Status));
     return;
   }
 
@@ -363,7 +363,7 @@ RegisterScreenshotHandlers (
                   TextInExInstallEvent,
                   &TextInExInstallRegistration);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: couldn't register protocol install notify: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: couldn't register protocol install notify: %r\n", __func__, Status));
     return;
   }
 }

--- a/Platform/RaspberryPi/Drivers/FdtDxe/FdtDxe.c
+++ b/Platform/RaspberryPi/Drivers/FdtDxe/FdtDxe.c
@@ -43,14 +43,14 @@ FixEthernetAliases (
   //
   Aliases = fdt_path_offset (mFdtImage, "/aliases");
   if (Aliases < 0) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to locate '/aliases'\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to locate '/aliases'\n", __func__));
     return EFI_NOT_FOUND;
   }
   Ethernet = fdt_getprop (mFdtImage, Aliases, "ethernet", NULL);
   Ethernet0 = fdt_getprop (mFdtImage, Aliases, "ethernet0", NULL);
   Alias = Ethernet ? Ethernet : Ethernet0;
   if (!Alias) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to locate 'ethernet[0]' alias\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to locate 'ethernet[0]' alias\n", __func__));
     return EFI_NOT_FOUND;
   }
 
@@ -60,7 +60,7 @@ FixEthernetAliases (
   CopySize = AsciiStrSize (Alias);
   Copy = AllocateCopyPool (CopySize, Alias);
   if (!Copy) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to copy '%a'\n", __FUNCTION__, Alias));
+    DEBUG ((DEBUG_ERROR, "%a: failed to copy '%a'\n", __func__, Alias));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -73,18 +73,18 @@ FixEthernetAliases (
     if (Retval != 0) {
       Status = EFI_NOT_FOUND;
       DEBUG ((DEBUG_ERROR, "%a: failed to create 'ethernet' alias (%d)\n",
-        __FUNCTION__, Retval));
+        __func__, Retval));
     }
-    DEBUG ((DEBUG_INFO, "%a: created 'ethernet' alias '%a'\n", __FUNCTION__, Copy));
+    DEBUG ((DEBUG_INFO, "%a: created 'ethernet' alias '%a'\n", __func__, Copy));
   }
   if (!Ethernet0) {
     Retval = fdt_setprop (mFdtImage, Aliases, "ethernet0", Copy, CopySize);
     if (Retval != 0) {
       Status = EFI_NOT_FOUND;
       DEBUG ((DEBUG_ERROR, "%a: failed to create 'ethernet0' alias (%d)\n",
-        __FUNCTION__, Retval));
+        __func__, Retval));
     }
-    DEBUG ((DEBUG_INFO, "%a: created 'ethernet0' alias '%a'\n", __FUNCTION__, Copy));
+    DEBUG ((DEBUG_INFO, "%a: created 'ethernet0' alias '%a'\n", __func__, Copy));
   }
 
   FreePool (Copy);
@@ -107,7 +107,7 @@ UpdateMacAddress (
   //
   Node = fdt_path_offset (mFdtImage, "ethernet");
   if (Node < 0) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to locate 'ethernet' alias\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to locate 'ethernet' alias\n", __func__));
     return EFI_NOT_FOUND;
   }
 
@@ -116,7 +116,7 @@ UpdateMacAddress (
   //
   Status = mFwProtocol->GetMacAddress (MacAddress);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to retrieve MAC address\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to retrieve MAC address\n", __func__));
     return Status;
   }
 
@@ -124,12 +124,12 @@ UpdateMacAddress (
     sizeof MacAddress);
   if (Retval != 0) {
     DEBUG ((DEBUG_ERROR, "%a: failed to create 'mac-address' property (%d)\n",
-      __FUNCTION__, Retval));
+      __func__, Retval));
     return EFI_NOT_FOUND;
   }
 
   DEBUG ((DEBUG_INFO, "%a: setting MAC address to %02x:%02x:%02x:%02x:%02x:%02x\n",
-    __FUNCTION__, MacAddress[0], MacAddress[1], MacAddress[2], MacAddress[3],
+    __func__, MacAddress[0], MacAddress[1], MacAddress[2], MacAddress[3],
     MacAddress[4], MacAddress[5]));
   return EFI_SUCCESS;
 }
@@ -155,38 +155,38 @@ AddUsbCompatibleProperty (
   // Locate the node that the 'usb' alias refers to
   Node = fdt_path_offset (mFdtImage, "usb");
   if (Node < 0) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to locate 'usb' alias\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to locate 'usb' alias\n", __func__));
     return EFI_NOT_FOUND;
   }
 
   // Get the property list. This is a list of NUL terminated strings.
   List = fdt_getprop (mFdtImage, Node, "compatible", &ListSize);
   if (List == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to locate properties\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to locate properties\n", __func__));
     return EFI_NOT_FOUND;
   }
 
   // Check if the compatible value we plan to add is already present
   if (fdt_stringlist_contains (List, ListSize, NewProp)) {
     DEBUG ((DEBUG_INFO, "%a: property '%a' is already set.\n",
-      __FUNCTION__, NewProp));
+      __func__, NewProp));
     return EFI_SUCCESS;
   }
 
   // Make sure the compatible device is what we expect
   if (!fdt_stringlist_contains (List, ListSize, Prop)) {
     DEBUG ((DEBUG_ERROR, "%a: property '%a' is missing!\n",
-      __FUNCTION__, Prop));
+      __func__, Prop));
     return EFI_NOT_FOUND;
   }
 
   // Add the new NUL terminated entry to our list
   DEBUG ((DEBUG_INFO, "%a: adding '%a' to the properties\n",
-    __FUNCTION__, NewProp));
+    __func__, NewProp));
 
   NewList = AllocatePool (ListSize + sizeof (NewProp));
   if (NewList == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;;
   }
   CopyMem (NewList, List, ListSize);
@@ -197,7 +197,7 @@ AddUsbCompatibleProperty (
   FreePool (NewList);
   if (Retval != 0) {
     DEBUG ((DEBUG_ERROR, "%a: failed to update properties (%d)\n",
-      __FUNCTION__, Retval));
+      __func__, Retval));
     return EFI_NOT_FOUND;
   }
 
@@ -347,7 +347,7 @@ SyncPcie (
 
   Node = fdt_path_offset (mFdtImage, "pcie0");
   if (Node < 0) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to locate 'pcie0' alias\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to locate 'pcie0' alias\n", __func__));
     return EFI_NOT_FOUND;
   }
 
@@ -360,7 +360,7 @@ SyncPcie (
   DmaRanges[5] = cpu_to_fdt32 (0x00000000);
   DmaRanges[6] = cpu_to_fdt32 (0xc0000000);
 
-  DEBUG ((DEBUG_INFO, "%a: Updating PCIe dma-ranges\n",  __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Updating PCIe dma-ranges\n",  __func__));
 
   /*
    * Match dma-ranges with the EDK2+ACPI setup we are using.  This works
@@ -371,7 +371,7 @@ SyncPcie (
                         DmaRanges,  sizeof DmaRanges);
   if (Retval != 0) {
     DEBUG ((DEBUG_ERROR, "%a: failed to locate PCIe 'dma-ranges' property (%d)\n",
-      __FUNCTION__, Retval));
+      __func__, Retval));
     return EFI_NOT_FOUND;
   }
 
@@ -417,7 +417,7 @@ SyncPcie (
   Node = fdt_path_offset (mFdtImage, "/scb/pcie@7d500000/pci");
   if (Node < 0) {
     // This can happen on CM4/etc which doesn't have an onboard XHCI
-    DEBUG ((DEBUG_INFO, "%a: failed to locate /scb/pcie@7d500000/pci\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: failed to locate /scb/pcie@7d500000/pci\n", __func__));
   } else {
     Retval = fdt_del_node (mFdtImage, Node);
     if (Retval != 0) {

--- a/Platform/RaspberryPi/Drivers/MmcDxe/MmcBlockIo.c
+++ b/Platform/RaspberryPi/Drivers/MmcDxe/MmcBlockIo.c
@@ -54,14 +54,14 @@ ValidateWrittenBlockCount (
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD55,
                       MmcHostInstance->CardInfo.RCA << 16);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __func__, __LINE__, Status));
     return Status;
   }
 
   Status = MmcHost->SendCommand (MmcHost, MMC_ACMD22, 0);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n",
-      __FUNCTION__, __LINE__, Status));
+      __func__, __LINE__, Status));
     return Status;
   }
 
@@ -75,7 +75,7 @@ ValidateWrittenBlockCount (
   Status = MmcHost->ReadBlockData (MmcHost, 0, sizeof (Data),
                       (VOID*)Data);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __func__, __LINE__, Status));
     return Status;
   }
 
@@ -88,7 +88,7 @@ ValidateWrittenBlockCount (
                   ((UINT32)Data[3] << 0);
   if (BlocksWritten != Count) {
     DEBUG ((DEBUG_ERROR, "%a(%u): expected %u != gotten %u\n",
-      __FUNCTION__, __LINE__, Count, BlocksWritten));
+      __func__, __LINE__, Count, BlocksWritten));
     if (BlocksWritten == 0) {
       return EFI_DEVICE_ERROR;
     }
@@ -118,7 +118,7 @@ WaitUntilTran (
     Status = MmcHost->SendCommand (MmcHost, MMC_CMD13,
                         MmcHostInstance->CardInfo.RCA << 16);
     if (EFI_ERROR (Status) && Status != EFI_TIMEOUT) {
-      DEBUG ((DEBUG_ERROR, "%a(%u) CMD13 failed: %r\n", __FUNCTION__, __LINE__, Status));
+      DEBUG ((DEBUG_ERROR, "%a(%u) CMD13 failed: %r\n", __func__, __LINE__, Status));
       break;
     }
 
@@ -134,7 +134,7 @@ WaitUntilTran (
   }
 
   if (0 == Timeout) {
-    DEBUG ((DEBUG_ERROR, "%a(%u) card is busy\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "%a(%u) card is busy\n", __func__, __LINE__));
     return EFI_NOT_READY;
   }
 

--- a/Platform/RaspberryPi/Drivers/MmcDxe/MmcIdentification.c
+++ b/Platform/RaspberryPi/Drivers/MmcDxe/MmcIdentification.c
@@ -356,7 +356,7 @@ SdSelect (
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD7,
                       MmcHostInstance->CardInfo.RCA << 16);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: error: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: error: %r\n", __func__, Status));
   }
 
   return Status;
@@ -376,7 +376,7 @@ SdDeselect (
 
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD7, 0);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: error: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: error: %r\n", __func__, Status));
   }
 
   return Status;
@@ -396,13 +396,13 @@ SdGetCsd (
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD9,
                       MmcHostInstance->CardInfo.RCA << 16);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __func__, __LINE__, Status));
     return Status;
   }
 
   Status = MmcHost->ReceiveResponse (MmcHost, MMC_RESPONSE_TYPE_CSD, Response);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a(%u): error %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a(%u): error %r\n", __func__,
       __LINE__, Status));
     return Status;
   }
@@ -437,20 +437,20 @@ SdSet4Bit (
   CmdArg = MmcHostInstance->CardInfo.RCA << 16;
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD55, CmdArg);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __func__, __LINE__, Status));
     return Status;
   }
 
   /* Width: 4 */
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD6, 2);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a(%u): error %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "%a(%u): error %r\n", __func__, __LINE__, Status));
     return Status;
   }
 
   Status = MmcHost->SetIos (MmcHost, 0, BUSWIDTH_4, EMMCBACKWARD);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __func__, __LINE__, Status));
     return Status;
   }
 
@@ -488,7 +488,7 @@ SdSetSpeed (
    */
   Status = MmcHost->SetIos (MmcHost, Speed, 0, EMMCBACKWARD);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: error setting speed %u: %r\n", __FUNCTION__, Speed, Status));
+    DEBUG ((DEBUG_ERROR, "%a: error setting speed %u: %r\n", __func__, Speed, Status));
     return Status;
   }
 
@@ -506,14 +506,14 @@ SdSetSpeed (
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD6, CmdArg);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n",
-      __FUNCTION__, __LINE__, Status));
+      __func__, __LINE__, Status));
     return Status;
   } else {
     Status = MmcHost->ReadBlockData (MmcHost, 0, SWITCH_CMD_DATA_LENGTH,
       Buffer);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n",
-        __FUNCTION__, __LINE__, Status));
+        __func__, __LINE__, Status));
       return Status;
     }
   }
@@ -527,13 +527,13 @@ SdSetSpeed (
   CmdArg = SdSwitchCmdArgument (1, 0xf, 0xf, 0xf, TRUE);
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD6, CmdArg);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __func__, __LINE__, Status));
     return Status;
   } else {
     Status = MmcHost->ReadBlockData (MmcHost, 0,
       SWITCH_CMD_DATA_LENGTH, Buffer);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __FUNCTION__, __LINE__, Status));
+      DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __func__, __LINE__, Status));
       return Status;
     }
 
@@ -561,7 +561,7 @@ SdSetSpeed (
 
   Status = MmcHost->SetIos (MmcHost, Speed, 0, EMMCBACKWARD);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: error setting speed %u: %r\n", __FUNCTION__, Speed, Status));
+    DEBUG ((DEBUG_ERROR, "%a: error setting speed %u: %r\n", __func__, Speed, Status));
     return Status;
   }
 
@@ -585,13 +585,13 @@ SdExecuteScr (
                       MmcHostInstance->CardInfo.RCA << 16);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a (MMC_CMD55): Error and Status = %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     return Status;
   }
   Status = MmcHost->ReceiveResponse (MmcHost, MMC_RESPONSE_TYPE_R1, Response);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a (MMC_CMD55): Error and Status = %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     return Status;
   }
   if ((Response[0] & MMC_STATUS_APP_CMD) == 0) {
@@ -602,7 +602,7 @@ SdExecuteScr (
   Status = MmcHost->SendCommand (MmcHost, MMC_ACMD51, 0);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a (MMC_ACMD51): Error and Status = %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     return Status;
   }
 
@@ -610,7 +610,7 @@ SdExecuteScr (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a (MMC_ACMD51): ReadBlockData Error and Status = %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     return Status;
   }
 

--- a/Platform/RaspberryPi/Drivers/RpiFirmwareDxe/RpiFirmwareDxe.c
+++ b/Platform/RaspberryPi/Drivers/RpiFirmwareDxe/RpiFirmwareDxe.c
@@ -103,7 +103,7 @@ MailboxTransaction (
   //
   if (!DrainMailbox ()) {
     DEBUG ((DEBUG_ERROR, "%a: timeout waiting for mailbox to drain\n",
-      __FUNCTION__));
+      __func__));
     return EFI_TIMEOUT;
   }
 
@@ -112,7 +112,7 @@ MailboxTransaction (
   //
   if (!MailboxWaitForStatusCleared (1U << BCM2836_MBOX_STATUS_FULL)) {
     DEBUG ((DEBUG_ERROR, "%a: timeout waiting for outbox to become empty\n",
-      __FUNCTION__));
+      __func__));
     return EFI_TIMEOUT;
   }
 
@@ -131,7 +131,7 @@ MailboxTransaction (
   //
   if (!MailboxWaitForStatusCleared (1U << BCM2836_MBOX_STATUS_EMPTY)) {
     DEBUG ((DEBUG_ERROR, "%a: timeout waiting for inbox to become full\n",
-      __FUNCTION__));
+      __func__));
     return EFI_TIMEOUT;
   }
 
@@ -184,7 +184,7 @@ RpiFirmwareSetPowerState (
   UINT32                      Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -208,14 +208,14 @@ RpiFirmwareSetPowerState (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     Status = EFI_DEVICE_ERROR;
   }
 
   if (!EFI_ERROR (Status) &&
       PowerState ^ (Cmd->TagBody.PowerState & RPI_MBOX_POWER_STATE_ENABLE)) {
     DEBUG ((DEBUG_ERROR, "%a: failed to %sable power for device %d\n",
-      __FUNCTION__, PowerState ? "en" : "dis", DeviceId));
+      __func__, PowerState ? "en" : "dis", DeviceId));
     Status = EFI_DEVICE_ERROR;
   }
   ReleaseSpinLock (&mMailboxLock);
@@ -250,7 +250,7 @@ RpiFirmwareGetArmMemory (
   UINT32                      Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -271,7 +271,7 @@ RpiFirmwareGetArmMemory (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -309,7 +309,7 @@ RpiFirmwareGetMacAddress (
   UINT32                      Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -329,7 +329,7 @@ RpiFirmwareGetMacAddress (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -365,7 +365,7 @@ RpiFirmwareGetSerial (
   UINT32                      Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -385,7 +385,7 @@ RpiFirmwareGetSerial (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -428,7 +428,7 @@ RpiFirmwareGetModel (
   UINT32                      Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -448,7 +448,7 @@ RpiFirmwareGetModel (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -484,7 +484,7 @@ RpiFirmwareGetModelRevision (
   UINT32                        Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -504,7 +504,7 @@ RpiFirmwareGetModelRevision (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -527,7 +527,7 @@ RpiFirmwareGetFirmwareRevision (
   UINT32                        Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -547,7 +547,7 @@ RpiFirmwareGetFirmwareRevision (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -624,7 +624,7 @@ RPiFirmwareGetModelInstalledMB (
   Status = RpiFirmwareGetModelRevision(&Revision);
   if (EFI_ERROR(Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Could not get the board revision: Status == %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     return EFI_DEVICE_ERROR;
   }
 
@@ -652,7 +652,7 @@ RPiFirmwareGetModelFamily (
   if (EFI_ERROR(Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Could not get the board revision: Status == %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     return EFI_DEVICE_ERROR;
   } else {
     ModelId = (Revision >> 4) & 0xFF;
@@ -692,7 +692,7 @@ RPiFirmwareGetModelFamily (
   if (*ModelFamily == 0) {
     DEBUG ((DEBUG_ERROR,
       "%a: Unknown Raspberry Pi model family : ModelId == 0x%x\n",
-      __FUNCTION__, ModelId));
+      __func__, ModelId));
     return EFI_UNSUPPORTED;
     }
 
@@ -821,7 +821,7 @@ RpiFirmwareGetFbSize (
   UINT32                      Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -841,7 +841,7 @@ RpiFirmwareGetFbSize (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox  transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -863,7 +863,7 @@ RpiFirmwareFreeFb (VOID)
   UINT32             Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -884,7 +884,7 @@ RpiFirmwareFreeFb (VOID)
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -914,7 +914,7 @@ RpiFirmwareAllocFb (
   ASSERT (FbBase != NULL);
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -948,7 +948,7 @@ RpiFirmwareAllocFb (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -983,18 +983,18 @@ RpiFirmwareGetCommmandLine (
 
   if ((BufferSize % sizeof (UINT32)) != 0) {
     DEBUG ((DEBUG_ERROR, "%a: BufferSize must be a multiple of 4\n",
-      __FUNCTION__));
+      __func__));
     return EFI_INVALID_PARAMETER;
   }
 
   if (sizeof (*Cmd) + BufferSize > EFI_PAGES_TO_SIZE (NUM_PAGES)) {
     DEBUG ((DEBUG_ERROR, "%a: BufferSize exceeds size of DMA buffer\n",
-      __FUNCTION__));
+      __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -1013,7 +1013,7 @@ RpiFirmwareGetCommmandLine (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -1021,7 +1021,7 @@ RpiFirmwareGetCommmandLine (
   Cmd->TagHead.TagValueSize &= ~RPI_MBOX_VALUE_SIZE_RESPONSE_MASK;
   if (Cmd->TagHead.TagValueSize >= BufferSize &&
       Cmd->CommandLine[Cmd->TagHead.TagValueSize - 1] != '\0') {
-    DEBUG ((DEBUG_ERROR, "%a: insufficient buffer size\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: insufficient buffer size\n", __func__));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_OUT_OF_RESOURCES;
   }
@@ -1069,7 +1069,7 @@ RpiFirmwareSetClockRate (
   UINT32                      Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -1086,14 +1086,14 @@ RpiFirmwareSetClockRate (
   Cmd->TagBody.SkipTurbo      = SkipTurbo ? 1 : 0;
   Cmd->EndTag                 = 0;
 
-  DEBUG ((DEBUG_INFO, "%a: Request clock rate %X = %d\n", __FUNCTION__, ClockId, ClockRate));
+  DEBUG ((DEBUG_INFO, "%a: Request clock rate %X = %d\n", __func__, ClockId, ClockRate));
   Status = MailboxTransaction (Cmd->BufferHead.BufferSize, RPI_MBOX_VC_CHANNEL, &Result);
 
   if (EFI_ERROR (Status) ||
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -1130,7 +1130,7 @@ RpiFirmwareGetClockRate (
   UINT32                      Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -1151,7 +1151,7 @@ RpiFirmwareGetClockRate (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -1159,7 +1159,7 @@ RpiFirmwareGetClockRate (
   *ClockRate = Cmd->TagBody.ClockRate;
   ReleaseSpinLock (&mMailboxLock);
 
-  DEBUG ((DEBUG_INFO, "%a: Get Clock Rate return: ClockRate=%d ClockId=%X\n", __FUNCTION__, *ClockRate, ClockId));
+  DEBUG ((DEBUG_INFO, "%a: Get Clock Rate return: ClockRate=%d ClockId=%X\n", __func__, *ClockRate, ClockId));
 
   return EFI_SUCCESS;
 }
@@ -1234,7 +1234,7 @@ RpiFirmwareSetClockState (
   UINT32                      Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -1256,7 +1256,7 @@ RpiFirmwareSetClockState (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
     ReleaseSpinLock (&mMailboxLock);
     return EFI_DEVICE_ERROR;
   }
@@ -1293,7 +1293,7 @@ RpiFirmwareSetGpio (
   UINT32              Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return;
   }
 
@@ -1318,7 +1318,7 @@ RpiFirmwareSetGpio (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox  transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
   }
   ReleaseSpinLock (&mMailboxLock);
 }
@@ -1360,7 +1360,7 @@ RpiFirmwareNotifyXhciReset (
   UINT32                       Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -1381,7 +1381,7 @@ RpiFirmwareNotifyXhciReset (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox  transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
   }
 
   ReleaseSpinLock (&mMailboxLock);
@@ -1420,7 +1420,7 @@ RpiFirmwareNotifyGpioGetCfg (
   UINT32                       Result;
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -1444,7 +1444,7 @@ RpiFirmwareNotifyGpioGetCfg (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox  transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
   }
 
   ReleaseSpinLock (&mMailboxLock);
@@ -1487,13 +1487,13 @@ RpiFirmwareNotifyGpioSetCfg (
 
   Status = RpiFirmwareNotifyGpioGetCfg (Gpio, &Result);
   if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to get GPIO polarity\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to get GPIO polarity\n", __func__));
       Result = 0; //default polarity
   }
 
 
   if (!AcquireSpinLockOrFail (&mMailboxLock)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to acquire spinlock\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -1521,7 +1521,7 @@ RpiFirmwareNotifyGpioSetCfg (
       Cmd->BufferHead.Response != RPI_MBOX_RESP_SUCCESS) {
     DEBUG ((DEBUG_ERROR,
       "%a: mailbox  transaction error: Status == %r, Response == 0x%x\n",
-      __FUNCTION__, Status, Cmd->BufferHead.Response));
+      __func__, Status, Cmd->BufferHead.Response));
   }
 
   ReleaseSpinLock (&mMailboxLock);
@@ -1589,7 +1589,7 @@ RpiFirmwareDxeInitialize (
 
   Status = DmaAllocateBuffer (EfiBootServicesData, NUM_PAGES, &mDmaBuffer);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to allocate DMA buffer (Status == %r)\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to allocate DMA buffer (Status == %r)\n", __func__));
     return Status;
   }
 
@@ -1597,7 +1597,7 @@ RpiFirmwareDxeInitialize (
   Status = DmaMap (MapOperationBusMasterCommonBuffer, mDmaBuffer, &BufferSize,
              &mDmaBufferBusAddress, &mDmaBufferMapping);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to map DMA buffer (Status == %r)\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed to map DMA buffer (Status == %r)\n", __func__));
     goto FreeBuffer;
   }
 
@@ -1613,7 +1613,7 @@ RpiFirmwareDxeInitialize (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: failed to install RPI firmware protocol (Status == %r)\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     goto UnmapBuffer;
   }
 

--- a/Platform/RaspberryPi/Drivers/SdHostDxe/SdHostDxe.c
+++ b/Platform/RaspberryPi/Drivers/SdHostDxe/SdHostDxe.c
@@ -388,7 +388,7 @@ SdSendCommand (
     if (MmioRead32 (SDHOST_CMD) & SDHOST_CMD_NEW_FLAG) {
       DEBUG ((DEBUG_MMCHOST_SD_ERROR,
         "%a(%u): CMD%d is still being executed after %d trial(s)\n",
-        __FUNCTION__, __LINE__, MMC_GET_INDX (MmcCmd), RetryCount));
+        __func__, __LINE__, MMC_GET_INDX (MmcCmd), RetryCount));
     }
 
     // Write command and set it to start execution
@@ -445,7 +445,7 @@ SdSendCommand (
       Status = EFI_SUCCESS;
     } else {
       DEBUG ((DEBUG_MMCHOST_SD_ERROR, "%a(%u): CMD%d execution failed after %d trial(s)\n",
-        __FUNCTION__, __LINE__, MMC_GET_INDX (MmcCmd), RetryCount));
+        __func__, __LINE__, MMC_GET_INDX (MmcCmd), RetryCount));
       SdHostDumpStatus ();
     }
 

--- a/Platform/RaspberryPi/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/Platform/RaspberryPi/Library/PlatformBootManagerLib/PlatformBm.c
@@ -246,7 +246,7 @@ FilterAndProcess (
     //
     // This is not an error, just an informative condition.
     //
-    DEBUG ((DEBUG_VERBOSE, "%a: %g: %r\n", __FUNCTION__, ProtocolGuid,
+    DEBUG ((DEBUG_VERBOSE, "%a: %g: %r\n", __func__, ProtocolGuid,
       Status));
     return;
   }
@@ -297,25 +297,25 @@ AddOutput (
   DevicePath = DevicePathFromHandle (Handle);
   if (DevicePath == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: %s: handle %p: device path not found\n",
-      __FUNCTION__, ReportText, Handle));
+      __func__, ReportText, Handle));
     return;
   }
 
   Status = EfiBootManagerUpdateConsoleVariable (ConOut, DevicePath, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ConOut: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ConOut: %r\n", __func__,
       ReportText, Status));
     return;
   }
 
   Status = EfiBootManagerUpdateConsoleVariable (ErrOut, DevicePath, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ErrOut: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ErrOut: %r\n", __func__,
       ReportText, Status));
     return;
   }
 
-  DEBUG ((DEBUG_VERBOSE, "%a: %s: added to ConOut and ErrOut\n", __FUNCTION__,
+  DEBUG ((DEBUG_VERBOSE, "%a: %s: added to ConOut and ErrOut\n", __func__,
     ReportText));
 }
 
@@ -340,7 +340,7 @@ Connect (
                   FALSE   // Recursive
                   );
   DEBUG ((EFI_ERROR (Status) ? DEBUG_ERROR : DEBUG_VERBOSE, "%a: %s: %r\n",
-    __FUNCTION__, ReportText, Status));
+    __func__, ReportText, Status));
 }
 
 STATIC
@@ -459,7 +459,7 @@ RemoveStaleBootOptions (
       DEBUG ((
         EFI_ERROR (Status) ? DEBUG_WARN : DEBUG_INFO,
         "%a: removing stale Boot#%04x %s: %r\n",
-        __FUNCTION__,
+        __func__,
         (UINT32)BootOptions[Index].OptionNumber,
         DevicePathString == NULL ? L"<unavailable>" : DevicePathString,
         Status
@@ -734,7 +734,7 @@ BootDiscoveryPolicyHandler (
       DEBUG ((
         DEBUG_INFO,
         "%a - Unexpected DiscoveryPolicy (0x%x). Run Minimal Discovery Policy\n",
-        __FUNCTION__,
+        __func__,
         DiscoveryPolicy
         ));
       return EFI_SUCCESS;
@@ -746,13 +746,13 @@ BootDiscoveryPolicyHandler (
                   (VOID **)&BMPolicy
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - Failed to locate gEfiBootManagerPolicyProtocolGuid - %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a - Failed to locate gEfiBootManagerPolicyProtocolGuid - %r\n", __func__, Status));
     return Status;
   }
 
   Status = BMPolicy->ConnectDeviceClass (BMPolicy, Class);
   if (EFI_ERROR (Status)){
-    DEBUG ((DEBUG_ERROR, "%a - ConnectDeviceClass returns - %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a - ConnectDeviceClass returns - %r\n", __func__, Status));
     return Status;
   }
 
@@ -926,7 +926,7 @@ PlatformBootManagerUnableToBoot (
   //
   if (NewBootOptionCount != OldBootOptionCount) {
     DEBUG ((DEBUG_WARN, "%a: rebooting after refreshing all boot options\n",
-      __FUNCTION__));
+      __func__));
     gRT->ResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
   }
 

--- a/Platform/RaspberryPi/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/Platform/RaspberryPi/Library/PlatformBootManagerLib/PlatformBm.c
@@ -339,7 +339,7 @@ Connect (
                   NULL,   // RemainingDevicePath -- produce all children
                   FALSE   // Recursive
                   );
-  DEBUG ((EFI_ERROR (Status) ? EFI_D_ERROR : EFI_D_VERBOSE, "%a: %s: %r\n",
+  DEBUG ((EFI_ERROR (Status) ? DEBUG_ERROR : DEBUG_VERBOSE, "%a: %s: %r\n",
     __FUNCTION__, ReportText, Status));
 }
 
@@ -457,7 +457,7 @@ RemoveStaleBootOptions (
 
       DevicePathString = ConvertDevicePathToText(BootOptions[Index].FilePath, FALSE, FALSE);
       DEBUG ((
-        EFI_ERROR (Status) ? EFI_D_WARN : EFI_D_INFO,
+        EFI_ERROR (Status) ? DEBUG_WARN : DEBUG_INFO,
         "%a: removing stale Boot#%04x %s: %r\n",
         __FUNCTION__,
         (UINT32)BootOptions[Index].OptionNumber,

--- a/Platform/SiFive/U5SeriesPkg/Library/PeiCoreInfoHobLib/CoreInfoHob.c
+++ b/Platform/SiFive/U5SeriesPkg/Library/PeiCoreInfoHobLib/CoreInfoHob.c
@@ -106,7 +106,7 @@ CreateU5MCProcessorSmbiosDataHob (
   RISC_V_PROCESSOR_TYPE7_HOB_DATA *L2CacheDataHobPtr;
   RISC_V_PROCESSOR_SMBIOS_HOB_DATA *SmbiosDataHobPtr;
 
-  DEBUG ((DEBUG_INFO, "%a: Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry\n", __func__));
 
   if (SmbiosHobPtr == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -154,7 +154,7 @@ CreateU5MCProcessorSmbiosDataHob (
     ASSERT (FALSE);
   }
   *SmbiosHobPtr = SmbiosDataHobPtr;
-  DEBUG ((DEBUG_INFO, "%a: Exit\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Exit\n", __func__));
 
   return EFI_SUCCESS;
 }

--- a/Platform/SiFive/U5SeriesPkg/Library/PlatformSecPpiLib/PlatformSecPpiLib.c
+++ b/Platform/SiFive/U5SeriesPkg/Library/PlatformSecPpiLib/PlatformSecPpiLib.c
@@ -87,7 +87,7 @@ TemporaryRamMigration (
 
   DEBUG ((DEBUG_INFO,
     "%a: Temp Mem Base:0x%Lx, Permanent Mem Base:0x%Lx, CopySize:0x%Lx\n",
-    __FUNCTION__,
+    __func__,
     TemporaryMemoryBase,
     PermanentMemoryBase,
     (UINT64)CopySize
@@ -113,7 +113,7 @@ TemporaryRamMigration (
   // Relocate PEI Service **
   //
   FirmwareContext->PeiServiceTable += (unsigned long)((UINTN)NewStack - (UINTN)OldStack);
-  DEBUG ((DEBUG_INFO, "%a: OpenSBI Firmware Context is relocated to 0x%x\n", __FUNCTION__, FirmwareContext));
+  DEBUG ((DEBUG_INFO, "%a: OpenSBI Firmware Context is relocated to 0x%x\n", __func__, FirmwareContext));
   DEBUG ((DEBUG_INFO, "OpenSBI Firmware Context at 0x%x\n", FirmwareContext));
   DEBUG ((DEBUG_INFO, "             PEI Service at 0x%x\n\n", FirmwareContext->PeiServiceTable));
 
@@ -129,7 +129,7 @@ EFI_STATUS EFIAPI TemporaryRamDone (
   VOID
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: 2nd time PEI core, temporary ram done.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: 2nd time PEI core, temporary ram done.\n", __func__));
   return EFI_SUCCESS;
 }
 /** Return platform SEC PPI before PEI Core

--- a/Platform/Socionext/DeveloperBox/SmbiosPlatformDxe/SmbiosPlatformDxe.c
+++ b/Platform/Socionext/DeveloperBox/SmbiosPlatformDxe/SmbiosPlatformDxe.c
@@ -902,7 +902,7 @@ InstallAllStructures (
     Status = mSmbios->Add (mSmbios, NULL, &SmbiosHandle, FixedTables[Idx]);
     if (EFI_ERROR(Status)) {
       DEBUG ((DEBUG_WARN, "%a: failed to add SMBIOS type %u table - %r\n",
-        __FUNCTION__, FixedTables[Idx]->Type, Status));
+        __func__, FixedTables[Idx]->Type, Status));
       break;
     }
   }
@@ -914,7 +914,7 @@ InstallAllStructures (
   Status = InstallMemoryDeviceStructure();
   if (EFI_ERROR(Status)) {
       DEBUG ((DEBUG_WARN, "%a: failed to add SMBIOS type 17 table - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
   }
 
   for (Hob.Raw = GetHobList ();
@@ -926,7 +926,7 @@ InstallAllStructures (
                                        Hob.ResourceDescriptor->ResourceLength);
       if (EFI_ERROR(Status)) {
         DEBUG ((DEBUG_WARN, "%a: failed to add SMBIOS type 19 table - %r\n",
-          __FUNCTION__, Status));
+          __func__, Status));
         break;
       }
     }

--- a/Platform/SolidRun/Armada80x0McBin/NonDiscoverableInitLib/NonDiscoverableInitLib.c
+++ b/Platform/SolidRun/Armada80x0McBin/NonDiscoverableInitLib/NonDiscoverableInitLib.c
@@ -40,7 +40,7 @@ XhciInit (
 
   Status = MvGpioGetProtocol (MV_GPIO_DRIVER_TYPE_SOC_CONTROLLER, &GpioProtocol);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Unable to find GPIO protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Unable to find GPIO protocol\n", __func__));
     return Status;
   }
 

--- a/Platform/SolidRun/Cn913xCEx7Eval/NonDiscoverableInitLib/NonDiscoverableInitLib.c
+++ b/Platform/SolidRun/Cn913xCEx7Eval/NonDiscoverableInitLib/NonDiscoverableInitLib.c
@@ -39,7 +39,7 @@ ConfigurePins (
 
   Status = MvGpioGetProtocol (DriverType, &GpioProtocol);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Unable to find GPIO protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Unable to find GPIO protocol\n", __func__));
     return Status;
   }
 

--- a/Silicon/AMD/Styx/Drivers/PlatInitDxe/PlatInitDxe.c
+++ b/Silicon/AMD/Styx/Drivers/PlatInitDxe/PlatInitDxe.c
@@ -76,7 +76,7 @@ PlatInitDxeEntryPoint (
   UINTN                     ArmCoreCount;
   EFI_HANDLE                Handle = NULL;
 
-  DEBUG ((EFI_D_ERROR, "PlatInitDxe Loaded\n"));
+  DEBUG ((DEBUG_ERROR, "PlatInitDxe Loaded\n"));
 
   // Get core information
   ArmCoreCount = 0;

--- a/Silicon/AMD/Styx/Drivers/PlatInitPei/PlatInitPei.c
+++ b/Silicon/AMD/Styx/Drivers/PlatInitPei/PlatInitPei.c
@@ -121,12 +121,12 @@ PlatInitPeiEntryPoint (
   UINTN                       Index, CoreNum;
   UINT32                      *CpuIdReg = (UINT32 *)FixedPcdGet32 (PcdCpuIdRegister);
 
-  DEBUG ((EFI_D_ERROR, "PlatInit PEIM Loaded\n"));
+  DEBUG ((DEBUG_ERROR, "PlatInit PEIM Loaded\n"));
 
   // CPUID
   Status = PcdSet32S (PcdSocCpuId, *CpuIdReg);
   ASSERT_EFI_ERROR (Status);
-  DEBUG ((EFI_D_ERROR, "SocCpuId = 0x%X\n", PcdGet32 (PcdSocCpuId)));
+  DEBUG ((DEBUG_ERROR, "SocCpuId = 0x%X\n", PcdGet32 (PcdSocCpuId)));
 
   // Update core count based on PCD option
   if (mAmdCoreCount > PcdGet32 (PcdSocCoreCount)) {
@@ -169,7 +169,7 @@ PlatInitPeiEntryPoint (
       mAmdMpCoreInfoTable[Index].Mpidr = GET_MPID (CpuResetInfo.CoreStatus.ClusterId,
 		                           CpuResetInfo.CoreStatus.CoreId);
 
-      DEBUG ((EFI_D_ERROR, "Core[%d]: ClusterId = %d   CoreId = %d\n",
+      DEBUG ((DEBUG_ERROR, "Core[%d]: ClusterId = %d   CoreId = %d\n",
         Index, GET_MPIDR_AFF1 (mAmdMpCoreInfoTable[Index].Mpidr),
         GET_MPIDR_AFF0 (mAmdMpCoreInfoTable[Index].Mpidr)));
 
@@ -191,7 +191,7 @@ PlatInitPeiEntryPoint (
     ASSERT_EFI_ERROR (Status);
   }
 
-  DEBUG ((EFI_D_ERROR, "SocCoreCount = %d\n", PcdGet32 (PcdSocCoreCount)));
+  DEBUG ((DEBUG_ERROR, "SocCoreCount = %d\n", PcdGet32 (PcdSocCoreCount)));
 
   // Build AmdMpCoreInfo HOB
   BuildGuidDataHob (&gAmdStyxMpCoreInfoGuid, mAmdMpCoreInfoTable, sizeof (ARM_CORE_INFO) * mAmdCoreCount);
@@ -207,10 +207,10 @@ PlatInitPeiEntryPoint (
     ASSERT_EFI_ERROR (Status);
   }
   if (IscpMemDescriptor.Size0 == 0) {
-    DEBUG ((EFI_D_ERROR, "Warning: Could not get SystemMemorySize via ISCP, using default value.\n"));
+    DEBUG ((DEBUG_ERROR, "Warning: Could not get SystemMemorySize via ISCP, using default value.\n"));
   }
 
-  DEBUG ((EFI_D_ERROR, "SystemMemorySize = %ld\n", PcdGet64 (PcdSystemMemorySize)));
+  DEBUG ((DEBUG_ERROR, "SystemMemorySize = %ld\n", PcdGet64 (PcdSystemMemorySize)));
 
 
   if (FixedPcdGetBool (PcdXgbeEnable)) {
@@ -232,11 +232,11 @@ PlatInitPeiEntryPoint (
       ASSERT_EFI_ERROR (Status);
     }
 
-    DEBUG ((EFI_D_ERROR, "EthMacA = %02x:%02x:%02x:%02x:%02x:%02x\n",
+    DEBUG ((DEBUG_ERROR, "EthMacA = %02x:%02x:%02x:%02x:%02x:%02x\n",
       ((UINT8 *)PcdGetPtr (PcdEthMacA))[0], ((UINT8 *)PcdGetPtr (PcdEthMacA))[1],
       ((UINT8 *)PcdGetPtr (PcdEthMacA))[2], ((UINT8 *)PcdGetPtr (PcdEthMacA))[3],
       ((UINT8 *)PcdGetPtr (PcdEthMacA))[4], ((UINT8 *)PcdGetPtr (PcdEthMacA))[5]));
-    DEBUG ((EFI_D_ERROR, "EthMacB = %02x:%02x:%02x:%02x:%02x:%02x\n",
+    DEBUG ((DEBUG_ERROR, "EthMacB = %02x:%02x:%02x:%02x:%02x:%02x\n",
       ((UINT8 *)PcdGetPtr (PcdEthMacB))[0], ((UINT8 *)PcdGetPtr (PcdEthMacB))[1],
       ((UINT8 *)PcdGetPtr (PcdEthMacB))[2], ((UINT8 *)PcdGetPtr (PcdEthMacB))[3],
       ((UINT8 *)PcdGetPtr (PcdEthMacB))[4], ((UINT8 *)PcdGetPtr (PcdEthMacB))[5]));

--- a/Silicon/AMD/Styx/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.c
+++ b/Silicon/AMD/Styx/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.c
@@ -631,7 +631,7 @@ ProcessorInfoUpdateSmbiosType4 (
 {
   ISCP_TYPE4_SMBIOS_INFO *SmbiosT4 = &mSmbiosInfo.SmbiosCpuBuffer.T4[0];
 
-  DEBUG ((EFI_D_ERROR, "Logging SmbiosType4 from ISCP.\n"));
+  DEBUG ((DEBUG_ERROR, "Logging SmbiosType4 from ISCP.\n"));
 
   mProcessorInfoType4.ProcessorType = SmbiosT4->T4ProcType;
   mProcessorInfoType4.ProcessorFamily = SmbiosT4->T4ProcFamily;
@@ -667,7 +667,7 @@ CacheInfoUpdateSmbiosType7 (
   ISCP_TYPE7_SMBIOS_INFO *SmbiosT7;
   SMBIOS_TABLE_TYPE7 dstType7 = {{0}};
 
-  DEBUG ((EFI_D_ERROR, "Logging SmbiosType7 from ISCP.\n"));
+  DEBUG ((DEBUG_ERROR, "Logging SmbiosType7 from ISCP.\n"));
 
   CopyMem ((VOID *) &dstType7.Hdr, (VOID *) &mCacheInfoType7.Hdr, sizeof (SMBIOS_STRUCTURE));
   dstType7.SocketDesignation = 1;  // "L# Cache"
@@ -744,7 +744,7 @@ PhyMemArrayInfoUpdateSmbiosType16 (
 {
   ISCP_TYPE16_SMBIOS_INFO *SmbiosT16 = &mSmbiosInfo.SmbiosMemBuffer.T16;
 
-  DEBUG ((EFI_D_ERROR, "Logging SmbiosType16 from ISCP.\n"));
+  DEBUG ((DEBUG_ERROR, "Logging SmbiosType16 from ISCP.\n"));
 
   mPhyMemArrayInfoType16.Location = SmbiosT16->Location;
   mPhyMemArrayInfoType16.Use = SmbiosT16->Use;
@@ -767,7 +767,7 @@ MemDevInfoUpdatedstType17 (
   ISCP_TYPE17_SMBIOS_INFO *srcType17;
   UINTN i, j, StrIndex, LastIndex;
 
-  DEBUG ((EFI_D_ERROR, "Logging SmbiosType17 from ISCP.\n"));
+  DEBUG ((DEBUG_ERROR, "Logging SmbiosType17 from ISCP.\n"));
 
   LastIndex = (sizeof(mMemDevInfoType17Strings) / sizeof (CHAR8 *)) - 1;
   for (i = 0; i < 2; ++i) {
@@ -844,7 +844,7 @@ MemArrMapInfoUpdateSmbiosType19 (
 {
   ISCP_TYPE19_SMBIOS_INFO *SmbiosT19 = &mSmbiosInfo.SmbiosMemBuffer.T19;
 
-  DEBUG ((EFI_D_ERROR, "Logging SmbiosType19 from ISCP.\n"));
+  DEBUG ((DEBUG_ERROR, "Logging SmbiosType19 from ISCP.\n"));
 
   mMemArrMapInfoType19.StartingAddress = SmbiosT19->StartingAddr;
   mMemArrMapInfoType19.EndingAddress = SmbiosT19->EndingAddr;
@@ -881,7 +881,7 @@ PlatformSmbiosDriverEntryPoint (
 {
   EFI_STATUS Status;
 
-  DEBUG ((EFI_D_ERROR, "PlatformSmbiosDxe Loaded\n"));
+  DEBUG ((DEBUG_ERROR, "PlatformSmbiosDxe Loaded\n"));
 
   //
   // Locate Smbios protocol
@@ -894,7 +894,7 @@ PlatformSmbiosDriverEntryPoint (
 
   if (EFI_ERROR (Status)) {
     mSmbiosProtocol = NULL;
-    DEBUG ((EFI_D_ERROR, "Failed to Locate SMBIOS Protocol"));
+    DEBUG ((DEBUG_ERROR, "Failed to Locate SMBIOS Protocol"));
     return Status;
   }
 
@@ -905,7 +905,7 @@ PlatformSmbiosDriverEntryPoint (
                );
   if (EFI_ERROR (Status)) {
     mIscpDxeProtocol = NULL;
-    DEBUG ((EFI_D_ERROR, "Failed to Locate ISCP DXE Protocol"));
+    DEBUG ((DEBUG_ERROR, "Failed to Locate ISCP DXE Protocol"));
     return Status;
   }
 
@@ -914,7 +914,7 @@ PlatformSmbiosDriverEntryPoint (
                     &mSmbiosInfo
                     );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Failed to get SMBIOS data via ISCP"));
+    DEBUG ((DEBUG_ERROR, "Failed to get SMBIOS data via ISCP"));
     return Status;
   }
 

--- a/Silicon/AMD/Styx/Drivers/StyxSataPlatformDxe/InitController.c
+++ b/Silicon/AMD/Styx/Drivers/StyxSataPlatformDxe/InitController.c
@@ -161,7 +161,7 @@ StyxSataPlatformDxeEntryPoint (
              FixedPcdGet8(PcdSata0PortCount), 0);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_WARN, "%a: failed to initialize primary SATA controller!\n",
-      __FUNCTION__));
+      __func__));
     return Status;
   }
 
@@ -186,7 +186,7 @@ StyxSataPlatformDxeEntryPoint (
                FixedPcdGet8(PcdSata0PortCount));
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_WARN, "%a: failed to initialize secondary SATA controller!\n",
-        __FUNCTION__));
+        __func__));
     } else {
       for (PortNum = 0; PortNum < FixedPcdGet8(PcdSata1PortCount); PortNum++) {
           SetPrdSingleSata1 (PortNum);

--- a/Silicon/AMD/Styx/Drivers/StyxSpiFvDxe/StyxSpiFvDxe.c
+++ b/Silicon/AMD/Styx/Drivers/StyxSpiFvDxe/StyxSpiFvDxe.c
@@ -474,7 +474,7 @@ StyxSpiFvDxeInitialize (
 
   DEBUG ((DEBUG_INFO,
     "%a: Using NV store FV in-memory copy at 0x%lx, LBA offset == 0x%lx\n",
-    __FUNCTION__, mNvStorageBase, mNvStorageLbaOffset));
+    __func__, mNvStorageBase, mNvStorageLbaOffset));
 
   Status = gBS->LocateProtocol (&gAmdIscpDxeProtocolGuid, NULL,
                   (VOID **)&mIscpDxeProtocol);

--- a/Silicon/AMD/Styx/Drivers/StyxSpiFvDxe/StyxSpiFvDxe.c
+++ b/Silicon/AMD/Styx/Drivers/StyxSpiFvDxe/StyxSpiFvDxe.c
@@ -472,7 +472,7 @@ StyxSpiFvDxeInitialize (
   mNvStorageLbaOffset = (FixedPcdGet64 (PcdFlashNvStorageOriginalBase) -
                          SPI_BASE) / BLOCK_SIZE;
 
-  DEBUG ((EFI_D_INFO,
+  DEBUG ((DEBUG_INFO,
     "%a: Using NV store FV in-memory copy at 0x%lx, LBA offset == 0x%lx\n",
     __FUNCTION__, mNvStorageBase, mNvStorageLbaOffset));
 

--- a/Silicon/AMD/Styx/Library/AmdStyxLib/StyxMem.c
+++ b/Silicon/AMD/Styx/Library/AmdStyxLib/StyxMem.c
@@ -34,7 +34,7 @@ static const char *tblAttrDesc[] =
 };
 #endif
 
-#define LOG_MEM(desc) DEBUG ((EFI_D_ERROR, desc, VirtualMemoryTable[Index].PhysicalBase, \
+#define LOG_MEM(desc) DEBUG ((DEBUG_ERROR, desc, VirtualMemoryTable[Index].PhysicalBase, \
                             ( VirtualMemoryTable[Index].PhysicalBase+VirtualMemoryTable[Index].Length - 1), \
                              VirtualMemoryTable[Index].Length, tblAttrDesc[VirtualMemoryTable[Index].Attributes]));
 
@@ -74,8 +74,8 @@ ArmPlatformGetVirtualMemoryMap (
 
   CacheAttributes = DDR_ATTRIBUTES_CACHED;
 
-  DEBUG ((EFI_D_ERROR, " Memory Map\n------------------------------------------------------------------------\n"));
-  DEBUG ((EFI_D_ERROR, "Description                    :        START       -        END         [        SIZE        ]    {              ATTR             }\n"));
+  DEBUG ((DEBUG_ERROR, " Memory Map\n------------------------------------------------------------------------\n"));
+  DEBUG ((DEBUG_ERROR, "Description                    :        START       -        END         [        SIZE        ]    {              ATTR             }\n"));
 
   // 0xE000_0000 - 0xEFFF_FFFF: Mapped I/O space
   VirtualMemoryTable[Index].PhysicalBase   = 0xE0000000UL;

--- a/Silicon/AMD/Styx/Library/AmdStyxPciHostBridgeLib/AmdStyxPciHostBridgeLib.c
+++ b/Silicon/AMD/Styx/Library/AmdStyxPciHostBridgeLib/AmdStyxPciHostBridgeLib.c
@@ -154,24 +154,24 @@ PciHostBridgeResourceConflict (
 {
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *Descriptor;
   UINTN                             RootBridgeIndex;
-  DEBUG ((EFI_D_ERROR, "PciHostBridge: Resource conflict happens!\n"));
+  DEBUG ((DEBUG_ERROR, "PciHostBridge: Resource conflict happens!\n"));
 
   RootBridgeIndex = 0;
   Descriptor = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *) Configuration;
   while (Descriptor->Desc == ACPI_ADDRESS_SPACE_DESCRIPTOR) {
-    DEBUG ((EFI_D_ERROR, "RootBridge[%d]:\n", RootBridgeIndex++));
+    DEBUG ((DEBUG_ERROR, "RootBridge[%d]:\n", RootBridgeIndex++));
     for (; Descriptor->Desc == ACPI_ADDRESS_SPACE_DESCRIPTOR; Descriptor++) {
       ASSERT (Descriptor->ResType <
               (sizeof (mPciHostBridgeLibAcpiAddressSpaceTypeStr) /
                sizeof (mPciHostBridgeLibAcpiAddressSpaceTypeStr[0])
                )
               );
-      DEBUG ((EFI_D_ERROR, " %s: Length/Alignment = 0x%lx / 0x%lx\n",
+      DEBUG ((DEBUG_ERROR, " %s: Length/Alignment = 0x%lx / 0x%lx\n",
               mPciHostBridgeLibAcpiAddressSpaceTypeStr[Descriptor->ResType],
               Descriptor->AddrLen, Descriptor->AddrRangeMax
               ));
       if (Descriptor->ResType == ACPI_ADDRESS_SPACE_TYPE_MEM) {
-        DEBUG ((EFI_D_ERROR, "     Granularity/SpecificFlag = %ld / %02x%s\n",
+        DEBUG ((DEBUG_ERROR, "     Granularity/SpecificFlag = %ld / %02x%s\n",
                 Descriptor->AddrSpaceGranularity, Descriptor->SpecificFlag,
                 ((Descriptor->SpecificFlag &
                   EFI_ACPI_MEMORY_RESOURCE_SPECIFIC_FLAG_CACHEABLE_PREFETCHABLE

--- a/Silicon/AMD/Styx/Library/MemoryInitPei/MemoryInitPeiLib.c
+++ b/Silicon/AMD/Styx/Library/MemoryInitPei/MemoryInitPeiLib.c
@@ -76,7 +76,7 @@ MoveNvStoreImage (
   CopyMem (NewBase, OldBase, Size);
 
   DEBUG ((DEBUG_INFO, "%a: Relocating NV store FV from %p to %p\n",
-    __FUNCTION__, OldBase, NewBase));
+    __func__, OldBase, NewBase));
 
   Status = PcdSet64S (PcdFlashNvStorageVariableBase64, (UINT64)NewBase);
   ASSERT_EFI_ERROR (Status);

--- a/Silicon/AMD/Styx/Library/MemoryInitPei/MemoryInitPeiLib.c
+++ b/Silicon/AMD/Styx/Library/MemoryInitPei/MemoryInitPeiLib.c
@@ -45,7 +45,7 @@ InitMmu (
   //       of DRAM as it is the first permanent memory allocation)
   Status = ArmConfigureMmu (MemoryTable, &TranslationTableBase, &TranslationTableSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Error: Failed to enable MMU\n"));
+    DEBUG ((DEBUG_ERROR, "Error: Failed to enable MMU\n"));
   }
 }
 
@@ -75,7 +75,7 @@ MoveNvStoreImage (
 
   CopyMem (NewBase, OldBase, Size);
 
-  DEBUG ((EFI_D_INFO, "%a: Relocating NV store FV from %p to %p\n",
+  DEBUG ((DEBUG_INFO, "%a: Relocating NV store FV from %p to %p\n",
     __FUNCTION__, OldBase, NewBase));
 
   Status = PcdSet64S (PcdFlashNvStorageVariableBase64, (UINT64)NewBase);

--- a/Silicon/AMD/Styx/Library/RealTimeClockLib/RealTimeClockLib.c
+++ b/Silicon/AMD/Styx/Library/RealTimeClockLib/RealTimeClockLib.c
@@ -55,7 +55,7 @@ LibGetTime (
   EFI_STATUS     Status;
 
   if (mRtcIscpDxeProtocol == NULL) {
-      DEBUG((EFI_D_ERROR, "RTC: ISCP DXE Protocol is NULL!\n"));
+      DEBUG((DEBUG_ERROR, "RTC: ISCP DXE Protocol is NULL!\n"));
       return EFI_DEVICE_ERROR;
   }
 
@@ -67,7 +67,7 @@ LibGetTime (
                                   &RtcInfo
                                   );
   if (EFI_ERROR(Status)) {
-      DEBUG((EFI_D_ERROR, "RTC: Failed GetRtc() via ISCP - Status = %r \n", Status));
+      DEBUG((DEBUG_ERROR, "RTC: Failed GetRtc() via ISCP - Status = %r \n", Status));
       return Status;
   }
 
@@ -112,7 +112,7 @@ LibSetTime (
   RtcInfo.Second = Time->Second;
 
   if (mRtcIscpDxeProtocol == NULL) {
-      DEBUG((EFI_D_ERROR, "RTC: ISCP DXE Protocol is NULL!\n"));
+      DEBUG((DEBUG_ERROR, "RTC: ISCP DXE Protocol is NULL!\n"));
       return EFI_DEVICE_ERROR;
   }
 
@@ -121,7 +121,7 @@ LibSetTime (
                                   &RtcInfo
                                   );
   if (EFI_ERROR(Status)) {
-      DEBUG((EFI_D_ERROR, "RTC: Failed SetRtc() via ISCP - Status = %r \n", Status));
+      DEBUG((DEBUG_ERROR, "RTC: Failed SetRtc() via ISCP - Status = %r \n", Status));
       return Status;
   }
 
@@ -233,7 +233,7 @@ LibRtcInitialize (
                (VOID **)&mRtcIscpDxeProtocol
                );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "RTC: Failed to Locate ISCP DXE Protocol - Status = %r \n", Status));
+    DEBUG ((DEBUG_ERROR, "RTC: Failed to Locate ISCP DXE Protocol - Status = %r \n", Status));
     return Status;
   }
 

--- a/Silicon/AMD/Styx/Library/StyxDtbLoaderLib/StyxDtbLoaderLib.c
+++ b/Silicon/AMD/Styx/Library/StyxDtbLoaderLib/StyxDtbLoaderLib.c
@@ -149,7 +149,7 @@ SetDeviceStatus (
       if (Rc) {
         DEBUG ((DEBUG_ERROR,
           "%a: Could not set 'status' property for '%a' node\n",
-          __FUNCTION__, Device));
+          __func__, Device));
       }
     }
   }
@@ -178,7 +178,7 @@ SetMacAddress (
       if (Rc) {
         DEBUG ((DEBUG_ERROR,
           "%a: Could not set 'mac-address' property for '%a' node\n",
-          __FUNCTION__, Device));
+          __func__, Device));
       }
     }
   }
@@ -199,14 +199,14 @@ DisableSmmu (
   Node = fdt_path_offset (Fdt, DeviceNodeName);
   if (Node <= 0) {
     DEBUG ((DEBUG_WARN, "%a: Failed to find path %s: %a\n",
-      __FUNCTION__, DeviceNodeName, fdt_strerror (Node)));
+      __func__, DeviceNodeName, fdt_strerror (Node)));
     return;
   }
 
   Error = fdt_delprop (Fdt, Node, IommuPropName);
   if (Error != 0) {
     DEBUG ((DEBUG_WARN, "%a: Failed to delete property %a: %a\n",
-      __FUNCTION__, IommuPropName, fdt_strerror (Error)));
+      __func__, IommuPropName, fdt_strerror (Error)));
     return;
   }
 
@@ -218,7 +218,7 @@ DisableSmmu (
   Error = fdt_del_node (Fdt, Node);
   if (Error != 0) {
     DEBUG ((DEBUG_WARN, "%a: Failed to delete node %a: %a\n",
-      __FUNCTION__, SmmuNodeName, fdt_strerror (Error)));
+      __func__, SmmuNodeName, fdt_strerror (Error)));
   }
 }
 

--- a/Silicon/AMD/Styx/Library/StyxPlatformFlashAccessLib/StyxPlatformFlashAccessLib.c
+++ b/Silicon/AMD/Styx/Library/StyxPlatformFlashAccessLib/StyxPlatformFlashAccessLib.c
@@ -69,7 +69,7 @@ PerformFlashWriteWithProgress (
 
   if (FlashAddressType != FlashAddressTypeRelativeAddress) {
     DEBUG ((DEBUG_ERROR, "%a: only FlashAddressTypeRelativeAddress supported\n",
-      __FUNCTION__));
+      __func__));
 
     return EFI_INVALID_PARAMETER;
   }
@@ -77,7 +77,7 @@ PerformFlashWriteWithProgress (
   if (FirmwareType != PlatformFirmwareTypeSystemFirmware) {
     DEBUG ((DEBUG_ERROR,
       "%a: only PlatformFirmwareTypeSystemFirmware supported\n",
-      __FUNCTION__));
+      __func__));
 
     return EFI_INVALID_PARAMETER;
   }
@@ -85,14 +85,14 @@ PerformFlashWriteWithProgress (
   if ((FlashAddress % mBlockSize) != 0 || (Length % mBlockSize) != 0) {
     DEBUG ((DEBUG_ERROR,
       "%a:region [0x%lx, 0x%lx) is not a multiple of the blocksize 0x%lx\n",
-      __FUNCTION__, FlashAddress, Length, mBlockSize));
+      __func__, FlashAddress, Length, mBlockSize));
     return EFI_INVALID_PARAMETER;
   }
 
   if ((FlashAddress + Length) > mFlashMaxSize) {
     DEBUG ((DEBUG_ERROR,
       "%a: updated region [0x%lx, 0x%lx) outside of FV region [0x0, 0x%lx)\n",
-      __FUNCTION__, FlashAddress, FlashAddress + Length, mFlashMaxSize));
+      __func__, FlashAddress, FlashAddress + Length, mFlashMaxSize));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -105,20 +105,20 @@ PerformFlashWriteWithProgress (
     // Erase the block
     //
     DEBUG ((DEBUG_INFO, "%a: erasing 0x%llx bytes at address 0x%llx\n",
-      __FUNCTION__, mBlockSize, FlashAddress));
+      __func__, mBlockSize, FlashAddress));
 
     Status = IscpDxeProtocol->AmdExecuteEraseFvBlockDxe (IscpDxeProtocol,
                                 FlashAddress, mBlockSize);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: AmdExecuteEraseFvBlockDxe () failed - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
     }
 
     //
     // Write the new data
     //
     DEBUG ((DEBUG_INFO, "%a: writing 0x%llx bytes at at address 0x%llx\\n",
-      __FUNCTION__, mBlockSize, FlashAddress));
+      __func__, mBlockSize, FlashAddress));
 
     Status = IscpDxeProtocol->AmdExecuteUpdateFvBlockDxe (IscpDxeProtocol,
                                 FlashAddress, Buffer, mBlockSize);
@@ -126,7 +126,7 @@ PerformFlashWriteWithProgress (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR,
         "%a: write of block address 0x%lx failed - %r\n",
-        __FUNCTION__, FlashAddress, Status));
+        __func__, FlashAddress, Status));
     }
 
     FlashAddress += mBlockSize;

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/CpuConfigDxe/CpuConfigDxe.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/CpuConfigDxe/CpuConfigDxe.c
@@ -82,7 +82,7 @@ CpuNvParamGet (
              &Value
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a %d Fail to get NVParam, %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "%a %d Fail to get NVParam, %r\n", __func__, __LINE__, Status));
     Configuration->CpuSubNumaMode = SUBNUMA_MODE_MONOLITHIC;
   } else {
     Configuration->CpuSubNumaMode = Value;
@@ -117,7 +117,7 @@ CpuNvParamSet (
                Configuration->CpuSubNumaMode
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a %d Fail to set NVParam, %r\n", __FUNCTION__, __LINE__, Status));
+      DEBUG ((DEBUG_ERROR, "%a %d Fail to set NVParam, %r\n", __func__, __LINE__, Status));
       ASSERT_EFI_ERROR (Status);
       return Status;
     }

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/FlashFvbDxe/FlashFvbDxe.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/FlashFvbDxe/FlashFvbDxe.c
@@ -483,7 +483,7 @@ FlashFvbDxeInitialize (
   DEBUG ((
     DEBUG_INFO,
     "%a: Using NV store FV in-memory copy at 0x%lx with size 0x%x\n",
-    __FUNCTION__,
+    __func__,
     mNvStorageBase,
     mNvStorageSize
     ));
@@ -491,14 +491,14 @@ FlashFvbDxeInitialize (
   // Get NV Flash information
   Status = FlashGetNvRamInfo (&mNvFlashBase, &mNvFlashSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to get Flash info\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get Flash info\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
   if (mNvFlashSize >= (mNvStorageSize * 2)) {
-    DEBUG ((DEBUG_INFO, "%a: NV store on Flash is valid\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: NV store on Flash is valid\n", __func__));
   } else {
-    DEBUG ((DEBUG_ERROR, "%a: NV store on Flash is invalid\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: NV store on Flash is invalid\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/FlashPei/FlashPei.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/FlashPei/FlashPei.c
@@ -50,14 +50,14 @@ FlashPeiEntryPoint (
   DEBUG ((
     DEBUG_INFO,
     "%a: Using NV store FV in-memory copy at 0x%lx with size 0x%x\n",
-    __FUNCTION__,
+    __func__,
     NvRamAddress,
     NvRamSize
     ));
 
   Status = FlashGetNvRamInfo (&FWNvRamStartOffset, &FWNvRamSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to get Flash NVRAM info %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get Flash NVRAM info %r\n", __func__, Status));
     return Status;
   }
 

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/PlatformInfoDxe/PlatformInfoDxe.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/PlatformInfoDxe/PlatformInfoDxe.c
@@ -380,7 +380,7 @@ PlatformInfoEntryPoint (
     DEBUG ((
       DEBUG_ERROR,
       "%a %d Fail to update the platform info screen \n",
-      __FUNCTION__,
+      __func__,
       __LINE__
       ));
     return Status;

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/RasConfigDxe/RasConfigDxe.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/RasConfigDxe/RasConfigDxe.c
@@ -113,7 +113,7 @@ RasConfigNvParamGet (
                Value
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __func__, __LINE__));
       ASSERT_EFI_ERROR (Status);
       Value = 0;
     }
@@ -134,7 +134,7 @@ RasConfigNvParamGet (
                Value
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __func__, __LINE__));
       ASSERT_EFI_ERROR (Status);
       Value = 0;
     }
@@ -155,7 +155,7 @@ RasConfigNvParamGet (
                Value
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __func__, __LINE__));
       ASSERT_EFI_ERROR (Status);
       Value = 0;
     }
@@ -176,7 +176,7 @@ RasConfigNvParamGet (
                Value
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __func__, __LINE__));
       ASSERT_EFI_ERROR (Status);
       Value = 0;
     }
@@ -197,7 +197,7 @@ RasConfigNvParamGet (
                Value
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __func__, __LINE__));
       ASSERT_EFI_ERROR (Status);
       Value = 0;
     }
@@ -218,7 +218,7 @@ RasConfigNvParamGet (
                Value
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __func__, __LINE__));
       ASSERT_EFI_ERROR (Status);
       Value = 0;
     }
@@ -239,7 +239,7 @@ RasConfigNvParamGet (
                Value
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __func__, __LINE__));
       ASSERT_EFI_ERROR (Status);
       Value = 0;
     }
@@ -260,7 +260,7 @@ RasConfigNvParamGet (
                Value
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "%a:%d NVParamSet() failed!\n", __func__, __LINE__));
       ASSERT_EFI_ERROR (Status);
       Value = 0;
     }
@@ -809,7 +809,7 @@ RasConfigEntryPoint (
     DEBUG ((
       DEBUG_ERROR,
       "%a %d Fail to update Memory Configuration screen \n",
-      __FUNCTION__,
+      __func__,
       __LINE__
       ));
     RasConfigUnload ();

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/RngDxe/RngDxe.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/RngDxe/RngDxe.c
@@ -111,7 +111,7 @@ RngGetRNG (
     DEBUG ((
       DEBUG_ERROR,
       "%a:%d Failed to generate a random number. \n",
-      __FUNCTION__,
+      __func__,
       __LINE__
       ));
     return Status;

--- a/Silicon/Ampere/AmpereAltraPkg/Library/Ac01PcieLib/PcieCore.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Library/Ac01PcieLib/PcieCore.c
@@ -1031,7 +1031,7 @@ AutoLaneBifurcationRetry:
 
     Status = PciePhyInit (RootComplex->SerdesBase);
     if (RETURN_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to initialize the PCIe PHY\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to initialize the PCIe PHY\n", __func__));
       return RETURN_DEVICE_ERROR;
     }
   }

--- a/Silicon/Ampere/AmpereAltraPkg/Library/AmpereCpuLib/AmpereCpuLib.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Library/AmpereCpuLib/AmpereCpuLib.c
@@ -33,7 +33,7 @@ GetPlatformHob (
                          (CONST VOID *)FixedPcdGet64 (PcdSystemMemoryBase)
                          );
     if (mPlatformInfoHob == NULL) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to get gPlatformInfoHobGuid!\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to get gPlatformInfoHobGuid!\n", __func__));
       return NULL;
     }
  }

--- a/Silicon/Ampere/AmpereAltraPkg/Library/AmpereCpuLib/RuntimeAmpereCpuLib.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Library/AmpereCpuLib/RuntimeAmpereCpuLib.c
@@ -85,7 +85,7 @@ RuntimeAmpereCpuLibConstructor (
           (CONST VOID *)FixedPcdGet64 (PcdSystemMemoryBase)
           );
   if (Hob == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to get gPlatformInfoHobGuid!\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get gPlatformInfoHobGuid!\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 

--- a/Silicon/Ampere/AmpereAltraPkg/Library/DwI2cLib/DwI2cLib.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Library/DwI2cLib/DwI2cLib.c
@@ -180,7 +180,7 @@ I2cHWInit (
   mI2cBusList[Bus].Enabled = 0;
 
   DEBUG ((DEBUG_VERBOSE, "%a: Bus %d, Rx_Buffer %d, Tx_Buffer %d\n",
-    __FUNCTION__,
+    __func__,
     Bus,
     mI2cBusList[Bus].RxFifo,
     mI2cBusList[Bus].TxFifo
@@ -213,7 +213,7 @@ I2cEnable (
   } while (I2cStatusCnt-- != 0);
 
   if (I2cStatusCnt == 0) {
-    DEBUG ((DEBUG_ERROR, "%a: Enable/disable timeout\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Enable/disable timeout\n", __func__));
   }
 
   if ((Enable == 0) || (I2cStatusCnt == 0)) {
@@ -262,7 +262,7 @@ I2cCheckErrors (
 
   if ((ErrorStatus & DW_IC_INTR_RX_UNDER) != 0) {
     DEBUG ((DEBUG_ERROR, "%a: RX_UNDER error on i2c bus %d error status %08x\n",
-      __FUNCTION__,
+      __func__,
       Bus,
       ErrorStatus
       ));
@@ -271,7 +271,7 @@ I2cCheckErrors (
 
   if ((ErrorStatus & DW_IC_INTR_RX_OVER) != 0) {
     DEBUG ((DEBUG_ERROR, "%a: RX_OVER error on i2c bus %d error status %08x\n",
-      __FUNCTION__,
+      __func__,
       Bus,
       ErrorStatus
       ));
@@ -280,7 +280,7 @@ I2cCheckErrors (
 
   if ((ErrorStatus & DW_IC_INTR_TX_ABRT) != 0) {
     DEBUG ((DEBUG_VERBOSE, "%a: TX_ABORT at source %08x\n",
-      __FUNCTION__,
+      __func__,
       MmioRead32 (Base + DW_IC_TX_ABRT_SOURCE)
       ));
     MmioRead32 (Base + DW_IC_CLR_TX_ABRT);
@@ -305,7 +305,7 @@ I2cWaitBusNotBusy (
 
   while ((MmioRead32 (Base + DW_IC_STATUS) & DW_IC_STATUS_MST_ACTIVITY) != 0) {
     if (PollCount == 0) {
-      DEBUG ((DEBUG_VERBOSE, "%a: Timeout while waiting for bus ready\n", __FUNCTION__));
+      DEBUG ((DEBUG_VERBOSE, "%a: Timeout while waiting for bus ready\n", __func__));
       return FALSE;
     }
     PollCount--;
@@ -336,7 +336,7 @@ I2cWaitTxData (
 
   while (MmioRead32 (Base + DW_IC_TXFLR) == mI2cBusList[Bus].TxFifo) {
     if (PollCount++ >= DW_MAX_TRANSFER_POLL_COUNT) {
-      DEBUG ((DEBUG_ERROR, "%a: Timeout waiting for TX buffer available\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Timeout waiting for TX buffer available\n", __func__));
       return EFI_TIMEOUT;
     }
 
@@ -366,7 +366,7 @@ I2cWaitRxData (
 
   while ((MmioRead32 (Base + DW_IC_STATUS) & DW_IC_STATUS_RFNE) == 0) {
     if (PollCount++ >= DW_MAX_TRANSFER_POLL_COUNT) {
-      DEBUG ((DEBUG_ERROR, "%a: Timeout waiting for RX buffer available\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Timeout waiting for RX buffer available\n", __func__));
       return EFI_TIMEOUT;
     }
 
@@ -400,7 +400,7 @@ I2cSclInit (
   I2cSpeedKhz = I2cSpeed / 1000;
 
   DEBUG ((DEBUG_VERBOSE, "%a: Bus %d I2cClkFreq %d I2cSpeed %d\n",
-    __FUNCTION__,
+    __func__,
     Bus,
     I2cClkFreq,
     I2cSpeed
@@ -476,7 +476,7 @@ I2cFinish (
   } while (PollCount++ < DW_MAX_TRANSFER_POLL_COUNT);
 
   if (PollCount >= DW_MAX_TRANSFER_POLL_COUNT) {
-    DEBUG ((DEBUG_ERROR, "%a: Timeout waiting for TX FIFO empty\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Timeout waiting for TX FIFO empty\n", __func__));
     return EFI_TIMEOUT;
   }
 
@@ -490,7 +490,7 @@ I2cFinish (
     MicroSecondDelay (mI2cBusList[Bus].PollingTime);
   } while (PollCount++ < DW_MAX_TRANSFER_POLL_COUNT);
 
-  DEBUG ((DEBUG_ERROR, "%a: Timeout waiting for transaction finished\n", __FUNCTION__));
+  DEBUG ((DEBUG_ERROR, "%a: Timeout waiting for transaction finished\n", __func__));
   return EFI_TIMEOUT;
 }
 
@@ -509,7 +509,7 @@ InternalI2cWrite (
   Base = mI2cBusList[Bus].Base;
 
   DEBUG ((DEBUG_VERBOSE, "%a: Write Bus %d Buf %p Length %d\n",
-    __FUNCTION__,
+    __func__,
     Bus,
     Buf,
     *Length
@@ -640,7 +640,7 @@ InternalI2cRead (
   ReadCount = 0;
 
   DEBUG ((DEBUG_VERBOSE, "%a: Read Bus %d Buf %p Length:%d\n",
-    __FUNCTION__,
+    __func__,
     Bus,
     Buf,
     *Length
@@ -723,7 +723,7 @@ InternalI2cRead (
       if (I2cCheckErrors (Bus) != 0) {
         DEBUG ((DEBUG_VERBOSE,
           "%a: Sending reading command remaining length %d CRC error\n",
-          __FUNCTION__,
+          __func__,
           *Length
           ));
         Status = EFI_CRC_ERROR;
@@ -736,7 +736,7 @@ InternalI2cRead (
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_VERBOSE,
           "%a: Reading remaining length %d failed to wait data\n",
-          __FUNCTION__,
+          __func__,
           *Length
           ));
 
@@ -753,7 +753,7 @@ InternalI2cRead (
 
       if (I2cCheckErrors (Bus) != 0) {
         DEBUG ((DEBUG_VERBOSE, "%a: Reading remaining length %d CRC error\n",
-          __FUNCTION__,
+          __func__,
           *Length
           ));
         Status = EFI_CRC_ERROR;

--- a/Silicon/Ampere/AmpereAltraPkg/Library/FlashLib/FlashLibCommon.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Library/FlashLib/FlashLibCommon.c
@@ -82,7 +82,7 @@ FlashGetFailSafeInfo (
     DEBUG ((
       DEBUG_INFO,
       "%a: FailSafe Base 0x%llx, Size 0x%lx\n",
-      __FUNCTION__,
+      __func__,
       *FailSafeBase,
       *FailSafeSize
       ));
@@ -134,7 +134,7 @@ FlashGetNvRamInfo (
     DEBUG ((
       DEBUG_INFO,
       "%a: NVRAM Base 0x%llx, Size 0x%lx\n",
-      __FUNCTION__,
+      __func__,
       *NvRamBase,
       *NvRamSize
       ));
@@ -186,7 +186,7 @@ FlashGetNvRam2Info (
     DEBUG ((
       DEBUG_INFO,
       "%a: NVRAM2 Base 0x%llx, Size 0x%lx\n",
-      __FUNCTION__,
+      __func__,
       *NvRam2Base,
       *NvRam2Size
       ));
@@ -235,7 +235,7 @@ FlashEraseCommand (
   }
 
   if (MmSpiNorRes.Status != MM_SPINOR_RES_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "%a: Device error %llx\n", __FUNCTION__, MmSpiNorRes.Status));
+    DEBUG ((DEBUG_ERROR, "%a: Device error %llx\n", __func__, MmSpiNorRes.Status));
     return EFI_DEVICE_ERROR;
   }
 
@@ -291,7 +291,7 @@ FlashWriteCommand (
     }
 
     if (MmSpiNorRes.Status != MM_SPINOR_RES_SUCCESS) {
-      DEBUG ((DEBUG_ERROR, "%a: Device error 0x%llx\n", __FUNCTION__, MmSpiNorRes.Status));
+      DEBUG ((DEBUG_ERROR, "%a: Device error 0x%llx\n", __func__, MmSpiNorRes.Status));
       return EFI_DEVICE_ERROR;
     }
 
@@ -351,7 +351,7 @@ FlashReadCommand (
     }
 
     if (MmSpiNorRes.Status != MM_SPINOR_RES_SUCCESS) {
-      DEBUG ((DEBUG_ERROR, "%a: Device error %llx\n", __FUNCTION__, MmSpiNorRes.Status));
+      DEBUG ((DEBUG_ERROR, "%a: Device error %llx\n", __func__, MmSpiNorRes.Status));
       return EFI_DEVICE_ERROR;
     }
 

--- a/Silicon/Ampere/AmpereAltraPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -128,7 +128,7 @@ PciHostBridgeGetRootBridges (
 
   RootBridges = AllocatePool (AC01_PCIE_MAX_ROOT_COMPLEX * sizeof (PCI_ROOT_BRIDGE));
   if (RootBridges == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate RootBridges\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate RootBridges\n", __func__));
     return NULL;
   }
 
@@ -161,7 +161,7 @@ PciHostBridgeGetRootBridges (
                    (VOID *)&mEfiPciRootBridgeDevicePath
                    );
     if (DevicePath == NULL) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to allocate device path\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to allocate device path\n", __func__));
       return NULL;
     }
 

--- a/Silicon/Ampere/AmpereAltraPkg/Library/TrngLib/TrngLib.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Library/TrngLib/TrngLib.c
@@ -52,7 +52,7 @@ GenerateRandomNumbers (
     if (RandSize != 0) {
       Status = MailboxMsgGetRandomNumber64 ((UINT8 *)&Value);
       if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "%a: Failed to get random number!\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to get random number!\n", __func__));
         return EFI_DEVICE_ERROR;
       }
       CopyMem (Buffer + Count * sizeof (UINT64), &Value, RandSize);

--- a/Silicon/Ampere/AmpereSiliconPkg/Library/PlatformUiLib/PlatformManager.c
+++ b/Silicon/Ampere/AmpereSiliconPkg/Library/PlatformUiLib/PlatformManager.c
@@ -289,7 +289,7 @@ PlatformManagerUiLibConstructor (
     //
     CreatePlatformManagerForm (PLATFORM_MANAGER_FORM_ID);
   } else {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to add Hii package\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to add Hii package\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 

--- a/Silicon/Atmel/AtSha204a/AtSha204aDriver.c
+++ b/Silicon/Atmel/AtSha204a/AtSha204aDriver.c
@@ -151,7 +151,7 @@ AtSha240aGetRNG (
     Status = AtSha204a->I2cIo->QueueRequest (AtSha204a->I2cIo, 1, NULL,
                                  (VOID *)&Request, NULL);
     DEBUG ((DEBUG_INFO, "%a: wake AtSha204a: I2cIo->QueueRequest() - %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
 
     gBS->Stall (2500); // wait 2.5 ms for wake to complete
 
@@ -164,7 +164,7 @@ AtSha240aGetRNG (
         continue;
       }
       DEBUG ((DEBUG_ERROR, "%a: I2C request transfer failed, Status == %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
       return EFI_DEVICE_ERROR;
     }
 
@@ -177,7 +177,7 @@ AtSha240aGetRNG (
         continue;
       }
       DEBUG ((DEBUG_ERROR, "%a: I2C response transfer failed, Status == %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
       return EFI_DEVICE_ERROR;
     }
 
@@ -188,7 +188,7 @@ AtSha240aGetRNG (
       if (++Retries <= MAX_RETRIES) {
         continue;
       }
-      DEBUG ((DEBUG_WARN, "%a: incomplete packet received\n", __FUNCTION__));
+      DEBUG ((DEBUG_WARN, "%a: incomplete packet received\n", __func__));
       return EFI_DEVICE_ERROR;
     }
 

--- a/Silicon/Broadcom/Bcm283x/Drivers/InterruptDxe/InterruptDxe.c
+++ b/Silicon/Broadcom/Bcm283x/Drivers/InterruptDxe/InterruptDxe.c
@@ -290,7 +290,7 @@ CpuArchEventProtocolNotify (
   Status = Cpu->RegisterInterruptHandler (Cpu, ARM_ARCH_EXCEPTION_IRQ, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Cpu->RegisterInterruptHandler() - %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     ASSERT (FALSE);
     return;
   }
@@ -301,7 +301,7 @@ CpuArchEventProtocolNotify (
   Status = Cpu->RegisterInterruptHandler (Cpu, ARM_ARCH_EXCEPTION_IRQ, IrqInterruptHandler);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Cpu->RegisterInterruptHandler() - %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     ASSERT (FALSE);
     return;
   }

--- a/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/DriverBinding.c
+++ b/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/DriverBinding.c
@@ -129,7 +129,7 @@ GenetDriverBindingStart (
   Genet = AllocateZeroPool (sizeof (GENET_PRIVATE_DATA));
   if (Genet == NULL) {
     DEBUG ((DEBUG_ERROR,
-      "%a: Couldn't allocate private data\n", __FUNCTION__));
+      "%a: Couldn't allocate private data\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -141,14 +141,14 @@ GenetDriverBindingStart (
                               EFI_OPEN_PROTOCOL_BY_DRIVER);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
-      "%a: Couldn't open protocol: %r\n", __FUNCTION__, Status));
+      "%a: Couldn't open protocol: %r\n", __func__, Status));
     goto FreeDevice;
   }
 
   Status = GenetDmaAlloc (Genet);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
-      "%a: Couldn't allocate DMA buffers: %r\n", __FUNCTION__, Status));
+      "%a: Couldn't allocate DMA buffers: %r\n", __func__, Status));
     goto FreeDevice;
   }
 
@@ -210,7 +210,7 @@ GenetDriverBindingStart (
 
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
-      "%a: Couldn't install protocol interfaces: %r\n", __FUNCTION__, Status));
+      "%a: Couldn't install protocol interfaces: %r\n", __func__, Status));
     gBS->CloseProtocol (ControllerHandle,
                         &gBcmGenetPlatformDeviceProtocolGuid,
                         This->DriverBindingHandle,
@@ -224,7 +224,7 @@ GenetDriverBindingStart (
 FreeEvent:
   gBS->CloseEvent (Genet->ExitBootServicesEvent);
 FreeDevice:
-  DEBUG ((DEBUG_WARN, "%a: Returning %r\n", __FUNCTION__, Status));
+  DEBUG ((DEBUG_WARN, "%a: Returning %r\n", __func__, Status));
   FreePool (Genet);
   return Status;
 }
@@ -457,7 +457,7 @@ GenetUnload (
 
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_WARN, "%a: failed to disconnect all controllers - %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     return Status;
   }
 

--- a/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/GenericPhy.c
+++ b/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/GenericPhy.c
@@ -115,7 +115,7 @@ GenericPhyDetect (
       Phy->PhyAddr = PhyAddr;
       DEBUG ((DEBUG_INFO,
         "%a: PHY detected at address 0x%02X (PHYIDR1=0x%04X, PHYIDR2=0x%04X)\n",
-        __FUNCTION__, PhyAddr, Id1, Id2));
+        __func__, PhyAddr, Id1, Id2));
       return EFI_SUCCESS;
     }
   }
@@ -354,7 +354,7 @@ GenericPhyGetConfig (
   }
 
   DEBUG ((DEBUG_INFO, "%a: Link speed %d Mbps, %a-duplex\n",
-    __FUNCTION__, *Speed, *Duplex == PHY_DUPLEX_FULL ? "full" : "half"));
+    __func__, *Speed, *Duplex == PHY_DUPLEX_FULL ? "full" : "half"));
 
   return EFI_SUCCESS;
 }
@@ -387,7 +387,7 @@ GenericPhyUpdateConfig (
 
   if (Phy->LinkUp != LinkUp) {
     if (LinkUp) {
-      DEBUG ((DEBUG_VERBOSE, "%a: Link is up\n", __FUNCTION__));
+      DEBUG ((DEBUG_VERBOSE, "%a: Link is up\n", __func__));
 
       Status = GenericPhyGetConfig (Phy, &Speed, &Duplex);
       if (EFI_ERROR (Status)) {
@@ -396,7 +396,7 @@ GenericPhyUpdateConfig (
 
       GenericPhyConfigure (Phy, Speed, Duplex);
     } else {
-      DEBUG ((DEBUG_VERBOSE, "%a: Link is down\n", __FUNCTION__));
+      DEBUG ((DEBUG_VERBOSE, "%a: Link is down\n", __func__));
     }
   }
 

--- a/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/GenetUtil.c
+++ b/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/GenetUtil.c
@@ -108,7 +108,7 @@ GenetPhyRead (
 
   if (Retry == 0) {
     DEBUG ((DEBUG_ERROR,
-      "%a: Timeout reading PhyAddr %d, Reg %d\n", __FUNCTION__, PhyAddr, Reg));
+      "%a: Timeout reading PhyAddr %d, Reg %d\n", __func__, PhyAddr, Reg));
     return EFI_DEVICE_ERROR;
   }
 
@@ -157,7 +157,7 @@ GenetPhyWrite (
 
   if (Retry == 0) {
     DEBUG ((DEBUG_ERROR,
-      "%a: Timeout writing PhyAddr %d, Reg %d\n", __FUNCTION__, PhyAddr, Reg));
+      "%a: Timeout writing PhyAddr %d, Reg %d\n", __func__, PhyAddr, Reg));
     return EFI_DEVICE_ERROR;
   }
 
@@ -618,7 +618,7 @@ GenetDmaAlloc (
                   &Genet->RxBuffer);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
-      "%a: Failed to allocate RX buffer: %r\n", __FUNCTION__, Status));
+      "%a: Failed to allocate RX buffer: %r\n", __func__, Status));
   }
   return Status;
 }
@@ -653,7 +653,7 @@ GenetDmaMapRxDescriptor (
              &Genet->RxBufferMap[DescIndex].Mapping);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to map RX buffer: %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     return Status;
   }
 

--- a/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/SimpleNetwork.c
+++ b/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/SimpleNetwork.c
@@ -578,7 +578,7 @@ GenetSimpleNetworkTransmit (
 
   if (This == NULL || Buffer == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter (missing handle or buffer)\n",
-      __FUNCTION__));
+      __func__));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -603,13 +603,13 @@ GenetSimpleNetworkTransmit (
     // grub send failure messages.
     //
     Retries = 1000;
-    DEBUG ((DEBUG_INFO, "%a: Waiting 10s for link\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Waiting 10s for link\n", __func__));
     do {
       gBS->Stall (10000);
       Status = GenericPhyUpdateConfig (&Genet->Phy);
     } while (EFI_ERROR (Status) && Retries-- > 0);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: no link\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: no link\n", __func__));
       return EFI_NOT_READY;
     } else {
       Genet->SnpMode.MediaPresent = TRUE;
@@ -620,32 +620,32 @@ GenetSimpleNetworkTransmit (
     if (HeaderSize != Genet->SnpMode.MediaHeaderSize) {
       DEBUG ((DEBUG_ERROR,
         "%a: Invalid parameter (header size mismatch; HeaderSize 0x%X, SnpMode.MediaHeaderSize 0x%X))\n",
-        __FUNCTION__, HeaderSize, Genet->SnpMode.MediaHeaderSize));
+        __func__, HeaderSize, Genet->SnpMode.MediaHeaderSize));
       return EFI_INVALID_PARAMETER;
     }
     if (DestAddr == NULL || Protocol == NULL) {
       DEBUG ((DEBUG_ERROR,
         "%a: Invalid parameter (dest addr or protocol missing)\n",
-        __FUNCTION__));
+        __func__));
       return EFI_INVALID_PARAMETER;
     }
   }
 
   if (BufferSize < Genet->SnpMode.MediaHeaderSize) {
-    DEBUG ((DEBUG_ERROR, "%a: Buffer too small\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Buffer too small\n", __func__));
     return EFI_BUFFER_TOO_SMALL;
   }
 
   Status = EfiAcquireLockOrFail (&Genet->Lock);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Couldn't get lock: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Couldn't get lock: %r\n", __func__, Status));
     return EFI_ACCESS_DENIED;
   }
 
   if (Genet->TxQueued == GENET_DMA_DESC_COUNT - 1) {
     EfiReleaseLock (&Genet->Lock);
 
-    DEBUG ((DEBUG_ERROR, "%a: Queue full\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Queue full\n", __func__));
     return EFI_NOT_READY;
   }
 
@@ -667,7 +667,7 @@ GenetSimpleNetworkTransmit (
                    &DmaDeviceAddress,
                    &Genet->TxBufferMap[Desc]);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: DmaMap failed: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: DmaMap failed: %r\n", __func__, Status));
     EfiReleaseLock (&Genet->Lock);
     return Status;
   }
@@ -736,7 +736,7 @@ GenetSimpleNetworkReceive (
 
   if (This == NULL || Buffer == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter (missing handle or buffer)\n",
-      __FUNCTION__));
+      __func__));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -750,7 +750,7 @@ GenetSimpleNetworkReceive (
 
   Status = EfiAcquireLockOrFail (&Genet->Lock);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Couldn't get lock: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Couldn't get lock: %r\n", __func__, Status));
     return EFI_ACCESS_DENIED;
   }
 
@@ -774,7 +774,7 @@ GenetSimpleNetworkReceive (
     if (*BufferSize < FrameLength) {
       DEBUG ((DEBUG_ERROR,
         "%a: Buffer size (0x%X) is too small for frame (0x%X)\n",
-        __FUNCTION__, *BufferSize, FrameLength));
+        __func__, *BufferSize, FrameLength));
       Status = EFI_BUFFER_TOO_SMALL;
       goto out;
     }
@@ -798,14 +798,14 @@ GenetSimpleNetworkReceive (
     Status = EFI_SUCCESS;
   } else {
     DEBUG ((DEBUG_ERROR, "%a: Short packet (FrameLength 0x%X)",
-      __FUNCTION__, FrameLength));
+      __func__, FrameLength));
     Status = EFI_NOT_READY;
   }
 
 out:
   Status = GenetDmaMapRxDescriptor (Genet, DescIndex);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to remap RX descriptor!\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to remap RX descriptor!\n", __func__));
   }
 
   GenetRxComplete (Genet);

--- a/Silicon/Hisilicon/Drivers/AcpiPlatformDxe/UpdateDsdt.c
+++ b/Silicon/Hisilicon/Drivers/AcpiPlatformDxe/UpdateDsdt.c
@@ -39,7 +39,7 @@
 //#define ACPI_DEBUG
 
 #ifdef ACPI_DEBUG
-#define DBG(arg...) DEBUG((EFI_D_ERROR,## arg))
+#define DBG(arg...) DEBUG((DEBUG_ERROR,## arg))
 #else
 #define DBG(arg...)
 #endif
@@ -76,19 +76,19 @@ GetEnvMac(
   Status = gBS->LocateProtocol(&gHisiBoardNicProtocolGuid, NULL, (VOID **)&OemNic);
   if(EFI_ERROR(Status))
   {
-    DEBUG((EFI_D_ERROR, "[%a]:[%dL] LocateProtocol failed %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] LocateProtocol failed %r\n", __FUNCTION__, __LINE__, Status));
     return Status;
   }
 
   Status = OemNic->GetMac(&Mac, MacNextID);
   if(EFI_ERROR(Status))
   {
-    DEBUG((EFI_D_ERROR, "[%a]:[%dL] GetMac failed %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] GetMac failed %r\n", __FUNCTION__, __LINE__, Status));
     return Status;
   }
 
   CopyMem (MacBuffer, &Mac, 6);
-  DEBUG((EFI_D_ERROR, "Port %d MAC %02x:%02x:%02x:%02x:%02x:%02x\n",
+  DEBUG((DEBUG_ERROR, "Port %d MAC %02x:%02x:%02x:%02x:%02x:%02x\n",
         MacNextID,
         MacBuffer[0],
         MacBuffer[1],
@@ -341,7 +341,7 @@ GetDeviceInfo (
   // Get NameString
   Status = AcpiTableProtocol->GetOption (ChildHandle, 1, &DataType, &Buffer, &DataSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "[%a:%d] Get NameString failed: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "[%a:%d] Get NameString failed: %r\n", __FUNCTION__, __LINE__, Status));
     return Status;
   }
 
@@ -623,7 +623,7 @@ UpdateAcpiDsdtTable (
   EFI_ACPI_HANDLE         TableHandle;
   UINTN                   i;
 
-  DEBUG ((EFI_D_ERROR, "Updating Ethernet MAC in ACPI DSDT...\n"));
+  DEBUG ((DEBUG_ERROR, "Updating Ethernet MAC in ACPI DSDT...\n"));
 
   //
   // Find the AcpiTable protocol

--- a/Silicon/Hisilicon/Drivers/AcpiPlatformDxe/UpdateDsdt.c
+++ b/Silicon/Hisilicon/Drivers/AcpiPlatformDxe/UpdateDsdt.c
@@ -76,14 +76,14 @@ GetEnvMac(
   Status = gBS->LocateProtocol(&gHisiBoardNicProtocolGuid, NULL, (VOID **)&OemNic);
   if(EFI_ERROR(Status))
   {
-    DEBUG((DEBUG_ERROR, "[%a]:[%dL] LocateProtocol failed %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] LocateProtocol failed %r\n", __func__, __LINE__, Status));
     return Status;
   }
 
   Status = OemNic->GetMac(&Mac, MacNextID);
   if(EFI_ERROR(Status))
   {
-    DEBUG((DEBUG_ERROR, "[%a]:[%dL] GetMac failed %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] GetMac failed %r\n", __func__, __LINE__, Status));
     return Status;
   }
 
@@ -341,7 +341,7 @@ GetDeviceInfo (
   // Get NameString
   Status = AcpiTableProtocol->GetOption (ChildHandle, 1, &DataType, &Buffer, &DataSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "[%a:%d] Get NameString failed: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "[%a:%d] Get NameString failed: %r\n", __func__, __LINE__, Status));
     return Status;
   }
 
@@ -361,7 +361,7 @@ GetDeviceInfo (
     *FoundDev = DsdtDeviceSas;
   } else {
     DEBUG ((DEBUG_ERROR, "[%a:%d] The NameString %a is not ETHn or SASn\n",
-            __FUNCTION__, __LINE__, Data));
+            __func__, __LINE__, Data));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -433,7 +433,7 @@ EFI_STATUS ProcessDSDTDevice (
           Status = AcpiTableProtocol->GetOption(ValueHandle, 1, &DataType, &Buffer, &DataSize);
 
           Data = Buffer;
-          DBG("[%a:%d] - _HID = %a\n", __FUNCTION__, __LINE__, Data);
+          DBG("[%a:%d] - _HID = %a\n", __func__, __LINE__, Data);
 
           if (EFI_ERROR(Status) ||
               DataType != EFI_ACPI_DATA_TYPE_STRING) {
@@ -572,10 +572,10 @@ static EFI_STATUS ProcessDSDT(
   EFI_ACPI_HANDLE         ChildHandle;
   //
   // Parse table for device type
-  DBG ("[%a:%d] - TableHandle=%p\n", __FUNCTION__, __LINE__, TableHandle);
+  DBG ("[%a:%d] - TableHandle=%p\n", __func__, __LINE__, TableHandle);
   for (ChildHandle = NULL; ; ) {
     Status = AcpiTableProtocol->GetChild(TableHandle, &ChildHandle);
-    DBG ("[%a:%d] - Child=%p, %r\n", __FUNCTION__, __LINE__, ChildHandle, Status);
+    DBG ("[%a:%d] - Child=%p, %r\n", __func__, __LINE__, ChildHandle, Status);
     if (EFI_ERROR(Status))
       break;
     if (ChildHandle == NULL)

--- a/Silicon/Hisilicon/Drivers/FlashFvbDxe/FlashBlockIoDxe.c
+++ b/Silicon/Hisilicon/Drivers/FlashFvbDxe/FlashBlockIoDxe.c
@@ -28,7 +28,7 @@ FlashBlockIoReadBlocks (
 
     Instance = INSTANCE_FROM_BLKIO_THIS(This);
 
-    DEBUG ((EFI_D_INFO, "FlashBlockIoReadBlocks(MediaId=0x%x, Lba=%ld, BufferSize=0x%x bytes (%d kB), BufferPtr @ 0x%08x)\n", MediaId, Lba, BufferSizeInBytes, Buffer));
+    DEBUG ((DEBUG_INFO, "FlashBlockIoReadBlocks(MediaId=0x%x, Lba=%ld, BufferSize=0x%x bytes (%d kB), BufferPtr @ 0x%08x)\n", MediaId, Lba, BufferSizeInBytes, Buffer));
 
     if ( !This->Media->MediaPresent )
     {
@@ -64,7 +64,7 @@ FlashBlockIoWriteBlocks (
 
     Instance = INSTANCE_FROM_BLKIO_THIS(This);
 
-    DEBUG ((EFI_D_INFO, "FlashBlockIoWriteBlocks(MediaId=0x%x, Lba=%ld, BufferSize=0x%x bytes (%d kB), BufferPtr @ 0x%08x)\n", MediaId, Lba, BufferSizeInBytes, Buffer));
+    DEBUG ((DEBUG_INFO, "FlashBlockIoWriteBlocks(MediaId=0x%x, Lba=%ld, BufferSize=0x%x bytes (%d kB), BufferPtr @ 0x%08x)\n", MediaId, Lba, BufferSizeInBytes, Buffer));
 
     if ( !This->Media->MediaPresent )
     {

--- a/Silicon/Hisilicon/Drivers/FlashFvbDxe/FlashFvbDxe.c
+++ b/Silicon/Hisilicon/Drivers/FlashFvbDxe/FlashFvbDxe.c
@@ -230,14 +230,14 @@ ValidateFvHeader (
            || (FwVolHeader->FvLength  != FvLength)
        )
     {
-        DEBUG ((EFI_D_ERROR, "ValidateFvHeader: No Firmware Volume header present\n"));
+        DEBUG ((DEBUG_ERROR, "ValidateFvHeader: No Firmware Volume header present\n"));
         return EFI_NOT_FOUND;
     }
 
     // Check the Firmware Volume Guid
     if ( CompareGuid (&FwVolHeader->FileSystemGuid, &gEfiSystemNvDataFvGuid) == FALSE )
     {
-        DEBUG ((EFI_D_ERROR, "ValidateFvHeader: Firmware Volume Guid non-compatible\n"));
+        DEBUG ((DEBUG_ERROR, "ValidateFvHeader: Firmware Volume Guid non-compatible\n"));
         return EFI_NOT_FOUND;
     }
 
@@ -245,7 +245,7 @@ ValidateFvHeader (
     Checksum = CalculateSum16((UINT16*)FwVolHeader, FwVolHeader->HeaderLength);
     if (Checksum != 0)
     {
-        DEBUG ((EFI_D_ERROR, "ValidateFvHeader: FV checksum is invalid (Checksum:0x%X)\n", Checksum));
+        DEBUG ((DEBUG_ERROR, "ValidateFvHeader: FV checksum is invalid (Checksum:0x%X)\n", Checksum));
         return EFI_NOT_FOUND;
     }
 
@@ -254,14 +254,14 @@ ValidateFvHeader (
     // Check the Variable Store Guid
     if ( CompareGuid (&VariableStoreHeader->Signature, &gEfiVariableGuid) == FALSE )
     {
-        DEBUG ((EFI_D_ERROR, "ValidateFvHeader: Variable Store Guid non-compatible\n"));
+        DEBUG ((DEBUG_ERROR, "ValidateFvHeader: Variable Store Guid non-compatible\n"));
         return EFI_NOT_FOUND;
     }
 
     VariableStoreLength = PcdGet32 (PcdFlashNvStorageVariableSize) - FwVolHeader->HeaderLength;
     if (VariableStoreHeader->Size != VariableStoreLength)
     {
-        DEBUG ((EFI_D_ERROR, "ValidateFvHeader: Variable Store Length does not match\n"));
+        DEBUG ((DEBUG_ERROR, "ValidateFvHeader: Variable Store Length does not match\n"));
         return EFI_NOT_FOUND;
     }
 
@@ -343,7 +343,7 @@ FvbSetAttributes(
     IN OUT    EFI_FVB_ATTRIBUTES_2*                 Attributes
 )
 {
-    DEBUG ((EFI_D_ERROR, "FvbSetAttributes(0x%X) is not supported\n", *Attributes));
+    DEBUG ((DEBUG_ERROR, "FvbSetAttributes(0x%X) is not supported\n", *Attributes));
     return EFI_UNSUPPORTED;
 }
 
@@ -513,7 +513,7 @@ FvbRead (
     if (!Instance->Initialized && Instance->Initialize)
     {
         if (EfiAtRuntime ()) {
-            DEBUG ((EFI_D_ERROR, "[%a]:[%dL] Initialize at runtime is not supported!\n", __FUNCTION__, __LINE__));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Initialize at runtime is not supported!\n", __FUNCTION__, __LINE__));
             return EFI_UNSUPPORTED;
         }
 
@@ -531,7 +531,7 @@ FvbRead (
         (*NumBytes            >  BlockSize) ||
         ((Offset + *NumBytes) >  BlockSize))
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL] ERROR - EFI_BAD_BUFFER_SIZE: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n", __FUNCTION__, __LINE__, Offset, *NumBytes, BlockSize ));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL] ERROR - EFI_BAD_BUFFER_SIZE: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n", __FUNCTION__, __LINE__, Offset, *NumBytes, BlockSize ));
         return EFI_BAD_BUFFER_SIZE;
     }
 
@@ -640,7 +640,7 @@ FvbWrite (
     if (!Instance->Initialized && Instance->Initialize)
     {
         if (EfiAtRuntime ()) {
-            DEBUG ((EFI_D_ERROR, "[%a]:[%dL] Initialize at runtime is not supported!\n", __FUNCTION__, __LINE__));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Initialize at runtime is not supported!\n", __FUNCTION__, __LINE__));
             return EFI_UNSUPPORTED;
         }
 
@@ -652,7 +652,7 @@ FvbWrite (
     // Detect WriteDisabled state
     if (Instance->Media.ReadOnly == TRUE)
     {
-        DEBUG ((EFI_D_ERROR, "FvbWrite: ERROR - Can not write: Device is in WriteDisabled state.\n"));
+        DEBUG ((DEBUG_ERROR, "FvbWrite: ERROR - Can not write: Device is in WriteDisabled state.\n"));
         // It is in WriteDisabled state, return an error right away
         return EFI_ACCESS_DENIED;
     }
@@ -666,14 +666,14 @@ FvbWrite (
          ( *NumBytes            >  BlockSize ) ||
          ( (Offset + *NumBytes) >  BlockSize )    )
     {
-        DEBUG ((EFI_D_ERROR, "FvbWrite: ERROR - EFI_BAD_BUFFER_SIZE: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n", Offset, *NumBytes, BlockSize ));
+        DEBUG ((DEBUG_ERROR, "FvbWrite: ERROR - EFI_BAD_BUFFER_SIZE: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n", Offset, *NumBytes, BlockSize ));
         return EFI_BAD_BUFFER_SIZE;
     }
 
     // We must have some bytes to write
     if (*NumBytes == 0)
     {
-        DEBUG ((EFI_D_ERROR, "FvbWrite: ERROR - EFI_BAD_BUFFER_SIZE: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n", Offset, *NumBytes, BlockSize ));
+        DEBUG ((DEBUG_ERROR, "FvbWrite: ERROR - EFI_BAD_BUFFER_SIZE: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n", Offset, *NumBytes, BlockSize ));
         return EFI_BAD_BUFFER_SIZE;
     }
 
@@ -683,7 +683,7 @@ FvbWrite (
     Status = mFlash->Write(mFlash, (UINT32)WriteAddress, (UINT8*)Buffer, *NumBytes);
     if (EFI_SUCCESS != Status)
     {
-        DEBUG((EFI_D_ERROR, "%s - %d Status=%r\n", __FILE__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "%s - %d Status=%r\n", __FILE__, __LINE__, Status));
         return Status;
     }
 
@@ -999,7 +999,7 @@ FlashEraseSingleBlock (
     Status = mFlash->Erase(mFlash, (UINT32)EraseAddress, Instance->Media.BlockSize);
     if (EFI_SUCCESS != Status)
     {
-        DEBUG((EFI_D_ERROR, "%s - %d Status=%r\n", __FILE__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "%s - %d Status=%r\n", __FILE__, __LINE__, Status));
         return Status;
     }
 
@@ -1034,7 +1034,7 @@ FlashUnlockAndEraseSingleBlock (
 
     if (Index == FLASH_ERASE_RETRY)
     {
-        DEBUG((EFI_D_ERROR, "EraseSingleBlock(BlockAddress=0x%08x: Block Locked Error (try to erase %d times)\n", BlockAddress, Index));
+        DEBUG((DEBUG_ERROR, "EraseSingleBlock(BlockAddress=0x%08x: Block Locked Error (try to erase %d times)\n", BlockAddress, Index));
     }
 
     return Status;
@@ -1080,7 +1080,7 @@ FlashWriteBlocks (
     NumBlocks = ((UINT32)BufferSizeInBytes) / Instance->Media.BlockSize ;
     if ((Lba + NumBlocks) > (Instance->Media.LastBlock + 1))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL]ERROR - Write will exceed last block.\n", __FUNCTION__, __LINE__ ));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL]ERROR - Write will exceed last block.\n", __FUNCTION__, __LINE__ ));
         return EFI_INVALID_PARAMETER;
     }
 
@@ -1091,7 +1091,7 @@ FlashWriteBlocks (
     Status = mFlash->Write(mFlash, (UINT32)WriteAddress, (UINT8*)Buffer, BufferSizeInBytes);
     if (EFI_SUCCESS != Status)
     {
-        DEBUG((EFI_D_ERROR, "%s - %d Status=%r\n", __FILE__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "%s - %d Status=%r\n", __FILE__, __LINE__, Status));
         return Status;
     }
 
@@ -1133,7 +1133,7 @@ FlashReadBlocks (
     NumBlocks = ((UINT32)BufferSizeInBytes) / Instance->Media.BlockSize ;
     if ((Lba + NumBlocks) > (Instance->Media.LastBlock + 1))
     {
-        DEBUG((EFI_D_ERROR, "FlashReadBlocks: ERROR - Read will exceed last block\n"));
+        DEBUG((DEBUG_ERROR, "FlashReadBlocks: ERROR - Read will exceed last block\n"));
         return EFI_INVALID_PARAMETER;
     }
 
@@ -1149,7 +1149,7 @@ FlashReadBlocks (
     Status = mFlash->Read(mFlash, (UINT32)ReadAddress, Buffer, BufferSizeInBytes);
     if (EFI_SUCCESS != Status)
     {
-        DEBUG((EFI_D_ERROR, "%s - %d Status=%r\n", __FILE__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "%s - %d Status=%r\n", __FILE__, __LINE__, Status));
         return Status;
     }
 
@@ -1185,7 +1185,7 @@ FlashFvbInitialize (
     Status = FlashPlatformGetDevices (&FlashDevices, &FlashDeviceCount);
     if (EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Fail to get Flash devices\n", __FUNCTION__, __LINE__));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Fail to get Flash devices\n", __FUNCTION__, __LINE__));
         return Status;
     }
 
@@ -1194,7 +1194,7 @@ FlashFvbInitialize (
     Status = gBS->LocateProtocol (&gHisiSpiFlashProtocolGuid, NULL, (VOID*) &mFlash);
     if (EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Status=%r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Status=%r\n", __FUNCTION__, __LINE__, Status));
         return Status;
     }
 
@@ -1217,7 +1217,7 @@ FlashFvbInitialize (
                  );
         if (EFI_ERROR(Status))
         {
-            DEBUG((EFI_D_ERROR, "[%a]:[%dL] Fail to create instance for Flash[%d]\n", __FUNCTION__, __LINE__, Index));
+            DEBUG((DEBUG_ERROR, "[%a]:[%dL] Fail to create instance for Flash[%d]\n", __FUNCTION__, __LINE__, Index));
         }
     }
     //

--- a/Silicon/Hisilicon/Drivers/FlashFvbDxe/FlashFvbDxe.c
+++ b/Silicon/Hisilicon/Drivers/FlashFvbDxe/FlashFvbDxe.c
@@ -513,7 +513,7 @@ FvbRead (
     if (!Instance->Initialized && Instance->Initialize)
     {
         if (EfiAtRuntime ()) {
-            DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Initialize at runtime is not supported!\n", __FUNCTION__, __LINE__));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Initialize at runtime is not supported!\n", __func__, __LINE__));
             return EFI_UNSUPPORTED;
         }
 
@@ -531,7 +531,7 @@ FvbRead (
         (*NumBytes            >  BlockSize) ||
         ((Offset + *NumBytes) >  BlockSize))
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL] ERROR - EFI_BAD_BUFFER_SIZE: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n", __FUNCTION__, __LINE__, Offset, *NumBytes, BlockSize ));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL] ERROR - EFI_BAD_BUFFER_SIZE: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n", __func__, __LINE__, Offset, *NumBytes, BlockSize ));
         return EFI_BAD_BUFFER_SIZE;
     }
 
@@ -640,7 +640,7 @@ FvbWrite (
     if (!Instance->Initialized && Instance->Initialize)
     {
         if (EfiAtRuntime ()) {
-            DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Initialize at runtime is not supported!\n", __FUNCTION__, __LINE__));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Initialize at runtime is not supported!\n", __func__, __LINE__));
             return EFI_UNSUPPORTED;
         }
 
@@ -1080,7 +1080,7 @@ FlashWriteBlocks (
     NumBlocks = ((UINT32)BufferSizeInBytes) / Instance->Media.BlockSize ;
     if ((Lba + NumBlocks) > (Instance->Media.LastBlock + 1))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL]ERROR - Write will exceed last block.\n", __FUNCTION__, __LINE__ ));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL]ERROR - Write will exceed last block.\n", __func__, __LINE__ ));
         return EFI_INVALID_PARAMETER;
     }
 
@@ -1185,7 +1185,7 @@ FlashFvbInitialize (
     Status = FlashPlatformGetDevices (&FlashDevices, &FlashDeviceCount);
     if (EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Fail to get Flash devices\n", __FUNCTION__, __LINE__));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Fail to get Flash devices\n", __func__, __LINE__));
         return Status;
     }
 
@@ -1194,7 +1194,7 @@ FlashFvbInitialize (
     Status = gBS->LocateProtocol (&gHisiSpiFlashProtocolGuid, NULL, (VOID*) &mFlash);
     if (EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Status=%r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Status=%r\n", __func__, __LINE__, Status));
         return Status;
     }
 
@@ -1217,7 +1217,7 @@ FlashFvbInitialize (
                  );
         if (EFI_ERROR(Status))
         {
-            DEBUG((DEBUG_ERROR, "[%a]:[%dL] Fail to create instance for Flash[%d]\n", __FUNCTION__, __LINE__, Index));
+            DEBUG((DEBUG_ERROR, "[%a]:[%dL] Fail to create instance for Flash[%d]\n", __func__, __LINE__, Index));
         }
     }
     //

--- a/Silicon/Hisilicon/Drivers/NorFlashDxe/NorFlashDxe.c
+++ b/Silicon/Hisilicon/Drivers/NorFlashDxe/NorFlashDxe.c
@@ -64,17 +64,17 @@ EFIAPI Read(
 
     if (Offset + ulLen > (gFlashInfo[gIndex.InfIndex].SingleChipSize * gFlashInfo[gIndex.InfIndex].ParallelNum))
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:Exceed the flash scope!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Exceed the flash scope!\n", __FUNCTION__,__LINE__));
         return EFI_INVALID_PARAMETER;
     }
     if (0 == ulLen)
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:Length is Zero!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Length is Zero!\n", __FUNCTION__,__LINE__));
         return EFI_INVALID_PARAMETER;
     }
     if (NULL == Buffer)
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:Buffer is NULL!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Buffer is NULL!\n", __FUNCTION__,__LINE__));
         return EFI_BAD_BUFFER_SIZE;
     }
 
@@ -151,7 +151,7 @@ static EFI_STATUS WriteAfterErase_Fill(
     }
     if ((Offset % FlashUnitLength + Length) > FlashUnitLength)
     {
-        DEBUG ((EFI_D_INFO, "[%a]:[%dL]:Exceed the Flash Size!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_INFO, "[%a]:[%dL]:Exceed the Flash Size!\n", __FUNCTION__,__LINE__));
         return EFI_UNSUPPORTED;
     }
 
@@ -159,7 +159,7 @@ static EFI_STATUS WriteAfterErase_Fill(
     Status = gBS->AllocatePool(EfiBootServicesData, FlashUnitLength, (VOID *)&NewDataUnit);
     if (EFI_ERROR(Status))
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:Allocate Pool failed, %r!\n", __FUNCTION__,__LINE__, Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Allocate Pool failed, %r!\n", __FUNCTION__,__LINE__, Status));
         return Status;
     }
 
@@ -177,7 +177,7 @@ static EFI_STATUS WriteAfterErase_Fill(
     Status = BufferWrite(NewOffset, (void *)NewDataUnit, FlashUnitLength);
     if (EFI_ERROR(Status))
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:BufferWrite %r!\n", __FUNCTION__,__LINE__, Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:BufferWrite %r!\n", __FUNCTION__,__LINE__, Status));
         return Status;
     }
 
@@ -205,7 +205,7 @@ static EFI_STATUS WriteAfterErase_Final(
 
     if (0 != (Offset % FlashUnitLength))
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]: Offset must be a multiple of 0x%x!\n", __FUNCTION__,__LINE__,FlashUnitLength));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: Offset must be a multiple of 0x%x!\n", __FUNCTION__,__LINE__,FlashUnitLength));
         return EFI_UNSUPPORTED;
     }
 
@@ -216,7 +216,7 @@ static EFI_STATUS WriteAfterErase_Final(
         Status = BufferWrite(Offset, (void *)Buffer, FlashUnitLength);
         if (EFI_ERROR(Status))
         {
-            DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:BufferWrite Failed: %r!\n", __FUNCTION__,__LINE__, Status));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:BufferWrite Failed: %r!\n", __FUNCTION__,__LINE__, Status));
             return EFI_DEVICE_ERROR;
         }
         Offset += FlashUnitLength;
@@ -230,7 +230,7 @@ static EFI_STATUS WriteAfterErase_Final(
         Status = WriteAfterErase_Fill(Offset, Buffer, Length);
         if (EFI_ERROR(Status))
         {
-            DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:WriteAfterErase_Fill failed,%r!\n", __FUNCTION__,__LINE__, Status));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:WriteAfterErase_Fill failed,%r!\n", __FUNCTION__,__LINE__, Status));
             return Status;
         }
     }
@@ -270,7 +270,7 @@ WriteAfterErase(
         Status = WriteAfterErase_Fill(Offset, Buffer, TempLength);
         if (EFI_ERROR(Status))
         {
-            DEBUG ((EFI_D_ERROR, "[%a]:[%dL]: %r!\n", __FUNCTION__,__LINE__, Status));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: %r!\n", __FUNCTION__,__LINE__, Status));
             return Status;
         }
 
@@ -291,7 +291,7 @@ WriteAfterErase(
     Status = WriteAfterErase_Final(Offset, Buffer, Length);
     if (EFI_ERROR(Status))
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]: %r!\n", __FUNCTION__,__LINE__, Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: %r!\n", __FUNCTION__,__LINE__, Status));
         return Status;
     }
 
@@ -365,7 +365,7 @@ FlashSectorErase(
     Status = WriteAfterErase(TempBase, TempOffset, Buffer, TempLength);
     if (EFI_ERROR(Status))
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]: %r!\n", __FUNCTION__,__LINE__,Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: %r!\n", __FUNCTION__,__LINE__,Status));
         goto DO;
     }
 
@@ -394,7 +394,7 @@ EFIAPI Erase(
 
     if (Offset + Length > (gFlashInfo[gIndex.InfIndex].SingleChipSize * gFlashInfo[gIndex.InfIndex].ParallelNum))
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:Exceed the Flash Size!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Exceed the Flash Size!\n", __FUNCTION__,__LINE__));
         return EFI_ABORTED;
     }
     if (0 == Length)
@@ -427,7 +427,7 @@ EFIAPI Erase(
         Status = FlashSectorErase(TempBase, Offset, TempLength);
         if (EFI_ERROR(Status))
         {
-            DEBUG ((EFI_D_ERROR, "[%a]:[%dL]: FlashErase One Sector Error, Status = %r!\n", __FUNCTION__,__LINE__,Status));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: FlashErase One Sector Error, Status = %r!\n", __FUNCTION__,__LINE__,Status));
             return Status;
         }
 
@@ -462,7 +462,7 @@ EFIAPI Write(
 
     if((Offset + ulLength) > (gFlashInfo[gIndex.InfIndex].SingleChipSize * gFlashInfo[gIndex.InfIndex].ParallelNum))
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:Exceed the Flash Size!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Exceed the Flash Size!\n", __FUNCTION__,__LINE__));
         return EFI_INVALID_PARAMETER;
     }
     if (0 == ulLength)
@@ -498,7 +498,7 @@ EFIAPI Write(
             Status = FlashSectorErase(TempBase, Offset, TempLength);
             if (EFI_ERROR(Status))
             {
-                DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:FlashErase One Sector Error, Status = %r!\n", __FUNCTION__,__LINE__,Status));
+                DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:FlashErase One Sector Error, Status = %r!\n", __FUNCTION__,__LINE__,Status));
                 return Status;
             }
 
@@ -506,7 +506,7 @@ EFIAPI Write(
             Status = WriteAfterErase(TempBase, Offset, Buffer, TempLength);
             if (EFI_ERROR(Status))
             {
-                DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:WriteAfterErase Status = %r!\n", __FUNCTION__,__LINE__,Status));
+                DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:WriteAfterErase Status = %r!\n", __FUNCTION__,__LINE__,Status));
                 return Status;
             }
         }
@@ -535,7 +535,7 @@ VOID SetFlashAttributeToUncache(VOID)
     Status = gBS->LocateProtocol (&gEfiCpuArchProtocolGuid, NULL, (VOID **)&gCpu);
     if (EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "LocateProtocol gEfiCpuArchProtocolGuid Status = %r !\n", Status));
+        DEBUG((DEBUG_ERROR, "LocateProtocol gEfiCpuArchProtocolGuid Status = %r !\n", Status));
     }
 
     Status = gCpu->SetMemoryAttributes(
@@ -547,7 +547,7 @@ VOID SetFlashAttributeToUncache(VOID)
 
     if (EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "gCpu->SetMemoryAttributes Status = %r !\n", Status));
+        DEBUG((DEBUG_ERROR, "gCpu->SetMemoryAttributes Status = %r !\n", Status));
     }
 
 }
@@ -566,12 +566,12 @@ EFIAPI InitializeFlash (
     Status = FlashInit(gIndex.Base);
     if (EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "Init Flash Error !\n"));
+        DEBUG((DEBUG_ERROR, "Init Flash Error !\n"));
         return Status;
     }
     else
     {
-        DEBUG((EFI_D_ERROR, "Init Flash OK!\n"));
+        DEBUG((DEBUG_ERROR, "Init Flash OK!\n"));
     }
 
     Status = gBS->InstallProtocolInterface (
@@ -581,7 +581,7 @@ EFIAPI InitializeFlash (
                             &gUniNorFlash);
     if(EFI_SUCCESS != Status)
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:Install Protocol Interface %r!\n", __FUNCTION__,__LINE__,Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Install Protocol Interface %r!\n", __FUNCTION__,__LINE__,Status));
     }
 
     return Status;

--- a/Silicon/Hisilicon/Drivers/NorFlashDxe/NorFlashDxe.c
+++ b/Silicon/Hisilicon/Drivers/NorFlashDxe/NorFlashDxe.c
@@ -64,17 +64,17 @@ EFIAPI Read(
 
     if (Offset + ulLen > (gFlashInfo[gIndex.InfIndex].SingleChipSize * gFlashInfo[gIndex.InfIndex].ParallelNum))
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Exceed the flash scope!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Exceed the flash scope!\n", __func__,__LINE__));
         return EFI_INVALID_PARAMETER;
     }
     if (0 == ulLen)
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Length is Zero!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Length is Zero!\n", __func__,__LINE__));
         return EFI_INVALID_PARAMETER;
     }
     if (NULL == Buffer)
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Buffer is NULL!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Buffer is NULL!\n", __func__,__LINE__));
         return EFI_BAD_BUFFER_SIZE;
     }
 
@@ -151,7 +151,7 @@ static EFI_STATUS WriteAfterErase_Fill(
     }
     if ((Offset % FlashUnitLength + Length) > FlashUnitLength)
     {
-        DEBUG ((DEBUG_INFO, "[%a]:[%dL]:Exceed the Flash Size!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_INFO, "[%a]:[%dL]:Exceed the Flash Size!\n", __func__,__LINE__));
         return EFI_UNSUPPORTED;
     }
 
@@ -159,7 +159,7 @@ static EFI_STATUS WriteAfterErase_Fill(
     Status = gBS->AllocatePool(EfiBootServicesData, FlashUnitLength, (VOID *)&NewDataUnit);
     if (EFI_ERROR(Status))
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Allocate Pool failed, %r!\n", __FUNCTION__,__LINE__, Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Allocate Pool failed, %r!\n", __func__,__LINE__, Status));
         return Status;
     }
 
@@ -177,7 +177,7 @@ static EFI_STATUS WriteAfterErase_Fill(
     Status = BufferWrite(NewOffset, (void *)NewDataUnit, FlashUnitLength);
     if (EFI_ERROR(Status))
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:BufferWrite %r!\n", __FUNCTION__,__LINE__, Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:BufferWrite %r!\n", __func__,__LINE__, Status));
         return Status;
     }
 
@@ -205,7 +205,7 @@ static EFI_STATUS WriteAfterErase_Final(
 
     if (0 != (Offset % FlashUnitLength))
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: Offset must be a multiple of 0x%x!\n", __FUNCTION__,__LINE__,FlashUnitLength));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: Offset must be a multiple of 0x%x!\n", __func__,__LINE__,FlashUnitLength));
         return EFI_UNSUPPORTED;
     }
 
@@ -216,7 +216,7 @@ static EFI_STATUS WriteAfterErase_Final(
         Status = BufferWrite(Offset, (void *)Buffer, FlashUnitLength);
         if (EFI_ERROR(Status))
         {
-            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:BufferWrite Failed: %r!\n", __FUNCTION__,__LINE__, Status));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:BufferWrite Failed: %r!\n", __func__,__LINE__, Status));
             return EFI_DEVICE_ERROR;
         }
         Offset += FlashUnitLength;
@@ -230,7 +230,7 @@ static EFI_STATUS WriteAfterErase_Final(
         Status = WriteAfterErase_Fill(Offset, Buffer, Length);
         if (EFI_ERROR(Status))
         {
-            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:WriteAfterErase_Fill failed,%r!\n", __FUNCTION__,__LINE__, Status));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:WriteAfterErase_Fill failed,%r!\n", __func__,__LINE__, Status));
             return Status;
         }
     }
@@ -270,7 +270,7 @@ WriteAfterErase(
         Status = WriteAfterErase_Fill(Offset, Buffer, TempLength);
         if (EFI_ERROR(Status))
         {
-            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: %r!\n", __FUNCTION__,__LINE__, Status));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: %r!\n", __func__,__LINE__, Status));
             return Status;
         }
 
@@ -291,7 +291,7 @@ WriteAfterErase(
     Status = WriteAfterErase_Final(Offset, Buffer, Length);
     if (EFI_ERROR(Status))
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: %r!\n", __FUNCTION__,__LINE__, Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: %r!\n", __func__,__LINE__, Status));
         return Status;
     }
 
@@ -365,7 +365,7 @@ FlashSectorErase(
     Status = WriteAfterErase(TempBase, TempOffset, Buffer, TempLength);
     if (EFI_ERROR(Status))
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: %r!\n", __FUNCTION__,__LINE__,Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: %r!\n", __func__,__LINE__,Status));
         goto DO;
     }
 
@@ -394,7 +394,7 @@ EFIAPI Erase(
 
     if (Offset + Length > (gFlashInfo[gIndex.InfIndex].SingleChipSize * gFlashInfo[gIndex.InfIndex].ParallelNum))
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Exceed the Flash Size!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Exceed the Flash Size!\n", __func__,__LINE__));
         return EFI_ABORTED;
     }
     if (0 == Length)
@@ -427,7 +427,7 @@ EFIAPI Erase(
         Status = FlashSectorErase(TempBase, Offset, TempLength);
         if (EFI_ERROR(Status))
         {
-            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: FlashErase One Sector Error, Status = %r!\n", __FUNCTION__,__LINE__,Status));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: FlashErase One Sector Error, Status = %r!\n", __func__,__LINE__,Status));
             return Status;
         }
 
@@ -462,7 +462,7 @@ EFIAPI Write(
 
     if((Offset + ulLength) > (gFlashInfo[gIndex.InfIndex].SingleChipSize * gFlashInfo[gIndex.InfIndex].ParallelNum))
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Exceed the Flash Size!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Exceed the Flash Size!\n", __func__,__LINE__));
         return EFI_INVALID_PARAMETER;
     }
     if (0 == ulLength)
@@ -498,7 +498,7 @@ EFIAPI Write(
             Status = FlashSectorErase(TempBase, Offset, TempLength);
             if (EFI_ERROR(Status))
             {
-                DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:FlashErase One Sector Error, Status = %r!\n", __FUNCTION__,__LINE__,Status));
+                DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:FlashErase One Sector Error, Status = %r!\n", __func__,__LINE__,Status));
                 return Status;
             }
 
@@ -506,7 +506,7 @@ EFIAPI Write(
             Status = WriteAfterErase(TempBase, Offset, Buffer, TempLength);
             if (EFI_ERROR(Status))
             {
-                DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:WriteAfterErase Status = %r!\n", __FUNCTION__,__LINE__,Status));
+                DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:WriteAfterErase Status = %r!\n", __func__,__LINE__,Status));
                 return Status;
             }
         }
@@ -581,7 +581,7 @@ EFIAPI InitializeFlash (
                             &gUniNorFlash);
     if(EFI_SUCCESS != Status)
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Install Protocol Interface %r!\n", __FUNCTION__,__LINE__,Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Install Protocol Interface %r!\n", __func__,__LINE__,Status));
     }
 
     return Status;

--- a/Silicon/Hisilicon/Drivers/NorFlashDxe/NorFlashHw.c
+++ b/Silicon/Hisilicon/Drivers/NorFlashDxe/NorFlashHw.c
@@ -39,7 +39,7 @@ UINT32 PortReadData (
             return MmioRead16 (FlashAddr);
 
         default:
-            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:illegal PortWidth!\n", __FUNCTION__,__LINE__));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:illegal PortWidth!\n", __func__,__LINE__));
             return 0xffffffff;
     }
 }
@@ -61,7 +61,7 @@ PortWriteData (
              MmioWrite16 (FlashAddr, InputData);
              break;
         default:
-             DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:illegal PortWidth!\n", __FUNCTION__,__LINE__));
+             DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:illegal PortWidth!\n", __func__,__LINE__));
              return EFI_DEVICE_ERROR;
     }
     return EFI_SUCCESS;
@@ -107,7 +107,7 @@ EFI_STATUS GetCommandIndex(
 
     if(Flag)
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Can not Get Reset Command!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Can not Get Reset Command!\n", __func__,__LINE__));
         return EFI_DEVICE_ERROR;
     }
 
@@ -124,7 +124,7 @@ EFI_STATUS GetCommandIndex(
 
     if(Flag)
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Can not Get ID Command!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Can not Get ID Command!\n", __func__,__LINE__));
         return EFI_DEVICE_ERROR;
     }
 
@@ -141,7 +141,7 @@ EFI_STATUS GetCommandIndex(
 
     if(Flag)
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Can not Get Write Command!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Can not Get Write Command!\n", __func__,__LINE__));
         return EFI_DEVICE_ERROR;
     }
 
@@ -158,7 +158,7 @@ EFI_STATUS GetCommandIndex(
 
     if(Flag)
     {
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Can not Get Erase Command!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Can not Get Erase Command!\n", __func__,__LINE__));
         return EFI_DEVICE_ERROR;
     }
 
@@ -214,7 +214,7 @@ EFI_STATUS FlashInit(UINT32 Base)
         Status = GetCommandIndex(i);
         if (EFI_ERROR(Status))
          {
-             DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Get Command Index %r!\n", __FUNCTION__,__LINE__, Status));
+             DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Get Command Index %r!\n", __func__,__LINE__, Status));
              return Status;
          }
 
@@ -310,7 +310,7 @@ EFI_STATUS BufferWriteCommand(UINTN Base, UINTN Offset, void *pData)
 
     if(gFlashBusy)
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL]:Flash is busy!\n", __FUNCTION__,__LINE__));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL]:Flash is busy!\n", __func__,__LINE__));
         return EFI_NOT_READY;
     }
     gFlashBusy = TRUE;
@@ -392,7 +392,7 @@ EFI_STATUS SectorEraseCommand(UINTN Base, UINTN Offset)
 
     if(gFlashBusy)
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL]:Flash is busy!\n", __FUNCTION__,__LINE__));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL]:Flash is busy!\n", __func__,__LINE__));
         return EFI_NOT_READY;
     }
 
@@ -434,7 +434,7 @@ EFI_STATUS CompleteCheck(UINT32 Base, UINT32 Offset, void *pData, UINT32 Length)
 
     if(gFlashBusy)
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL]:Flash is busy!\n", __FUNCTION__,__LINE__));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL]:Flash is busy!\n", __func__,__LINE__));
         return EFI_NOT_READY;
     }
     gFlashBusy = TRUE;

--- a/Silicon/Hisilicon/Drivers/NorFlashDxe/NorFlashHw.c
+++ b/Silicon/Hisilicon/Drivers/NorFlashDxe/NorFlashHw.c
@@ -39,7 +39,7 @@ UINT32 PortReadData (
             return MmioRead16 (FlashAddr);
 
         default:
-            DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:illegal PortWidth!\n", __FUNCTION__,__LINE__));
+            DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:illegal PortWidth!\n", __FUNCTION__,__LINE__));
             return 0xffffffff;
     }
 }
@@ -61,7 +61,7 @@ PortWriteData (
              MmioWrite16 (FlashAddr, InputData);
              break;
         default:
-             DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:illegal PortWidth!\n", __FUNCTION__,__LINE__));
+             DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:illegal PortWidth!\n", __FUNCTION__,__LINE__));
              return EFI_DEVICE_ERROR;
     }
     return EFI_SUCCESS;
@@ -80,7 +80,7 @@ UINT32 PortAdjustData(
         case 1:
              return (0x0000ffff & ulInputData );
         default:
-            DEBUG((EFI_D_ERROR,"[FLASH_S29GL256N_PortAdjustData]: Error--illegal g_ulFlashS29Gl256NPortWidth!\n\r"));
+            DEBUG((DEBUG_ERROR,"[FLASH_S29GL256N_PortAdjustData]: Error--illegal g_ulFlashS29Gl256NPortWidth!\n\r"));
             return 0xffffffff;
     }
 }
@@ -107,7 +107,7 @@ EFI_STATUS GetCommandIndex(
 
     if(Flag)
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:Can not Get Reset Command!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Can not Get Reset Command!\n", __FUNCTION__,__LINE__));
         return EFI_DEVICE_ERROR;
     }
 
@@ -124,7 +124,7 @@ EFI_STATUS GetCommandIndex(
 
     if(Flag)
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:Can not Get ID Command!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Can not Get ID Command!\n", __FUNCTION__,__LINE__));
         return EFI_DEVICE_ERROR;
     }
 
@@ -141,7 +141,7 @@ EFI_STATUS GetCommandIndex(
 
     if(Flag)
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:Can not Get Write Command!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Can not Get Write Command!\n", __FUNCTION__,__LINE__));
         return EFI_DEVICE_ERROR;
     }
 
@@ -158,7 +158,7 @@ EFI_STATUS GetCommandIndex(
 
     if(Flag)
     {
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:Can not Get Erase Command!\n", __FUNCTION__,__LINE__));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Can not Get Erase Command!\n", __FUNCTION__,__LINE__));
         return EFI_DEVICE_ERROR;
     }
 
@@ -214,7 +214,7 @@ EFI_STATUS FlashInit(UINT32 Base)
         Status = GetCommandIndex(i);
         if (EFI_ERROR(Status))
          {
-             DEBUG ((EFI_D_ERROR, "[%a]:[%dL]:Get Command Index %r!\n", __FUNCTION__,__LINE__, Status));
+             DEBUG ((DEBUG_ERROR, "[%a]:[%dL]:Get Command Index %r!\n", __FUNCTION__,__LINE__, Status));
              return Status;
          }
 
@@ -235,10 +235,10 @@ EFI_STATUS FlashInit(UINT32 Base)
         TempDev1 = PortReadData(i, Base + (gFlashCommandId[gIndex.IdIndex].DeviceIDAddress1 << gFlashInfo[i].ParallelNum));
         TempDev2 = PortReadData(i, Base + (gFlashCommandId[gIndex.IdIndex].DeviceIDAddress2 << gFlashInfo[i].ParallelNum));
         TempDev3 = PortReadData(i, Base + (gFlashCommandId[gIndex.IdIndex].DeviceIDAddress3 << gFlashInfo[i].ParallelNum));
-        DEBUG ((EFI_D_ERROR, "[cdtest]manufactor ID 0x%x!\n",TempData));
-        DEBUG ((EFI_D_ERROR, "[cdtest]Device ID 1 0x%x!\n",TempDev1));
-        DEBUG ((EFI_D_ERROR, "[cdtest]Device ID 2 0x%x!\n",TempDev2));
-        DEBUG ((EFI_D_ERROR, "[cdtest]Device ID 3 0x%x!\n",TempDev3));
+        DEBUG ((DEBUG_ERROR, "[cdtest]manufactor ID 0x%x!\n",TempData));
+        DEBUG ((DEBUG_ERROR, "[cdtest]Device ID 1 0x%x!\n",TempDev1));
+        DEBUG ((DEBUG_ERROR, "[cdtest]Device ID 2 0x%x!\n",TempDev2));
+        DEBUG ((DEBUG_ERROR, "[cdtest]Device ID 3 0x%x!\n",TempDev3));
 
         FlashReset(Base);
 
@@ -310,7 +310,7 @@ EFI_STATUS BufferWriteCommand(UINTN Base, UINTN Offset, void *pData)
 
     if(gFlashBusy)
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL]:Flash is busy!\n", __FUNCTION__,__LINE__));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL]:Flash is busy!\n", __FUNCTION__,__LINE__));
         return EFI_NOT_READY;
     }
     gFlashBusy = TRUE;
@@ -392,7 +392,7 @@ EFI_STATUS SectorEraseCommand(UINTN Base, UINTN Offset)
 
     if(gFlashBusy)
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL]:Flash is busy!\n", __FUNCTION__,__LINE__));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL]:Flash is busy!\n", __FUNCTION__,__LINE__));
         return EFI_NOT_READY;
     }
 
@@ -434,7 +434,7 @@ EFI_STATUS CompleteCheck(UINT32 Base, UINT32 Offset, void *pData, UINT32 Length)
 
     if(gFlashBusy)
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL]:Flash is busy!\n", __FUNCTION__,__LINE__));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL]:Flash is busy!\n", __FUNCTION__,__LINE__));
         return EFI_NOT_READY;
     }
     gFlashBusy = TRUE;
@@ -463,11 +463,11 @@ EFI_STATUS CompleteCheck(UINT32 Base, UINT32 Offset, void *pData, UINT32 Length)
 
         if((UINT16)(dwTemp1 >> 16) != (UINT16)(dwTestData >> 16))
         {
-            DEBUG((EFI_D_ERROR, "CompleteCheck ERROR: chip1 address %x, buffer %x, flash %x!\n", Offset, dwTestData, dwTemp1));
+            DEBUG((DEBUG_ERROR, "CompleteCheck ERROR: chip1 address %x, buffer %x, flash %x!\n", Offset, dwTestData, dwTemp1));
         }
         if((UINT16)(dwTemp1) != (UINT16)(dwTestData))
         {
-            DEBUG((EFI_D_ERROR, "CompleteCheck ERROR: chip2 address %x, buffer %x, flash %x!\n", Offset, dwTestData, dwTemp1));
+            DEBUG((DEBUG_ERROR, "CompleteCheck ERROR: chip2 address %x, buffer %x, flash %x!\n", Offset, dwTestData, dwTemp1));
         }
     }
     else
@@ -495,13 +495,13 @@ EFI_STATUS CompleteCheck(UINT32 Base, UINT32 Offset, void *pData, UINT32 Length)
 
     for(i = 0; i < 5; i ++)
     {
-        DEBUG((EFI_D_ERROR, "CompleteCheck ERROR: flash %x\n",PortReadData(gIndex.InfIndex, dwTestAddr)));
+        DEBUG((DEBUG_ERROR, "CompleteCheck ERROR: flash %x\n",PortReadData(gIndex.InfIndex, dwTestAddr)));
     }
 
     FlashReset(Base);
 
     gFlashBusy = FALSE;
-    DEBUG((EFI_D_ERROR, "CompleteCheck ERROR: timeout address %x, buffer %x, flash %x\n", Offset, dwTestData, dwTemp1));
+    DEBUG((DEBUG_ERROR, "CompleteCheck ERROR: timeout address %x, buffer %x, flash %x\n", Offset, dwTestData, dwTemp1));
     return EFI_TIMEOUT;
 }
 
@@ -556,7 +556,7 @@ EFI_STATUS BufferWrite(UINT32 Offset, void *pData, UINT32 Length)
             {
                 if (*(UINT8 *)(UINTN)(gIndex.Base + Offset + dwLoop) != *((UINT8 *)pData + dwLoop))
                 {
-                    DEBUG((EFI_D_ERROR, "Flash_WriteUnit ERROR: address %x, buffer %x, flash %x\n", Offset, *((UINT8 *)pData + dwLoop), *(UINT8 *)(UINTN)(gIndex.Base + Offset + dwLoop)));
+                    DEBUG((DEBUG_ERROR, "Flash_WriteUnit ERROR: address %x, buffer %x, flash %x\n", Offset, *((UINT8 *)pData + dwLoop), *(UINT8 *)(UINTN)(gIndex.Base + Offset + dwLoop)));
                     Status = EFI_ABORTED;
                     continue;
                 }
@@ -564,7 +564,7 @@ EFI_STATUS BufferWrite(UINT32 Offset, void *pData, UINT32 Length)
         }
         else
         {
-            DEBUG((EFI_D_ERROR, "Flash_WriteUnit ERROR: complete check failed, %r\n", Status));
+            DEBUG((DEBUG_ERROR, "Flash_WriteUnit ERROR: complete check failed, %r\n", Status));
             continue;
         }
     } while ((Retry--) && EFI_ERROR(Status));
@@ -600,7 +600,7 @@ EFI_STATUS SectorErase(UINT32 Base, UINT32 Offset)
             }
             else
             {
-                DEBUG((EFI_D_ERROR, "Flash_SectorErase ERROR: not all address equal 0xFF\n"));
+                DEBUG((DEBUG_ERROR, "Flash_SectorErase ERROR: not all address equal 0xFF\n"));
 
                 Status = EFI_ABORTED;
                 continue;
@@ -608,7 +608,7 @@ EFI_STATUS SectorErase(UINT32 Base, UINT32 Offset)
         }
         else
         {
-            DEBUG((EFI_D_ERROR, "Flash_SectorErase ERROR: complete check failed, %r\n", Status));
+            DEBUG((DEBUG_ERROR, "Flash_SectorErase ERROR: complete check failed, %r\n", Status));
             continue;
         }
     }while ((Retry--) && EFI_ERROR(Status));

--- a/Silicon/Hisilicon/Drivers/SasPlatform/SasPlatform.c
+++ b/Silicon/Hisilicon/Drivers/SasPlatform/SasPlatform.c
@@ -87,7 +87,7 @@ SasPlatformInitialize (
       FreePool (PrivateData);
       DEBUG ((DEBUG_ERROR,
               "[%a]:[%dL] InstallProtocolInterface fail. %r\n",
-              __FUNCTION__,
+              __func__,
               __LINE__,
               Status));
       continue;

--- a/Silicon/Hisilicon/Drivers/SasV1Dxe/SasV1Dxe.c
+++ b/Silicon/Hisilicon/Drivers/SasV1Dxe/SasV1Dxe.c
@@ -326,7 +326,7 @@ STATIC EFI_STATUS prepare_cmd (
     if (slot->used || (r == (w+1) % QUEUE_SLOTS)) {
       queue = (queue + 1) % QUEUE_CNT;
       if (queue == hba->queue) {
-        DEBUG ((EFI_D_ERROR, "could not find free slot\n"));
+        DEBUG ((DEBUG_ERROR, "could not find free slot\n"));
         return EFI_NOT_READY;
       }
       continue;
@@ -429,10 +429,10 @@ STATIC EFI_STATUS prepare_cmd (
       // Check whether dma transfer error
       if ((data & CMPLT_HDR_ERR_RCRD_XFRD_MSK) &&
         !(data & CMPLT_HDR_RSPNS_XFRD_MSK)) {
-        DEBUG ((EFI_D_VERBOSE, "sas retry data=0x%x\n", data));
-        DEBUG ((EFI_D_VERBOSE, "sts[0]=0x%x\n", sts->status[0]));
-        DEBUG ((EFI_D_VERBOSE, "sts[1]=0x%x\n", sts->status[1]));
-        DEBUG ((EFI_D_VERBOSE, "sts[2]=0x%x\n", sts->status[2]));
+        DEBUG ((DEBUG_VERBOSE, "sas retry data=0x%x\n", data));
+        DEBUG ((DEBUG_VERBOSE, "sts[0]=0x%x\n", sts->status[0]));
+        DEBUG ((DEBUG_VERBOSE, "sts[1]=0x%x\n", sts->status[1]));
+        DEBUG ((DEBUG_VERBOSE, "sts[2]=0x%x\n", sts->status[2]));
         Status = EFI_NOT_READY;
         // wait 1 second and retry, some disk need long time to be ready
         // and ScsiDisk treat retry over 3 times as error

--- a/Silicon/Hisilicon/Drivers/Smbios/AddSmbiosType9/AddSmbiosType9.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/AddSmbiosType9/AddSmbiosType9.c
@@ -52,7 +52,7 @@ UpdateSmbiosType9Info (
                     (VOID **)&PciIo
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n", __FUNCTION__, __LINE__, Status));
+      DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n", __func__, __LINE__, Status));
       continue;
     }
     (VOID)PciIo->GetLocation (PciIo, &SegmentNumber, &BusNumber, &DeviceNumber, &FunctionNumber);
@@ -94,7 +94,7 @@ EmptySmbiosType9 (
       Status = Smbios->Remove (Smbios, SmbiosHandle);
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Remove System Slot Failed. Status : %r\n",
-          __FUNCTION__, __LINE__, Status));
+          __func__, __LINE__, Status));
         break;
       }
     }
@@ -204,7 +204,7 @@ AddSmbiosType9Entry (
                   );
   if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "[%a]:[%dL] LocateProtocol Failed. Status : %r\n",
-        __FUNCTION__, __LINE__, Status));
+        __func__, __LINE__, Status));
       return Status;
   }
 

--- a/Silicon/Hisilicon/Drivers/Smbios/MemorySubClassDxe/MemorySubClass.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/MemorySubClassDxe/MemorySubClass.c
@@ -330,7 +330,7 @@ SmbiosAddType16Table (
     Status = mSmbios->Add (mSmbios, NULL, MemArraySmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *)Type16Record);
     if(EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type16 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type16 Table Log Failed! %r \n", __func__, __LINE__, Status));
     }
 
     FreePool(Type16Record);
@@ -381,7 +381,7 @@ SmbiosAddType19Table (
     Status = mSmbios->Add (mSmbios, NULL, &MemArrayMappedAddrSmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *)Type19Record);
     if(EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type19 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type19 Table Log Failed! %r \n", __func__, __LINE__, Status));
     }
 
     FreePool(Type19Record);
@@ -642,7 +642,7 @@ SmbiosAddType17Table (
     Status = mSmbios->Add (mSmbios, NULL, &MemDevSmbiosHandle, (EFI_SMBIOS_TABLE_HEADER*) Type17Record);
     if(EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type17 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type17 Table Log Failed! %r \n", __func__, __LINE__, Status));
     }
 
     FreePool (Type17Record);

--- a/Silicon/Hisilicon/Drivers/Smbios/MemorySubClassDxe/MemorySubClass.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/MemorySubClassDxe/MemorySubClass.c
@@ -330,7 +330,7 @@ SmbiosAddType16Table (
     Status = mSmbios->Add (mSmbios, NULL, MemArraySmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *)Type16Record);
     if(EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Smbios Type16 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type16 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
     }
 
     FreePool(Type16Record);
@@ -381,7 +381,7 @@ SmbiosAddType19Table (
     Status = mSmbios->Add (mSmbios, NULL, &MemArrayMappedAddrSmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *)Type19Record);
     if(EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Smbios Type19 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type19 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
     }
 
     FreePool(Type19Record);
@@ -642,7 +642,7 @@ SmbiosAddType17Table (
     Status = mSmbios->Add (mSmbios, NULL, &MemDevSmbiosHandle, (EFI_SMBIOS_TABLE_HEADER*) Type17Record);
     if(EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Smbios Type17 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type17 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
     }
 
     FreePool (Type17Record);
@@ -699,7 +699,7 @@ MemorySubClassEntryPoint(
     GuidHob = GetFirstGuidHob(&gHisiEfiMemoryMapGuid);
     if(NULL == GuidHob)
     {
-        DEBUG((EFI_D_ERROR, "Could not get MemoryMap Guid hob.  %r\n"));
+        DEBUG((DEBUG_ERROR, "Could not get MemoryMap Guid hob.  %r\n"));
         return EFI_NOT_FOUND;
     }
     pGblData = (GBL_INTERFACE*) GET_GUID_HOB_DATA(GuidHob);
@@ -710,7 +710,7 @@ MemorySubClassEntryPoint(
     Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID**)&Smbios);
     if (EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "Could not locate SMBIOS protocol.  %r\n", Status));
+        DEBUG((DEBUG_ERROR, "Could not locate SMBIOS protocol.  %r\n", Status));
         return Status;
     }
     mSmbios = Smbios;
@@ -732,14 +732,14 @@ MemorySubClassEntryPoint(
     Status = SmbiosAddType16Table (pGblData, &MemArraySmbiosHandle);
     if(EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "Smbios Add Type16 Table Failed.  %r\n", Status));
+        DEBUG((DEBUG_ERROR, "Smbios Add Type16 Table Failed.  %r\n", Status));
         return Status;
     }
 
     Status = SmbiosAddType19Table (pGblData, MemArraySmbiosHandle);
     if(EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "Smbios Add Type19 Table Failed.  %r\n", Status));
+        DEBUG((DEBUG_ERROR, "Smbios Add Type19 Table Failed.  %r\n", Status));
         return Status;
     }
 
@@ -752,7 +752,7 @@ MemorySubClassEntryPoint(
                 Status = SmbiosAddType17Table (pGblData, Skt, Ch, Dimm, MemArraySmbiosHandle);
                 if(EFI_ERROR(Status))
                 {
-                    DEBUG((EFI_D_ERROR, "Smbios Add Type17 Table Failed.  %r\n", Status));
+                    DEBUG((DEBUG_ERROR, "Smbios Add Type17 Table Failed.  %r\n", Status));
                 }
             }
         }

--- a/Silicon/Hisilicon/Drivers/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
@@ -628,7 +628,7 @@ AddSmbiosProcessorTypeTable (
     Status = mSmbios->Add (mSmbios, NULL, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *)Type4Record);
     if (EFI_ERROR (Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Smbios Type04 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type04 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
     }
     FreePool (Type4Record);
 
@@ -687,7 +687,7 @@ ProcessorSubClassEntryPoint(
     Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID**)&mSmbios);
     if (EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "Could not locate SMBIOS protocol.  %r\n", Status));
+        DEBUG((DEBUG_ERROR, "Could not locate SMBIOS protocol.  %r\n", Status));
         return Status;
     }
 
@@ -718,7 +718,7 @@ ProcessorSubClassEntryPoint(
         Status = AddSmbiosProcessorTypeTable (SocketIndex);
         if(EFI_ERROR(Status))
         {
-            DEBUG((EFI_D_ERROR, "Add Processor Type Table Failed!  %r.\n", Status));
+            DEBUG((DEBUG_ERROR, "Add Processor Type Table Failed!  %r.\n", Status));
             return Status;
         }
     }

--- a/Silicon/Hisilicon/Drivers/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
@@ -628,7 +628,7 @@ AddSmbiosProcessorTypeTable (
     Status = mSmbios->Add (mSmbios, NULL, &SmbiosHandle, (EFI_SMBIOS_TABLE_HEADER *)Type4Record);
     if (EFI_ERROR (Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type04 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type04 Table Log Failed! %r \n", __func__, __LINE__, Status));
     }
     FreePool (Type4Record);
 

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/SmbiosMiscEntryPoint.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/SmbiosMiscEntryPoint.c
@@ -64,7 +64,7 @@ SmbiosMiscEntryPoint(
     EfiStatus = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID**)&Smbios);
     if (EFI_ERROR(EfiStatus))
     {
-        DEBUG((EFI_D_ERROR, "Could not locate SMBIOS protocol.  %r\n", EfiStatus));
+        DEBUG((DEBUG_ERROR, "Could not locate SMBIOS protocol.  %r\n", EfiStatus));
         return EfiStatus;
     }
 
@@ -95,7 +95,7 @@ SmbiosMiscEntryPoint(
 
             if (EFI_ERROR(EfiStatus))
             {
-                DEBUG((EFI_D_ERROR, "Misc smbios store error.  Index=%d, ReturnStatus=%r\n", Index, EfiStatus));
+                DEBUG((DEBUG_ERROR, "Misc smbios store error.  Index=%d, ReturnStatus=%r\n", Index, EfiStatus));
                 return EfiStatus;
             }
         }
@@ -158,7 +158,7 @@ GetLinkTypeHandle(
     *HandleArray = AllocateZeroPool(sizeof(UINT16) * MAX_HANDLE_COUNT);
     if (*HandleArray == NULL)
     {
-        DEBUG ((EFI_D_INFO, "HandleArray allocate memory resource failed.\n"));
+        DEBUG ((DEBUG_INFO, "HandleArray allocate memory resource failed.\n"));
         return;
     }
 

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
@@ -66,7 +66,7 @@ GetBiosReleaseDate (
 
     Hob = GetFirstGuidHob (&gVersionInfoHobGuid);
     if (Hob == NULL) {
-      DEBUG ((EFI_D_ERROR, "[%a:%d] Version info HOB not found!\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "[%a:%d] Version info HOB not found!\n", __FUNCTION__, __LINE__));
       return NULL;
     }
 
@@ -91,7 +91,7 @@ GetBiosVersion (
 
     Hob = GetFirstGuidHob (&gVersionInfoHobGuid);
     if (Hob == NULL) {
-      DEBUG ((EFI_D_ERROR, "[%a:%d] Version info HOB not found!\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "[%a:%d] Version info HOB not found!\n", __FUNCTION__, __LINE__));
       return NULL;
     }
     Version = GET_GUID_HOB_DATA (Hob);
@@ -225,7 +225,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscBiosVendor)
     Status = LogSmbiosData( (UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Smbios Type00 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type00 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
@@ -66,7 +66,7 @@ GetBiosReleaseDate (
 
     Hob = GetFirstGuidHob (&gVersionInfoHobGuid);
     if (Hob == NULL) {
-      DEBUG ((DEBUG_ERROR, "[%a:%d] Version info HOB not found!\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "[%a:%d] Version info HOB not found!\n", __func__, __LINE__));
       return NULL;
     }
 
@@ -91,7 +91,7 @@ GetBiosVersion (
 
     Hob = GetFirstGuidHob (&gVersionInfoHobGuid);
     if (Hob == NULL) {
-      DEBUG ((DEBUG_ERROR, "[%a:%d] Version info HOB not found!\n", __FUNCTION__, __LINE__));
+      DEBUG ((DEBUG_ERROR, "[%a:%d] Version info HOB not found!\n", __func__, __LINE__));
       return NULL;
     }
     Version = GET_GUID_HOB_DATA (Hob);
@@ -225,7 +225,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscBiosVendor)
     Status = LogSmbiosData( (UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type00 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type00 Table Log Failed! %r \n", __func__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturerFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturerFunction.c
@@ -154,7 +154,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscSystemManufacturer)
     Status = LogSmbiosData( (UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type01 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type01 Table Log Failed! %r \n", __func__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturerFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturerFunction.c
@@ -154,7 +154,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscSystemManufacturer)
     Status = LogSmbiosData( (UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Smbios Type01 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type01 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturerFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturerFunction.c
@@ -158,7 +158,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscBaseBoardManufacturer)
     Status = LogSmbiosData( (UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type02 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type02 Table Log Failed! %r \n", __func__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturerFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturerFunction.c
@@ -158,7 +158,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscBaseBoardManufacturer)
     Status = LogSmbiosData( (UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Smbios Type02 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type02 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturerFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturerFunction.c
@@ -163,7 +163,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscChassisManufacturer)
     Status = LogSmbiosData( (UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type03 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type03 Table Log Failed! %r \n", __func__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturerFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturerFunction.c
@@ -163,7 +163,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscChassisManufacturer)
     Status = LogSmbiosData( (UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Smbios Type03 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type03 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type09/MiscSystemSlotDesignationFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type09/MiscSystemSlotDesignationFunction.c
@@ -73,7 +73,7 @@ UpdateSlotUsage(
     Status = OemGetSerdesParam (&SerdesParamA, &SerdesParamB, 0);
     if(EFI_ERROR(Status))
     {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] OemGetSerdesParam failed %r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] OemGetSerdesParam failed %r\n", __func__, __LINE__, Status));
         return;
     }
 
@@ -181,7 +181,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscSystemSlotDesignation)
     Status = LogSmbiosData( (UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status))
     {
-      DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type09 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+      DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type09 Table Log Failed! %r \n", __func__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type09/MiscSystemSlotDesignationFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type09/MiscSystemSlotDesignationFunction.c
@@ -73,7 +73,7 @@ UpdateSlotUsage(
     Status = OemGetSerdesParam (&SerdesParamA, &SerdesParamB, 0);
     if(EFI_ERROR(Status))
     {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] OemGetSerdesParam failed %r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] OemGetSerdesParam failed %r\n", __FUNCTION__, __LINE__, Status));
         return;
     }
 
@@ -181,7 +181,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscSystemSlotDesignation)
     Status = LogSmbiosData( (UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status))
     {
-      DEBUG((EFI_D_ERROR, "[%a]:[%dL] Smbios Type09 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+      DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type09 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type13/MiscNumberOfInstallableLanguagesFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type13/MiscNumberOfInstallableLanguagesFunction.c
@@ -149,7 +149,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscNumberOfInstallableLanguages)
   //
   Status = LogSmbiosData((UINT8*)SmbiosRecord, &SmbiosHandle);
   if(EFI_ERROR(Status)) {
-    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type13 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type13 Table Log Failed! %r \n", __func__, __LINE__, Status));
   }
 
   FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type13/MiscNumberOfInstallableLanguagesFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type13/MiscNumberOfInstallableLanguagesFunction.c
@@ -149,7 +149,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscNumberOfInstallableLanguages)
   //
   Status = LogSmbiosData((UINT8*)SmbiosRecord, &SmbiosHandle);
   if(EFI_ERROR(Status)) {
-    DEBUG((EFI_D_ERROR, "[%a]:[%dL] Smbios Type13 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+    DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type13 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
   }
 
   FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type32/MiscBootInformationFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type32/MiscBootInformationFunction.c
@@ -60,7 +60,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscBootInformation)
     //
     Status = LogSmbiosData( (UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status)) {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type32 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type32 Table Log Failed! %r \n", __func__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type32/MiscBootInformationFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type32/MiscBootInformationFunction.c
@@ -60,7 +60,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscBootInformation)
     //
     Status = LogSmbiosData( (UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status)) {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Smbios Type32 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type32 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type38/MiscIpmiDeviceInformationFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type38/MiscIpmiDeviceInformationFunction.c
@@ -73,7 +73,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscIpmiDeviceInformation)
     //
     Status = LogSmbiosData((UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status)) {
-        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type38 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type38 Table Log Failed! %r \n", __func__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type38/MiscIpmiDeviceInformationFunction.c
+++ b/Silicon/Hisilicon/Drivers/Smbios/SmbiosMiscDxe/Type38/MiscIpmiDeviceInformationFunction.c
@@ -73,7 +73,7 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscIpmiDeviceInformation)
     //
     Status = LogSmbiosData((UINT8*)SmbiosRecord, &SmbiosHandle);
     if(EFI_ERROR(Status)) {
-        DEBUG((EFI_D_ERROR, "[%a]:[%dL] Smbios Type38 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
+        DEBUG((DEBUG_ERROR, "[%a]:[%dL] Smbios Type38 Table Log Failed! %r \n", __FUNCTION__, __LINE__, Status));
     }
 
     FreePool(SmbiosRecord);

--- a/Silicon/Hisilicon/Drivers/UpdateFdtDxe/UpdateFdtDxe.c
+++ b/Silicon/Hisilicon/Drivers/UpdateFdtDxe/UpdateFdtDxe.c
@@ -117,7 +117,7 @@ EFIAPI UpdateFdt (
     Status = EFIFdtUpdate(NewFdtBlobBase);
     if (EFI_ERROR (Status))
     {
-        DEBUG((DEBUG_ERROR, "%a(%d):EFIFdtUpdate Fail!\n", __FUNCTION__,__LINE__));
+        DEBUG((DEBUG_ERROR, "%a(%d):EFIFdtUpdate Fail!\n", __func__,__LINE__));
         goto EXIT;
     }
 

--- a/Silicon/Hisilicon/Drivers/UpdateFdtDxe/UpdateFdtDxe.c
+++ b/Silicon/Hisilicon/Drivers/UpdateFdtDxe/UpdateFdtDxe.c
@@ -33,14 +33,14 @@ InstallFdtIntoConfigurationTable (
   // production device and this ASSERT() becomes not valid.
   if(!(fdt_check_header (FdtBlob) == 0))
   {
-      DEBUG ((EFI_D_ERROR,"can not find FdtBlob \n"));
+      DEBUG ((DEBUG_ERROR,"can not find FdtBlob \n"));
       return EFI_INVALID_PARAMETER;
   }
 
   // Ensure the Size of the Device Tree is smaller than the size of the read file
   if(!((UINTN)fdt_totalsize (FdtBlob) <= FdtSize))
   {
-      DEBUG ((EFI_D_ERROR,"FdtBlob <= FdtSize \n"));
+      DEBUG ((DEBUG_ERROR,"FdtBlob <= FdtSize \n"));
       return EFI_INVALID_PARAMETER;
   }
 
@@ -62,13 +62,13 @@ SetNvramSpace (VOID)
 
     Status = gDS->GetMemorySpaceDescriptor(PcdGet64(PcdReservedNvramBase),&desp);
     if(EFI_ERROR(Status)){
-         DEBUG ((EFI_D_ERROR,"get memory space error:--------- \n"));
+         DEBUG ((DEBUG_ERROR,"get memory space error:--------- \n"));
         return Status;
     }
     desp.Attributes |= EFI_MEMORY_RUNTIME | EFI_MEMORY_WB;
     Status = gDS->SetMemorySpaceAttributes(PcdGet64(PcdReservedNvramBase),PcdGet64(PcdReservedNvramSize), desp.Attributes);
     if(EFI_ERROR(Status)){
-        DEBUG ((EFI_D_ERROR,"set memory space error:--------- \n"));
+        DEBUG ((DEBUG_ERROR,"set memory space error:--------- \n"));
         return Status;
     }
 
@@ -96,10 +96,10 @@ EFIAPI UpdateFdt (
 
 
     Error = fdt_check_header ((VOID*)(PcdGet64(FdtFileAddress)));
-    DEBUG ((EFI_D_ERROR,"fdtfileaddress:--------- 0x%lx\n",PcdGet64(FdtFileAddress)));
+    DEBUG ((DEBUG_ERROR,"fdtfileaddress:--------- 0x%lx\n",PcdGet64(FdtFileAddress)));
     if (Error != 0)
     {
-        DEBUG ((EFI_D_ERROR,"ERROR: Device Tree header not valid (%a)\n", fdt_strerror(Error)));
+        DEBUG ((DEBUG_ERROR,"ERROR: Device Tree header not valid (%a)\n", fdt_strerror(Error)));
         return EFI_INVALID_PARAMETER;
     }
 
@@ -117,16 +117,16 @@ EFIAPI UpdateFdt (
     Status = EFIFdtUpdate(NewFdtBlobBase);
     if (EFI_ERROR (Status))
     {
-        DEBUG((EFI_D_ERROR, "%a(%d):EFIFdtUpdate Fail!\n", __FUNCTION__,__LINE__));
+        DEBUG((DEBUG_ERROR, "%a(%d):EFIFdtUpdate Fail!\n", __FUNCTION__,__LINE__));
         goto EXIT;
     }
 
 
     Status = InstallFdtIntoConfigurationTable ((VOID*)(UINTN)NewFdtBlobBase, NewFdtBlobSize);
-    DEBUG ((EFI_D_ERROR, "NewFdtBlobBase: 0x%lx  NewFdtBlobSize:0x%lx\n",NewFdtBlobBase,NewFdtBlobSize));
+    DEBUG ((DEBUG_ERROR, "NewFdtBlobBase: 0x%lx  NewFdtBlobSize:0x%lx\n",NewFdtBlobBase,NewFdtBlobSize));
     if (EFI_ERROR (Status))
     {
-        DEBUG ((EFI_D_ERROR, "installfdtconfiguration table fail():\n"));
+        DEBUG ((DEBUG_ERROR, "installfdtconfiguration table fail():\n"));
         goto EXIT;
     }
 
@@ -136,7 +136,7 @@ EFIAPI UpdateFdt (
         if (CompareGuid (&gFdtTableGuid, &(gST->ConfigurationTable[Index].VendorGuid)))
         {
             FDTConfigTable = (UINTN)gST->ConfigurationTable[Index].VendorTable;
-            DEBUG ((EFI_D_ERROR, "FDTConfigTable Address: 0x%lx\n",FDTConfigTable));
+            DEBUG ((DEBUG_ERROR, "FDTConfigTable Address: 0x%lx\n",FDTConfigTable));
             break;
         }
     }

--- a/Silicon/Hisilicon/Drivers/VersionInfoPeim/VersionInfoPeim.c
+++ b/Silicon/Hisilicon/Drivers/VersionInfoPeim/VersionInfoPeim.c
@@ -91,7 +91,7 @@ VersionInfoEntry (
                       sizeof (VersionInfo->String) +
                       StrSize (ReleaseString));
   if (VersionInfo == NULL) {
-    DEBUG ((EFI_D_ERROR, "[%a]:[%d] Build HOB failed!\n", __FILE__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "[%a]:[%d] Build HOB failed!\n", __FILE__, __LINE__));
     return EFI_OUT_OF_RESOURCES;
   }
 

--- a/Silicon/Hisilicon/Hi1610/Drivers/IoInitDxe/IoInitDxe.c
+++ b/Silicon/Hisilicon/Hi1610/Drivers/IoInitDxe/IoInitDxe.c
@@ -48,7 +48,7 @@ IoInitDxeEntry (
 
   if (EFI_ERROR(Status))
   {
-    DEBUG ((DEBUG_ERROR, "[%a:%d] - CreateEvent failed: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "[%a:%d] - CreateEvent failed: %r\n", __func__,
         __LINE__, Status));
   }
 

--- a/Silicon/Hisilicon/Hi1610/Drivers/IoInitDxe/IoInitDxe.c
+++ b/Silicon/Hisilicon/Hi1610/Drivers/IoInitDxe/IoInitDxe.c
@@ -21,7 +21,7 @@ ExitBootServicesEventSmmu (
   IN VOID       *Context
   )
 {
-  DEBUG((EFI_D_INFO,"SMMU ExitBootServicesEvent\n"));
+  DEBUG((DEBUG_INFO,"SMMU ExitBootServicesEvent\n"));
 }
 
 
@@ -48,7 +48,7 @@ IoInitDxeEntry (
 
   if (EFI_ERROR(Status))
   {
-    DEBUG ((EFI_D_ERROR, "[%a:%d] - CreateEvent failed: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "[%a:%d] - CreateEvent failed: %r\n", __FUNCTION__,
         __LINE__, Status));
   }
 

--- a/Silicon/Hisilicon/Hi1610/Drivers/PcieInit1610/PcieInit.c
+++ b/Silicon/Hisilicon/Hi1610/Drivers/PcieInit1610/PcieInit.c
@@ -145,7 +145,7 @@ PcieInitEntry (
             Status = PciePortInit(soctype, HostBridgeNum, &gastr_pcie_driver_cfg[Port]);
             if(EFI_ERROR(Status))
             {
-                DEBUG((EFI_D_ERROR, "HostBridge %d, Pcie Port %d Init Failed! \n", HostBridgeNum, Port));
+                DEBUG((DEBUG_ERROR, "HostBridge %d, Pcie Port %d Init Failed! \n", HostBridgeNum, Port));
             }
 
         }

--- a/Silicon/Hisilicon/Hi1610/Drivers/PcieInit1610/PcieInitLib.c
+++ b/Silicon/Hisilicon/Hi1610/Drivers/PcieInit1610/PcieInitLib.c
@@ -135,7 +135,7 @@ VOID PcieRxValidCtrl(UINT32 soctype, UINT32 HostBridgeNum, UINT32 Port, BOOLEAN 
                     MicroSecondDelay(500);
                 }
             if (Loopcnt == 0)
-                DEBUG((EFI_D_ERROR, "pcs locked timeout!\n"));
+                DEBUG((DEBUG_ERROR, "pcs locked timeout!\n"));
             for (i = 0; i < Lanenum; i++) {
                 RegRead(PCIE_PHY_BASE_1610[HostBridgeNum][Port] + 0x204 + i * 0x4, Value);
                 Value &= (~BIT14);
@@ -453,7 +453,7 @@ EFI_STATUS PcieSetupRC(UINT32 Port, PCIE_PORT_WIDTH Width)
     }
     else
     {
-        DEBUG((EFI_D_ERROR,"Width is not valid\n"));
+        DEBUG((DEBUG_ERROR,"Width is not valid\n"));
     }
 
     PcieRegWrite(Port, PCIE_EP_PORT_LOGIC4_REG, Value);
@@ -477,7 +477,7 @@ EFI_STATUS PcieSetupRC(UINT32 Port, PCIE_PORT_WIDTH Width)
     }
     else
     {
-        DEBUG((EFI_D_ERROR,"Width is not valid\n"));
+        DEBUG((DEBUG_ERROR,"Width is not valid\n"));
     }
 
     logic22.UInt32 |= (0x100<<8);
@@ -1150,7 +1150,7 @@ PciePortInit (
      else
      {
          mPcieIntCfg.RegResource[PortIndex] = (VOID *)(UINTN)PCIE_REG_BASE(HostBridgeNum, PortIndex);
-         DEBUG((EFI_D_INFO, "Soc type is 660\n"));
+         DEBUG((DEBUG_INFO, "Soc type is 660\n"));
      }
 
      /* assert reset signals */
@@ -1168,7 +1168,7 @@ PciePortInit (
          MicroSecondDelay(1000);
          Count++;
          if (Count >= 50) {
-            DEBUG((EFI_D_ERROR, "HostBridge %d, Port %d PLL Lock failed\n", HostBridgeNum, PortIndex));
+            DEBUG((DEBUG_ERROR, "HostBridge %d, Port %d PLL Lock failed\n", HostBridgeNum, PortIndex));
             return PCIE_ERR_LINK_OVER_TIME;
          }
      }
@@ -1209,11 +1209,11 @@ PciePortInit (
          MicroSecondDelay(1000);
          Count++;
          if (Count >= 1000) {
-            DEBUG((EFI_D_ERROR, "HostBridge %d, Port %d link up failed\n", HostBridgeNum, PortIndex));
+            DEBUG((DEBUG_ERROR, "HostBridge %d, Port %d link up failed\n", HostBridgeNum, PortIndex));
             return PCIE_ERR_LINK_OVER_TIME;
          }
      }
-     DEBUG((EFI_D_INFO, "HostBridge %d, Port %d Link up ok\n", HostBridgeNum, PortIndex));
+     DEBUG((DEBUG_INFO, "HostBridge %d, Port %d Link up ok\n", HostBridgeNum, PortIndex));
 
      PcieRegWrite(PortIndex, 0x8BC, 0);
 

--- a/Silicon/Hisilicon/Hi1610/Library/Hi161xPciPlatformLib/Hi161xPciPlatformLib.c
+++ b/Silicon/Hisilicon/Hi1610/Library/Hi161xPciPlatformLib/Hi161xPciPlatformLib.c
@@ -55,7 +55,7 @@ GetAppetureByRootBridgeIo (
       );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a:%d] RootBridgeIo->Configuration failed %r\n",
-          __FUNCTION__, __LINE__, Status));
+          __func__, __LINE__, Status));
     return NULL;
   };
 
@@ -67,7 +67,7 @@ GetAppetureByRootBridgeIo (
   }
 
   if (Configuration->Desc != ACPI_ADDRESS_SPACE_DESCRIPTOR) {
-    DEBUG ((DEBUG_ERROR, "[%a:%d] Can't find bus descriptor\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "[%a:%d] Can't find bus descriptor\n", __func__, __LINE__));
     return NULL;
   }
 
@@ -81,7 +81,7 @@ GetAppetureByRootBridgeIo (
     }
   }
 
-  DEBUG ((DEBUG_ERROR, "[%a:%d] Can't find PCI appeture\n", __FUNCTION__, __LINE__));
+  DEBUG ((DEBUG_ERROR, "[%a:%d] Can't find PCI appeture\n", __func__, __LINE__));
   return NULL;
 }
 
@@ -109,7 +109,7 @@ SetAtuConfig0RW (
   {
     UINTN i;
     for (i=0; i<0x20; i+=4) {
-      DEBUG ((DEBUG_ERROR, "[%a:%d] - Base=%p value=%x\n", __FUNCTION__, __LINE__, RbPciBase + 0x900 + i, MmioRead32(RbPciBase + 0x900 + i)));
+      DEBUG ((DEBUG_ERROR, "[%a:%d] - Base=%p value=%x\n", __func__, __LINE__, RbPciBase + 0x900 + i, MmioRead32(RbPciBase + 0x900 + i)));
     }
   }
 }
@@ -138,7 +138,7 @@ SetAtuConfig1RW (
   {
     UINTN i;
     for (i=0; i<0x20; i+=4) {
-      DEBUG ((DEBUG_ERROR, "[%a:%d] - Base=%p value=%x\n", __FUNCTION__, __LINE__, RbPciBase + 0x900 + i, MmioRead32(RbPciBase + 0x900 + i)));
+      DEBUG ((DEBUG_ERROR, "[%a:%d] - Base=%p value=%x\n", __func__, __LINE__, RbPciBase + 0x900 + i, MmioRead32(RbPciBase + 0x900 + i)));
     }
   }
 }
@@ -162,7 +162,7 @@ SetAtuIoRW (UINT64 RbPciBase,UINT64 IoBase,UINT64 CpuIoRegionLimit, UINT64 CpuIo
     {
       UINTN i;
       for (i=0; i<0x20; i+=4) {
-        DEBUG ((DEBUG_ERROR, "[%a:%d] - Base=%p value=%x\n", __FUNCTION__, __LINE__, RbPciBase + 0x900 + i, MmioRead32(RbPciBase + 0x900 + i)));
+        DEBUG ((DEBUG_ERROR, "[%a:%d] - Base=%p value=%x\n", __func__, __LINE__, RbPciBase + 0x900 + i, MmioRead32(RbPciBase + 0x900 + i)));
       }
     }
 }
@@ -186,7 +186,7 @@ SetAtuMemRW(UINT64 RbPciBase,UINT64 MemBase,UINT64 CpuMemRegionLimit, UINT64 Cpu
     {
       UINTN i;
       for (i=0; i<0x20; i+=4) {
-        DEBUG ((DEBUG_ERROR, "[%a:%d] - Base=%p value=%x\n", __FUNCTION__, __LINE__, RbPciBase + 0x900 + i, MmioRead32(RbPciBase + 0x900 + i)));
+        DEBUG ((DEBUG_ERROR, "[%a:%d] - Base=%p value=%x\n", __func__, __LINE__, RbPciBase + 0x900 + i, MmioRead32(RbPciBase + 0x900 + i)));
       }
     }
 }
@@ -296,7 +296,7 @@ EnlargeAtuConfig0 (
       (VOID **)&ResAlloc
       );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "[%a:%d] - HandleProtocol failed %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "[%a:%d] - HandleProtocol failed %r\n", __func__,
           __LINE__, Status));
     return;
   }
@@ -315,7 +315,7 @@ EnlargeAtuConfig0 (
         (VOID **)&RootBridgeIo
         );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "[%a:%d] - HandleProtocol failed %r\n", __FUNCTION__, __LINE__, Status));
+      DEBUG ((DEBUG_ERROR, "[%a:%d] - HandleProtocol failed %r\n", __func__, __LINE__, Status));
       // This should never happen so that it is a fatal error and we don't try
       // to continue
       break;
@@ -323,7 +323,7 @@ EnlargeAtuConfig0 (
 
     Appeture = GetAppetureByRootBridgeIo (RootBridgeIo);
     if (Appeture == NULL) {
-      DEBUG ((DEBUG_ERROR, "[%a:%d] Get appeture failed\n", __FUNCTION__,
+      DEBUG ((DEBUG_ERROR, "[%a:%d] Get appeture failed\n", __func__,
             __LINE__));
       continue;
     }

--- a/Silicon/Hisilicon/Hi1620/Drivers/Apei/Apei.c
+++ b/Silicon/Hisilicon/Hi1620/Drivers/Apei/Apei.c
@@ -48,7 +48,7 @@ ApeiEntryPoint (
   if (EFI_ERROR (Status)) {
     SetupData.EnRasSupport = 1;
     DEBUG ((DEBUG_ERROR, "[%a]GetVariable %r.Get default variable value\n",
-      __FUNCTION__, Status));
+      __func__, Status));
   }
   if (!SetupData.EnRasSupport) {
     return EFI_ABORTED;
@@ -89,7 +89,7 @@ ApeiEntryPoint (
   Status |= OemInitErstTable ();
   Status |= OemInitEinjTable ();
   // smc call
-  DEBUG ((DEBUG_INFO, "[%a]:[%dL]: %r\n", __FUNCTION__, __LINE__, Status));
+  DEBUG ((DEBUG_INFO, "[%a]:[%dL]: %r\n", __func__, __LINE__, Status));
   if (Status == EFI_SUCCESS) {
     SmcRegs.Arg0 = PRIVATE_ARM_SMC_ID_APEI;
     SmcRegs.Arg1 = (UINTN)mApeiTrustedfirmwareData;

--- a/Silicon/Hisilicon/Hi1620/Drivers/Apei/ErrorSource/Ghes.c
+++ b/Silicon/Hisilicon/Hi1620/Drivers/Apei/ErrorSource/Ghes.c
@@ -63,7 +63,7 @@ ErrorBlockAddErrorData (
 )
 {
   if (ErrorBlock == NULL || GenericErrorData == NULL) {
-    DEBUG ((DEBUG_ERROR, "[%a]:[%dL]Invalid Param \n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL]Invalid Param \n", __func__, __LINE__));
     return FALSE;
   }
   EFI_ACPI_6_1_GENERIC_ERROR_DATA_ENTRY_STRUCTURE*  Entry;
@@ -75,7 +75,7 @@ ErrorBlockAddErrorData (
            SizeOfGenericErrorData;
   if (sizeof (EFI_ACPI_6_1_GENERIC_ERROR_STATUS_STRUCTURE) + ExpectedNewDataLength >
       MaxBlockLength) {
-    DEBUG ((DEBUG_ERROR, "[%a]:[%dL]Out of BlockSize \n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL]Out of BlockSize \n", __func__, __LINE__));
     return FALSE;
   }
   // guid

--- a/Silicon/Hisilicon/Hi1620/Drivers/Apei/Hest/Hest.c
+++ b/Silicon/Hisilicon/Hi1620/Drivers/Apei/Hest/Hest.c
@@ -31,7 +31,7 @@ EFI_STATUS HestAddErrorSourceDescriptor (
   }
   HestHeader = Context->HestHeader;
   if (HestHeader->Header.Length + SizeOfDescriptor > Context->OccupiedMemorySize) {
-    DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: Hest Size Too small\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: Hest Size Too small\n", __func__, __LINE__));
     return EFI_BUFFER_TOO_SMALL;
   }
   Descriptor = (UINT8*)HestHeader + HestHeader->Header.Length;
@@ -58,7 +58,7 @@ HestSetAcpiTable (
   UINTN                     TableKey;
   UINT32                    Index;
   if (Context == NULL) {
-    DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: ERROR\n", __FUNCTION__, __LINE__));
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL]: ERROR\n", __func__, __LINE__));
     return;
   }
 
@@ -83,7 +83,7 @@ HestSetAcpiTable (
     mApeiTrustedfirmwareData->HestTableAddress = (EFI_PHYSICAL_ADDRESS)Table;
     DEBUG ((DEBUG_INFO, "Acpi HestSetAcpiTable Table = 0x%x.\n", (EFI_PHYSICAL_ADDRESS)Table));
   }
-  DEBUG ((DEBUG_INFO, "[%a]:[%dL]:OUT %llx, IN %llx \n", __FUNCTION__, __LINE__,
+  DEBUG ((DEBUG_INFO, "[%a]:[%dL]:OUT %llx, IN %llx \n", __func__, __LINE__,
           AcpiTableHandle, Context->HestHeader));
   return;
 }

--- a/Silicon/Hisilicon/Hi1620/Drivers/Apei/OemApeiHi1620.c
+++ b/Silicon/Hisilicon/Hi1620/Drivers/Apei/OemApeiHi1620.c
@@ -228,7 +228,7 @@ OemInitBertTable (
   }
   ErrorBlockInitial (Context.Block, EFI_ACPI_6_2_ERROR_SEVERITY_NONE);
   BertSetAcpiTable (&Context);
-  DEBUG ((DEBUG_INFO, "[%a]:[%dL]: %r\n", __FUNCTION__, __LINE__, Status));
+  DEBUG ((DEBUG_INFO, "[%a]:[%dL]: %r\n", __func__, __LINE__, Status));
   return EFI_SUCCESS;
 }
 /************************************************
@@ -261,7 +261,7 @@ OemInitEinjTable (
   (VOID)EinjConfigErrorInjectCapability (&Context, 0xFFF);// TBD
   (VOID)OemEinjConfigExecuteOperationEntry (&Context);
   EinjSetAcpiTable (&Context);
-  DEBUG ((DEBUG_INFO, "[%a]:[%dL]: %d\n", __FUNCTION__, __LINE__, Status));
+  DEBUG ((DEBUG_INFO, "[%a]:[%dL]: %d\n", __func__, __LINE__, Status));
   return EFI_SUCCESS;
 }
 /************************************************

--- a/Silicon/Hisilicon/Hi1620/Hi1620OemConfigUiLib/OemConfig.c
+++ b/Silicon/Hisilicon/Hi1620/Hi1620OemConfigUiLib/OemConfig.c
@@ -205,7 +205,7 @@ OemConfigUiLibConstructor (
                                    NULL
                                    );
   if (mOemConfigPrivate.HiiHandle == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a Fail to Add Oem Hii Package.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a Fail to Add Oem Hii Package.\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
   //

--- a/Silicon/Hisilicon/Hi1620/Pptt/Pptt.c
+++ b/Silicon/Hisilicon/Hi1620/Pptt/Pptt.c
@@ -366,7 +366,7 @@ GetApic (
     // Avoid dead loop due to corrupted MADT
     if (Ptr->Length == 0) {
       DEBUG ((DEBUG_ERROR, "[%a:%d] - Invalid MADT sub structure at 0x%x\n",
-            __FUNCTION__, __LINE__, (UINTN) Ptr - (UINTN) ApicTable));
+            __func__, __LINE__, (UINTN) Ptr - (UINTN) ApicTable));
       break;
     }
 

--- a/Silicon/Hisilicon/Library/ArmPlatformLibHisilicon/ArmPlatformLibMem.c
+++ b/Silicon/Hisilicon/Library/ArmPlatformLibHisilicon/ArmPlatformLibMem.c
@@ -81,7 +81,7 @@ ArmPlatformGetVirtualMemoryMap (
   VirtualMemoryTable[Index].Attributes   = (ARM_MEMORY_REGION_ATTRIBUTES)0;
 
   ASSERT((Index + 1) <= MAX_VIRTUAL_MEMORY_MAP_DESCRIPTORS);
-  DEBUG((EFI_D_INFO, "[%a]:[%dL] discriptor count=%d\n", __FUNCTION__, __LINE__, Index+1));
+  DEBUG((DEBUG_INFO, "[%a]:[%dL] discriptor count=%d\n", __FUNCTION__, __LINE__, Index+1));
 
   *VirtualMemoryMap = VirtualMemoryTable;
 }

--- a/Silicon/Hisilicon/Library/ArmPlatformLibHisilicon/ArmPlatformLibMem.c
+++ b/Silicon/Hisilicon/Library/ArmPlatformLibHisilicon/ArmPlatformLibMem.c
@@ -81,7 +81,7 @@ ArmPlatformGetVirtualMemoryMap (
   VirtualMemoryTable[Index].Attributes   = (ARM_MEMORY_REGION_ATTRIBUTES)0;
 
   ASSERT((Index + 1) <= MAX_VIRTUAL_MEMORY_MAP_DESCRIPTORS);
-  DEBUG((DEBUG_INFO, "[%a]:[%dL] discriptor count=%d\n", __FUNCTION__, __LINE__, Index+1));
+  DEBUG((DEBUG_INFO, "[%a]:[%dL] discriptor count=%d\n", __func__, __LINE__, Index+1));
 
   *VirtualMemoryMap = VirtualMemoryTable;
 }

--- a/Silicon/Hisilicon/Library/CpldIoLib/CpldIoLibRuntime.c
+++ b/Silicon/Hisilicon/Library/CpldIoLib/CpldIoLibRuntime.c
@@ -45,13 +45,13 @@ CpldRuntimeLibConstructor (
     mCpldRegAddr = PcdGet64(PcdCpldBaseAddress);
     Status = gDS->GetMemorySpaceDescriptor(mCpldRegAddr,&desp);
     if(EFI_ERROR(Status)){
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL] GetMemorySpaceDescriptor failed: %r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL] GetMemorySpaceDescriptor failed: %r\n", __FUNCTION__, __LINE__, Status));
         return Status;
     }
     desp.Attributes |= EFI_MEMORY_RUNTIME;
     Status = gDS->SetMemorySpaceAttributes(mCpldRegAddr,0x10000, desp.Attributes);
     if(EFI_ERROR(Status)){
-        DEBUG ((EFI_D_ERROR, "[%a]:[%dL] SetMemorySpaceAttributes failed: %r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL] SetMemorySpaceAttributes failed: %r\n", __FUNCTION__, __LINE__, Status));
         return Status;
     }
     //

--- a/Silicon/Hisilicon/Library/CpldIoLib/CpldIoLibRuntime.c
+++ b/Silicon/Hisilicon/Library/CpldIoLib/CpldIoLibRuntime.c
@@ -45,13 +45,13 @@ CpldRuntimeLibConstructor (
     mCpldRegAddr = PcdGet64(PcdCpldBaseAddress);
     Status = gDS->GetMemorySpaceDescriptor(mCpldRegAddr,&desp);
     if(EFI_ERROR(Status)){
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL] GetMemorySpaceDescriptor failed: %r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL] GetMemorySpaceDescriptor failed: %r\n", __func__, __LINE__, Status));
         return Status;
     }
     desp.Attributes |= EFI_MEMORY_RUNTIME;
     Status = gDS->SetMemorySpaceAttributes(mCpldRegAddr,0x10000, desp.Attributes);
     if(EFI_ERROR(Status)){
-        DEBUG ((DEBUG_ERROR, "[%a]:[%dL] SetMemorySpaceAttributes failed: %r\n", __FUNCTION__, __LINE__, Status));
+        DEBUG ((DEBUG_ERROR, "[%a]:[%dL] SetMemorySpaceAttributes failed: %r\n", __func__, __LINE__, Status));
         return Status;
     }
     //

--- a/Silicon/Hisilicon/Library/I2CLib/I2CLibRuntime.c
+++ b/Silicon/Hisilicon/Library/I2CLib/I2CLibRuntime.c
@@ -69,12 +69,12 @@ I2cLibRuntimeSetup (UINT32 Socket, UINT8 Port)
       EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
       );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_WARN, "[%a:%d] AddMemorySpace failed: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_WARN, "[%a:%d] AddMemorySpace failed: %r\n", __func__, __LINE__, Status));
   }
 
   Status = gDS->SetMemorySpaceAttributes (Base, SIZE_64KB, EFI_MEMORY_UC | EFI_MEMORY_RUNTIME);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "[%a:%d] SetMemorySpaceAttributes failed: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "[%a:%d] SetMemorySpaceAttributes failed: %r\n", __func__, __LINE__, Status));
     return Status;
   }
 
@@ -92,7 +92,7 @@ I2cLibRuntimeSetup (UINT32 Socket, UINT8 Port)
         &mI2cLibVirtualAddrChangeEvent
     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "[%a:%d] Create event failed: %r\n", __FUNCTION__, __LINE__, Status));
+      DEBUG ((DEBUG_ERROR, "[%a:%d] Create event failed: %r\n", __func__, __LINE__, Status));
       return Status;
     }
   }

--- a/Silicon/Hisilicon/Library/I2CLib/I2CLibRuntime.c
+++ b/Silicon/Hisilicon/Library/I2CLib/I2CLibRuntime.c
@@ -69,12 +69,12 @@ I2cLibRuntimeSetup (UINT32 Socket, UINT8 Port)
       EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
       );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_WARN, "[%a:%d] AddMemorySpace failed: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_WARN, "[%a:%d] AddMemorySpace failed: %r\n", __FUNCTION__, __LINE__, Status));
   }
 
   Status = gDS->SetMemorySpaceAttributes (Base, SIZE_64KB, EFI_MEMORY_UC | EFI_MEMORY_RUNTIME);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "[%a:%d] SetMemorySpaceAttributes failed: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "[%a:%d] SetMemorySpaceAttributes failed: %r\n", __FUNCTION__, __LINE__, Status));
     return Status;
   }
 
@@ -92,7 +92,7 @@ I2cLibRuntimeSetup (UINT32 Socket, UINT8 Port)
         &mI2cLibVirtualAddrChangeEvent
     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "[%a:%d] Create event failed: %r\n", __FUNCTION__, __LINE__, Status));
+      DEBUG ((DEBUG_ERROR, "[%a:%d] Create event failed: %r\n", __FUNCTION__, __LINE__, Status));
       return Status;
     }
   }

--- a/Silicon/Hisilicon/Library/M41T83RealTimeClockLib/M41T83RealTimeClockLib.c
+++ b/Silicon/Hisilicon/Library/M41T83RealTimeClockLib/M41T83RealTimeClockLib.c
@@ -108,25 +108,25 @@ InitializeM41T83 (
   Status = RtcRead (M41T83_REGADDR_SECONDS, 1, &Second.Uint8);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n",
-      __FUNCTION__, __LINE__, Status));
+      __func__, __LINE__, Status));
   }
   Second.Bits.ST= 1;
   Status = RtcWrite (M41T83_REGADDR_SECONDS, 1, &Second.Uint8);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n",
-      __FUNCTION__, __LINE__, Status));
+      __func__, __LINE__, Status));
     goto Exit;
   }
   Status = RtcRead (M41T83_REGADDR_SECONDS, 1, &Second.Uint8);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n",
-      __FUNCTION__, __LINE__, Status));
+      __func__, __LINE__, Status));
   }
   Second.Bits.ST= 0;
   Status = RtcWrite (M41T83_REGADDR_SECONDS, 1, &Second.Uint8);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n",
-      __FUNCTION__, __LINE__, Status));
+      __func__, __LINE__, Status));
     goto Exit;
   }
 
@@ -134,13 +134,13 @@ InitializeM41T83 (
   Status = RtcRead (M41T83_REGADDR_ALARM1HOUR, 1, &Alarm1Hour.Uint8);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n",
-      __FUNCTION__, __LINE__, Status));
+      __func__, __LINE__, Status));
   }
   Alarm1Hour.Bits.HT = 0;
   Status = RtcWrite (M41T83_REGADDR_ALARM1HOUR, 1, &Alarm1Hour.Uint8);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n",
-      __FUNCTION__, __LINE__, Status));
+      __func__, __LINE__, Status));
     goto Exit;
   }
 
@@ -181,7 +181,7 @@ LibSetTime (
   if (!IsTimeValid (Time)) {
     if (!EfiAtRuntime ()) {
       DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n",
-        __FUNCTION__, __LINE__, Status));
+        __func__, __LINE__, Status));
       DEBUG ((DEBUG_ERROR, "Now RTC Time is : %04d-%02d-%02d %02d:%02d:%02d\n",
         Time->Year, Time->Month, Time->Day, Time->Hour, Time->Minute, Time->Second
       ));
@@ -252,7 +252,7 @@ Exit:
   if (!EfiAtRuntime ()) {
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n",
-        __FUNCTION__, LineNum, Status));
+        __func__, LineNum, Status));
     }
     EfiReleaseLock (&mRtcLock);
   }
@@ -342,10 +342,10 @@ Exit:
   if (!EfiAtRuntime ()) {
     if (EFI_ERROR (Status)) {
       if (IsTimeInvalid == TRUE) {
-        DEBUG((DEBUG_ERROR, "%a(%d) Time invalid.\r\n",__FUNCTION__, LineNum));
+        DEBUG((DEBUG_ERROR, "%a(%d) Time invalid.\r\n",__func__, LineNum));
       } else {
         DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Status : %r\n",
-          __FUNCTION__, LineNum, Status));
+          __func__, LineNum, Status));
       }
     }
     EfiReleaseLock (&mRtcLock);
@@ -429,7 +429,7 @@ LibRtcInitialize (
   Status = InitializeM41T83 ();
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Status : %r\nRTC M41T83 Init Failed !!!\n",
-            __FUNCTION__, __LINE__, Status));
+            __func__, __LINE__, Status));
     /*
      * Returning ERROR on failure of RTC initilization will cause the system to hang up.
      * So we add some debug message to indecate the RTC initilization failed,
@@ -450,7 +450,7 @@ LibRtcInitialize (
     Status = LibSetTime (&EfiTime);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "[%a]:[%dL] RTC settime Status : %r\n",
-        __FUNCTION__, __LINE__, Status));
+        __func__, __LINE__, Status));
     }
   }
 

--- a/Silicon/Hisilicon/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/Silicon/Hisilicon/Library/PlatformBootManagerLib/PlatformBm.c
@@ -193,7 +193,7 @@ FilterAndProcess (
     //
     // This is not an error, just an informative condition.
     //
-    DEBUG ((DEBUG_VERBOSE, "%a: %g: %r\n", __FUNCTION__, ProtocolGuid,
+    DEBUG ((DEBUG_VERBOSE, "%a: %g: %r\n", __func__, ProtocolGuid,
       Status));
     return;
   }
@@ -254,7 +254,7 @@ IsPciDisplay (
   Status = PciIo->Pci.Read (PciIo, EfiPciIoWidthUint32, 0 /* Offset */,
                         sizeof Pci / sizeof (UINT32), &Pci);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: %s: %r\n", __FUNCTION__, ReportText, Status));
+    DEBUG ((DEBUG_ERROR, "%a: %s: %r\n", __func__, ReportText, Status));
     return FALSE;
   }
 
@@ -283,7 +283,7 @@ Connect (
                   FALSE   // Recursive
                   );
   DEBUG ((EFI_ERROR (Status) ? DEBUG_ERROR : DEBUG_VERBOSE, "%a: %s: %r\n",
-    __FUNCTION__, ReportText, Status));
+    __func__, ReportText, Status));
 }
 
 
@@ -305,25 +305,25 @@ AddOutput (
   DevicePath = DevicePathFromHandle (Handle);
   if (DevicePath == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: %s: handle %p: device path not found\n",
-      __FUNCTION__, ReportText, Handle));
+      __func__, ReportText, Handle));
     return;
   }
 
   Status = EfiBootManagerUpdateConsoleVariable (ConOut, DevicePath, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ConOut: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ConOut: %r\n", __func__,
       ReportText, Status));
     return;
   }
 
   Status = EfiBootManagerUpdateConsoleVariable (ErrOut, DevicePath, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ErrOut: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ErrOut: %r\n", __func__,
       ReportText, Status));
     return;
   }
 
-  DEBUG ((DEBUG_VERBOSE, "%a: %s: added to ConOut and ErrOut\n", __FUNCTION__,
+  DEBUG ((DEBUG_VERBOSE, "%a: %s: added to ConOut and ErrOut\n", __func__,
     ReportText));
 }
 
@@ -657,7 +657,7 @@ PlatformBootManagerAfterConsole (
     if (SetupData.BmcWdtEnable) {
       Status = IpmiCmdStopWatchdogTimer (EfiBiosPost);
       if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "%a:%r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a:%r\n", __func__, Status));
       }
     }
   }

--- a/Silicon/Hisilicon/Library/RtcHelperLib/RtcHelperLib.c
+++ b/Silicon/Hisilicon/Library/RtcHelperLib/RtcHelperLib.c
@@ -34,7 +34,7 @@ SwitchRtcI2cChannelAndLock (
       if (Count == 99) {
         if (!EfiAtRuntime ()) {
           DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Clear cpu_i2c_rtc_state 100 times fail!\n",
-            __FUNCTION__, __LINE__));
+            __func__, __LINE__));
         }
         return EFI_DEVICE_ERROR;
       }
@@ -55,7 +55,7 @@ SwitchRtcI2cChannelAndLock (
     if (Count == 99) {
       if (!EfiAtRuntime ()) {
         DEBUG ((DEBUG_ERROR, "[%a]:[%dL]  Clear cpu_i2c_rtc_state fail !!! \n",
-          __FUNCTION__, __LINE__));
+          __func__, __LINE__));
       }
       return EFI_DEVICE_ERROR;
     }

--- a/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/LibraryPrivate/BaseSpiCommonLib/SpiCommon.c
+++ b/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/Spi/LibraryPrivate/BaseSpiCommonLib/SpiCommon.c
@@ -963,7 +963,7 @@ SpiProtocolFlashReadSfdp (
   UINT32            FlashAddress;
 
   if (SpiIsSafModeActive ()) {
-    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __func__));
     return EFI_UNSUPPORTED;
   }
 
@@ -1022,7 +1022,7 @@ SpiProtocolFlashReadJedecId (
   UINT32            Address;
 
   if (SpiIsSafModeActive ()) {
-    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __func__));
     return EFI_UNSUPPORTED;
   }
 
@@ -1076,7 +1076,7 @@ SpiProtocolFlashWriteStatus (
   EFI_STATUS        Status;
 
   if (SpiIsSafModeActive ()) {
-    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __func__));
     return EFI_UNSUPPORTED;
   }
 
@@ -1117,7 +1117,7 @@ SpiProtocolFlashReadStatus (
   EFI_STATUS        Status;
 
   if (SpiIsSafModeActive ()) {
-    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __func__));
     return EFI_UNSUPPORTED;
   }
 

--- a/Silicon/Intel/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceMm.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceMm.c
@@ -121,7 +121,7 @@ FvbInitialize (
   Status = GetVariableFlashNvStorageInfo (&BaseAddress, &NvStorageFvSize);
   if (EFI_ERROR (Status)) {
     ASSERT_EFI_ERROR (Status);
-    DEBUG ((DEBUG_ERROR, "[%a] - An error ocurred getting variable info - %r.\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "[%a] - An error ocurred getting variable info - %r.\n", __func__, Status));
     return;
   }
 
@@ -129,7 +129,7 @@ FvbInitialize (
   Status = SafeUint64ToUint32 (BaseAddress, &mPlatformFvBaseAddress[0].FvBase);
   if (EFI_ERROR (Status)) {
     ASSERT_EFI_ERROR (Status);
-    DEBUG ((DEBUG_ERROR, "[%a] - 64-bit variable storage base address not supported.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "[%a] - 64-bit variable storage base address not supported.\n", __func__));
     return;
   }
   NvStorageBaseAddress = mPlatformFvBaseAddress[0].FvBase;
@@ -137,7 +137,7 @@ FvbInitialize (
   Status = SafeUint64ToUint32 (NvStorageFvSize, &mPlatformFvBaseAddress[0].FvSize);
   if (EFI_ERROR (Status)) {
     ASSERT_EFI_ERROR (Status);
-    DEBUG ((DEBUG_ERROR, "[%a] - 64-bit variable storage size not supported.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "[%a] - 64-bit variable storage size not supported.\n", __func__));
     return;
   }
   NvStorageFvSize = mPlatformFvBaseAddress[0].FvSize;

--- a/Silicon/Intel/IntelSiliconPkg/Feature/ShadowMicrocode/ShadowMicrocodePei.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/ShadowMicrocode/ShadowMicrocodePei.c
@@ -160,7 +160,7 @@ ShadowMicrocodePatchWorker (
   DEBUG ((
     DEBUG_INFO,
     "%a: Required microcode patches have been loaded at 0x%lx, with size 0x%lx.\n",
-    __FUNCTION__, *Buffer, *BufferSize
+    __func__, *Buffer, *BufferSize
     ));
 
   return;
@@ -354,7 +354,7 @@ ShadowMicrocode (
     DEBUG ((
       DEBUG_INFO,
       "%a: 0x%x microcode patches will be loaded into memory, with size 0x%x.\n",
-      __FUNCTION__, PatchCount, TotalLoadSize
+      __func__, PatchCount, TotalLoadSize
       ));
 
     ShadowMicrocodePatchWorker (PatchInfoBuffer, PatchCount, TotalLoadSize, BufferSize, Buffer);

--- a/Silicon/Intel/KabylakeSiliconPkg/Cpu/Library/PeiCpuPolicyLibPreMem/PeiCpuPolicyLib.c
+++ b/Silicon/Intel/KabylakeSiliconPkg/Cpu/Library/PeiCpuPolicyLibPreMem/PeiCpuPolicyLib.c
@@ -62,7 +62,7 @@ LoadCpuConfigLibPreMemConfigDefault (
     DEBUG ((
       DEBUG_ERROR,
       "Error: [%a]:[%dL] MCHBAR configured to >4GB\n",
-      __FUNCTION__,
+      __func__,
       __LINE__
       ));
   }

--- a/Silicon/Intel/KabylakeSiliconPkg/Hsti/Dxe/MpServiceHelp.c
+++ b/Silicon/Intel/KabylakeSiliconPkg/Hsti/Dxe/MpServiceHelp.c
@@ -36,7 +36,7 @@ InitMp (
 {
   EFI_STATUS  Status;
 
-  DEBUG ((EFI_D_INFO, "InitMp\n"));
+  DEBUG ((DEBUG_INFO, "InitMp\n"));
 
   Status = gBS->LocateProtocol (&gEfiMpServiceProtocolGuid, NULL, (VOID **) &mMpService);
   if (EFI_ERROR (Status)) {

--- a/Silicon/Intel/PurleyRefreshSiliconPkg/Pch/Library/DxeRuntimeResetSystemLib/PchReset.c
+++ b/Silicon/Intel/PurleyRefreshSiliconPkg/Pch/Library/DxeRuntimeResetSystemLib/PchReset.c
@@ -581,7 +581,7 @@ PchResetCallback (
       ASSERT_EFI_ERROR (Status);
 
       if (!EFI_ERROR (Status)) {
-        DEBUG((EFI_D_ERROR, "Calling PchResetCallback %d\n", Index));
+        DEBUG((DEBUG_ERROR, "Calling PchResetCallback %d\n", Index));
         PchResetCallback->ResetCallback (PchResetType);
       } else {
         DEBUG ((DEBUG_ERROR | DEBUG_INFO, "Failed to locate Pch Reset Callback protocol.\n"));
@@ -589,12 +589,12 @@ PchResetCallback (
       }
     }
   }
-  DEBUG((EFI_D_ERROR, "PchResetCallback After Runtime Check\n"));
+  DEBUG((DEBUG_ERROR, "PchResetCallback After Runtime Check\n"));
   if(PchResetType == WarmReset) {
     ///
     /// Check if there are pending capsules to process
     ///
-    DEBUG((EFI_D_ERROR, "PchResetCallback Warmreset\n"));
+    DEBUG((DEBUG_ERROR, "PchResetCallback Warmreset\n"));
     Size = sizeof (CapsuleDataPtr);
     Status = EfiGetVariable (
                EFI_CAPSULE_VARIABLE_NAME,

--- a/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Library/IntelQNCLib/IntelQNCLib.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Library/IntelQNCLib/IntelQNCLib.c
@@ -185,7 +185,7 @@ QNCCheckS3AndClearState (
     if (S3WakeEventFound == FALSE) {
       EventDescStr = "Unknown";
     }
-    DEBUG ((EFI_D_INFO, "S3 Wake Event - %a\n", EventDescStr));
+    DEBUG ((DEBUG_INFO, "S3 Wake Event - %a\n", EventDescStr));
 
     //
     // If no Power Button Override event occurs and one enabled wake event occurs,
@@ -386,7 +386,7 @@ QNCGetTSEGMemoryRange (
   *MemorySize = SMMAddress - (*BaseAddress);
 
   DEBUG ((
-    EFI_D_INFO,
+    DEBUG_INFO,
     "TSEG's memory range: BaseAddress = 0x%x, Size = 0x%x\n",
     (UINT32)*BaseAddress,
     (UINT32)*MemorySize
@@ -502,7 +502,7 @@ QncEnableLegacyFlashAccessViolationSmi (
 
   LpcPciCfg32 (R_QNC_LPC_BIOS_CNTL) = BcValue;
 
-  DEBUG ((EFI_D_INFO, "BIOS Control Lock Enabled!\n"));
+  DEBUG ((DEBUG_INFO, "BIOS Control Lock Enabled!\n"));
 }
 
 /**

--- a/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Library/IntelQNCLib/PciExpress.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Library/IntelQNCLib/PciExpress.c
@@ -837,7 +837,7 @@ QNCDownStreamPortsInit (
 
       if (!EFI_ERROR (Status)) {
         (*RpEnableMask) |= LShiftU64(1, Index);
-        DEBUG ((EFI_D_INFO, " Root Port %x device found, enabled. RpEnableMask: 0x%x\n", Index + 1, *RpEnableMask));
+        DEBUG ((DEBUG_INFO, " Root Port %x device found, enabled. RpEnableMask: 0x%x\n", Index + 1, *RpEnableMask));
       }
     }
   }
@@ -913,7 +913,7 @@ PciExpressInit (
   mQNCDeviceEnables.Uint32 = PcdGet32 (PcdDeviceEnables);
   mRootPortConfig = (PCIEXP_ROOT_PORT_CONFIGURATION*) PcdGetPtr (PcdPcieRootPortConfiguration);
 
-  DEBUG ((EFI_D_INFO, " mRootPortConfig: 0x%x,  value1: 0x%x, value2: 0x%x, value3: 0x%x, value4: 0x%x\n",
+  DEBUG ((DEBUG_INFO, " mRootPortConfig: 0x%x,  value1: 0x%x, value2: 0x%x, value3: 0x%x, value4: 0x%x\n",
           mRootPortConfig, mRootPortConfig[0].Uint32, mRootPortConfig[1].Uint32,
           mRootPortConfig[2].Uint32, mRootPortConfig[3].Uint32));
 

--- a/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Library/QNCSmmLib/QNCSmmLib.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Library/QNCSmmLib/QNCSmmLib.c
@@ -232,7 +232,7 @@ QNCOpenSmramRegion (
   //
   if (Smram & SMM_LOCKED) {
     // Cannot Open a locked region
-    DEBUG ((EFI_D_WARN, "Cannot open a locked SMRAM region\n"));
+    DEBUG ((DEBUG_WARN, "Cannot open a locked SMRAM region\n"));
     return FALSE;
   }
 
@@ -275,7 +275,7 @@ QNCCloseSmramRegion (
   //
   if(Smram & SMM_LOCKED) {
     // Cannot Open a locked region
-    DEBUG ((EFI_D_WARN, "Cannot close a locked SMRAM region\n"));
+    DEBUG ((DEBUG_WARN, "Cannot close a locked SMRAM region\n"));
     return FALSE;
   }
 
@@ -303,7 +303,7 @@ QNCLockSmramRegion (
   // Read the SMRAM register.
   Smram = QncHsmmcRead ();
   if(Smram & SMM_LOCKED) {
-    DEBUG ((EFI_D_WARN, "SMRAM region already locked!\n"));
+    DEBUG ((DEBUG_WARN, "SMRAM region already locked!\n"));
   }
   Smram |= SMM_LOCKED;
 

--- a/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.c
@@ -65,7 +65,7 @@ SmmCpuFeaturesInitializeProcessor (
   if ((CpuHotPlugData->SmrrSize < SIZE_4KB) ||
       (CpuHotPlugData->SmrrSize != GetPowerOfTwo32 (CpuHotPlugData->SmrrSize)) ||
       ((CpuHotPlugData->SmrrBase & ~(CpuHotPlugData->SmrrSize - 1)) != CpuHotPlugData->SmrrBase)) {
-    DEBUG ((EFI_D_ERROR, "SMM Base/Size does not meet alignment/size requirement!\n"));
+    DEBUG ((DEBUG_ERROR, "SMM Base/Size does not meet alignment/size requirement!\n"));
     CpuDeadLoop ();
   }
 

--- a/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/MemoryInit/Pei/memory_options.h
+++ b/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/MemoryInit/Pei/memory_options.h
@@ -68,9 +68,9 @@ uint8_t mgetch(void);
 #define D_TRN        0x0020
 #define D_TIME       0x0040
 
-#define ENTERFN()     DPF(D_FCALL, "<%s>\n", __FUNCTION__)
-#define LEAVEFN()     DPF(D_FCALL, "</%s>\n", __FUNCTION__)
-#define REPORTFN()    DPF(D_FCALL, "<%s/>\n", __FUNCTION__)
+#define ENTERFN()     DPF(D_FCALL, "<%s>\n", __func__)
+#define LEAVEFN()     DPF(D_FCALL, "</%s>\n", __func__)
+#define REPORTFN()    DPF(D_FCALL, "<%s/>\n", __func__)
 
 extern uint32_t DpfPrintMask;
 

--- a/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/QNCInit/Dxe/QNCInit.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/QNCInit/Dxe/QNCInit.c
@@ -238,26 +238,26 @@ QNCInit (
   //
   Status = QncInitRootPorts ();
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "QNC Root Port initialization is failed!\n"));
+    DEBUG ((DEBUG_ERROR, "QNC Root Port initialization is failed!\n"));
     return Status;
   }
 
   Status = LegacyRegionInit ();
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "QNC LegacyRegion initialization is failed!\n"));
+    DEBUG ((DEBUG_ERROR, "QNC LegacyRegion initialization is failed!\n"));
     return Status;
   }
 
 
   Status = InitializeQNCPolicy ();
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "QNC Policy initialization is failed!\n"));
+    DEBUG ((DEBUG_ERROR, "QNC Policy initialization is failed!\n"));
     return Status;
   }
 
   Status = InitializeQNCSmbus (ImageHandle,SystemTable);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "QNC Smbus driver is failed!\n"));
+    DEBUG ((DEBUG_ERROR, "QNC Smbus driver is failed!\n"));
     return Status;
   }
 
@@ -308,7 +308,7 @@ QNCReserveSpaceInGcd(
                     );
     if (EFI_ERROR (Status)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "Failed to add memory space :0x%x 0x%x\n",
         BaseAddress,
         Length
@@ -398,7 +398,7 @@ QNCInitializeResource (
   //
   Status = gDS->GetMemorySpaceDescriptor (0, &Descriptor);
   DEBUG ((
-    EFI_D_INFO,
+    DEBUG_INFO,
     "DOS Area Memory: base = 0x%x, length = 0x%x, attribute = 0x%x\n",
     Descriptor.BaseAddress,
     Descriptor.Length,
@@ -427,7 +427,7 @@ QNCInitializeResource (
   //
   Status = gDS->GetMemorySpaceDescriptor (0xA0000, &Descriptor);
   DEBUG ((
-    EFI_D_INFO,
+    DEBUG_INFO,
     "ABSEG Memory: base = 0x%x, length = 0x%x, attribute = 0x%x\n",
     Descriptor.BaseAddress,
     Descriptor.Length,
@@ -446,7 +446,7 @@ QNCInitializeResource (
   //
   Status = gDS->GetMemorySpaceDescriptor (0xC0000, &Descriptor);
   DEBUG ((
-    EFI_D_INFO,
+    DEBUG_INFO,
     "Memory base = 0x%x, length = 0x%x, attribute = 0x%x\n",
     Descriptor.BaseAddress,
     Descriptor.Length,

--- a/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Smm/Dxe/SmmAccessDxe/SmmAccessDriver.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Smm/Dxe/SmmAccessDxe/SmmAccessDriver.c
@@ -97,7 +97,7 @@ Returns:
     mSmmAccess.SmramDesc[Index].CpuStart      = DescriptorBlock->Descriptor[Index].CpuStart;
     mSmmAccess.SmramDesc[Index].PhysicalSize  = DescriptorBlock->Descriptor[Index].PhysicalSize;
     mSmmAccess.SmramDesc[Index].RegionState   = DescriptorBlock->Descriptor[Index].RegionState;
-    DEBUG ((EFI_D_INFO, "SM RAM index[%d] startaddr:%08X Size :%08X\n", Index, mSmmAccess.SmramDesc[Index].CpuStart,
+    DEBUG ((DEBUG_INFO, "SM RAM index[%d] startaddr:%08X Size :%08X\n", Index, mSmmAccess.SmramDesc[Index].CpuStart,
       mSmmAccess.SmramDesc[Index].PhysicalSize));
   }
 
@@ -121,8 +121,8 @@ Returns:
                 );
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG ((EFI_D_INFO, "SMM  Base: %08X\n", (UINT32)(mSmmAccess.SmramDesc[mSmmAccess.NumberRegions-1].PhysicalStart)));
-  DEBUG ((EFI_D_INFO, "SMM  Size: %08X\n", (UINT32)(mSmmAccess.SmramDesc[mSmmAccess.NumberRegions-1].PhysicalSize)));
+  DEBUG ((DEBUG_INFO, "SMM  Base: %08X\n", (UINT32)(mSmmAccess.SmramDesc[mSmmAccess.NumberRegions-1].PhysicalStart)));
+  DEBUG ((DEBUG_INFO, "SMM  Size: %08X\n", (UINT32)(mSmmAccess.SmramDesc[mSmmAccess.NumberRegions-1].PhysicalSize)));
 
   mSmmAccess.TsegSize = (UINT8)(mSmmAccess.SmramDesc[mSmmAccess.NumberRegions-1].PhysicalSize);
   //
@@ -174,7 +174,7 @@ Returns:
   SmmAccess = SMM_ACCESS_PRIVATE_DATA_FROM_THIS (This);
 
   if (mSmmAccess.SMMRegionState & EFI_SMRAM_LOCKED) {
-    DEBUG ((EFI_D_ERROR, "Cannot open a locked SMRAM region\n"));
+    DEBUG ((DEBUG_ERROR, "Cannot open a locked SMRAM region\n"));
     return EFI_DEVICE_ERROR;
   }
 
@@ -232,7 +232,7 @@ Returns:
     //
     // Cannot close a "locked" region
     //
-    DEBUG ((EFI_D_WARN, "Cannot close the locked SMRAM Region\n"));
+    DEBUG ((DEBUG_WARN, "Cannot close the locked SMRAM Region\n"));
     return EFI_DEVICE_ERROR;
   }
 

--- a/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Smm/Dxe/SmmControlDxe/SmmControlDriver.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Smm/Dxe/SmmControlDxe/SmmControlDriver.c
@@ -327,7 +327,7 @@ SmmControl2Init (
   DEBUG_CODE_BEGIN ();
   if (IoRead32 (GPE0BLK_Base + R_QNC_GPE0BLK_SMIS) & B_QNC_GPE0BLK_SMIS_EOS) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "******************************************************************************\n"
       "BIG ERROR: SmmControl constructor couldn't properly initialize the ACPI table.\n"
       "           SmmControl->Clear will probably hang.                              \n"

--- a/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Smm/DxeSmm/QncSmmDispatcher/QNCSmmCore.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Smm/DxeSmm/QncSmmDispatcher/QNCSmmCore.c
@@ -487,7 +487,7 @@ Returns:
 Error:
   FreePool (Record);
   //
-  // DEBUG((EFI_D_ERROR,"Free pool status %d\n", Status ));
+  // DEBUG((DEBUG_ERROR,"Free pool status %d\n", Status ));
   //
   return EFI_INVALID_PARAMETER;
 }

--- a/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Smm/Pei/SmmAccessPei/SmmAccessPei.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Smm/Pei/SmmAccessPei/SmmAccessPei.c
@@ -364,7 +364,7 @@ Returns:
   ASSERT_EFI_ERROR(Status);
 
   DEBUG (
-    (EFI_D_INFO, "SMM Base:Size %08X:%08X\n",
+    (DEBUG_INFO, "SMM Base:Size %08X:%08X\n",
     (UINTN)(SmmAccessPrivate->SmramDesc[SmmAccessPrivate->NumberRegions-1].PhysicalStart),
     (UINTN)(SmmAccessPrivate->SmramDesc[SmmAccessPrivate->NumberRegions-1].PhysicalSize)
     ));

--- a/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Spi/Common/SpiCommon.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkNorthCluster/Spi/Common/SpiCommon.c
@@ -186,7 +186,7 @@ Returns:
             EnumSpiRegionAll
             );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Unlock flash component 1 fail!\n"));
+    DEBUG ((DEBUG_ERROR, "Unlock flash component 1 fail!\n"));
     return Status;
   }
 
@@ -331,7 +331,7 @@ Returns:
             UnlockCmdOpcodeIndex
             );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Unlock flash components fail!\n"));
+    DEBUG ((DEBUG_ERROR, "Unlock flash components fail!\n"));
   }
 
   SpiPhaseInit ();
@@ -716,7 +716,7 @@ Returns:
     return EFI_SUCCESS;
   }
   //
-  // DEBUG((EFI_D_ERROR, "SPIADDR %x, %x, %x, %x\n", Address, HardwareSpiAddr, BaseAddress,
+  // DEBUG((DEBUG_ERROR, "SPIADDR %x, %x, %x, %x\n", Address, HardwareSpiAddr, BaseAddress,
   // LimitAddress));
   //
   if ((DataCycle == FALSE) && (DataByteCount > 0)) {

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Library/IohLib/IohLib.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Library/IohLib/IohLib.c
@@ -79,7 +79,7 @@ ReadIohGpioValues (
   SaveCmdReg = PciRead16 (GipAddr + PCI_COMMAND_OFFSET);
   SaveBarReg = PciRead32 (GipAddr + PcdGet8 (PcdIohGpioBarRegister));
 
-  DEBUG ((EFI_D_INFO, "SC GPIO temporary enable  at %08X\n", TempBarAddr));
+  DEBUG ((DEBUG_INFO, "SC GPIO temporary enable  at %08X\n", TempBarAddr));
 
   // Use predefined temporary memory resource.
   PciWrite32 ( GipAddr + PcdGet8 (PcdIohGpioBarRegister), TempBarAddr);

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Sdio/Dxe/SDControllerDxe/SDController.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Sdio/Dxe/SDControllerDxe/SDController.c
@@ -148,7 +148,7 @@ DividedClockModeBits (
   //
   *Bits |= ((UINT16) ((UINT8) N) << 8);
   DEBUG (
-    (EFI_D_INFO,
+    (DEBUG_INFO,
     "SDIO:DividedClockModeBits: %dbit mode Want %dHz Got %dHz bits = %04x\r\n",
     (Is8BitMode) ? 8 : 10,
     TargetFreq,
@@ -180,52 +180,52 @@ GetErrorReason (
 
   Status = EFI_DEVICE_ERROR;
 
-  DEBUG((EFI_D_ERROR, "[%2d] -- ", CommandIndex));
+  DEBUG((DEBUG_ERROR, "[%2d] -- ", CommandIndex));
 
   if (ErrorCode & BIT0) {
     Status = EFI_TIMEOUT;
-    DEBUG((EFI_D_ERROR, "Command Timeout Erro"));
+    DEBUG((DEBUG_ERROR, "Command Timeout Erro"));
   }
 
   if (ErrorCode & BIT1) {
     Status = EFI_CRC_ERROR;
-    DEBUG((EFI_D_ERROR, "Command CRC Error"));
+    DEBUG((DEBUG_ERROR, "Command CRC Error"));
   }
 
   if (ErrorCode & BIT2) {
-    DEBUG((EFI_D_ERROR, "Command End Bit Error"));
+    DEBUG((DEBUG_ERROR, "Command End Bit Error"));
   }
 
   if (ErrorCode & BIT3) {
-    DEBUG((EFI_D_ERROR, "Command Index Error"));
+    DEBUG((DEBUG_ERROR, "Command Index Error"));
   }
   if (ErrorCode & BIT4) {
     Status = EFI_TIMEOUT;
-    DEBUG((EFI_D_ERROR, "Data Timeout Error"));
+    DEBUG((DEBUG_ERROR, "Data Timeout Error"));
   }
 
   if (ErrorCode & BIT5) {
     Status = EFI_CRC_ERROR;
-    DEBUG((EFI_D_ERROR, "Data CRC Error"));
+    DEBUG((DEBUG_ERROR, "Data CRC Error"));
   }
 
   if (ErrorCode & BIT6) {
-    DEBUG((EFI_D_ERROR, "Data End Bit Error"));
+    DEBUG((DEBUG_ERROR, "Data End Bit Error"));
   }
 
   if (ErrorCode & BIT7) {
-    DEBUG((EFI_D_ERROR, "Current Limit Error"));
+    DEBUG((DEBUG_ERROR, "Current Limit Error"));
   }
 
   if (ErrorCode & BIT8) {
-    DEBUG((EFI_D_ERROR, "Auto CMD12 Error"));
+    DEBUG((DEBUG_ERROR, "Auto CMD12 Error"));
   }
 
   if (ErrorCode & BIT9) {
-    DEBUG((EFI_D_ERROR, "ADMA Error"));
+    DEBUG((DEBUG_ERROR, "ADMA Error"));
   }
 
-  DEBUG((EFI_D_ERROR, "\n"));
+  DEBUG((DEBUG_ERROR, "\n"));
 
   return Status;
 }
@@ -262,10 +262,10 @@ SetHighSpeedMode (
 
   if (Enable) {
     if (PcdGetBool(PcdSdHciQuirkNoHiSpd)) {
-      DEBUG ((EFI_D_INFO, "SDIO: Quirk never set High Speed Enable bit\r\n"));
+      DEBUG ((DEBUG_INFO, "SDIO: Quirk never set High Speed Enable bit\r\n"));
       return EFI_SUCCESS;
     }
-    DEBUG ((EFI_D_INFO, "Enable High Speed transfer mode ... \r\n"));
+    DEBUG ((DEBUG_INFO, "Enable High Speed transfer mode ... \r\n"));
     Data |= BIT2;
   } else {
     Data &= ~BIT2;
@@ -456,17 +456,17 @@ SendCommand (
 
   if (Buffer != NULL && DataType == NoData) {
     Status = EFI_INVALID_PARAMETER;
-    DEBUG ((EFI_D_ERROR, "SendCommand: invalid parameter \r\n"));
+    DEBUG ((DEBUG_ERROR, "SendCommand: invalid parameter \r\n"));
     goto Exit;
   }
 
   if (((UINTN)Buffer & (This->HostCapability.BoundarySize - 1)) != (UINTN)NULL) {
     Status = EFI_INVALID_PARAMETER;
-    DEBUG ((EFI_D_ERROR, "SendCommand: invalid parameter \r\n"));
+    DEBUG ((DEBUG_ERROR, "SendCommand: invalid parameter \r\n"));
     goto Exit;
   }
 
-  DEBUG ((EFI_D_INFO, "SendCommand: Command Index = %d \r\n", CommandIndex));
+  DEBUG ((DEBUG_INFO, "SendCommand: Command Index = %d \r\n", CommandIndex));
   //
   TimeOut2 = 1000; // 10 ms
   do {
@@ -607,7 +607,7 @@ SendCommand (
                );
 
 
-  DEBUG ((EFI_D_INFO, "Transfer mode read  = 0x%x \r\n", (Data & 0xFFFF)));
+  DEBUG ((DEBUG_INFO, "Transfer mode read  = 0x%x \r\n", (Data & 0xFFFF)));
   //
   //BIT0 - DMA Enable
   //BIT2 - Auto Cmd12
@@ -632,7 +632,7 @@ SendCommand (
      }
   }
 
-  DEBUG ((EFI_D_INFO, "Transfer mode write = 0x%x \r\n", (Data & 0xffff)));
+  DEBUG ((DEBUG_INFO, "Transfer mode write = 0x%x \r\n", (Data & 0xffff)));
   PciIo->Mem.Write (
                PciIo,
                EfiPciIoWidthUint16,
@@ -685,7 +685,7 @@ SendCommand (
     default:
       ASSERT (0);
       Status = EFI_INVALID_PARAMETER;
-      DEBUG ((EFI_D_ERROR, "SendCommand: invalid parameter \r\n"));
+      DEBUG ((DEBUG_ERROR, "SendCommand: invalid parameter \r\n"));
       goto Exit;
   }
 
@@ -719,7 +719,7 @@ SendCommand (
 
     if ((Data & 0x07FF) != 0) {
       Status = GetErrorReason (CommandIndex, (UINT16)Data);
-      DEBUG ((EFI_D_ERROR, "SendCommand: Error happens \r\n"));
+      DEBUG ((DEBUG_ERROR, "SendCommand: Error happens \r\n"));
       goto Exit;
     }
 
@@ -756,7 +756,7 @@ SendCommand (
 
   if (TimeOut == 0) {
     Status = EFI_TIMEOUT;
-    DEBUG ((EFI_D_ERROR, "SendCommand: Time out \r\n"));
+    DEBUG ((DEBUG_ERROR, "SendCommand: Time out \r\n"));
     goto Exit;
   }
 
@@ -879,15 +879,15 @@ SetClockFrequency (
     gBS->Stall (1 * 1000);
     TimeOutCount --;
     if (TimeOutCount == 0) {
-      DEBUG ((EFI_D_ERROR, "SetClockFrequency: Time out \r\n"));
+      DEBUG ((DEBUG_ERROR, "SetClockFrequency: Time out \r\n"));
       return EFI_TIMEOUT;
     }
   } while ((Data & BIT1) != BIT1);
 
-  DEBUG ((EFI_D_INFO, "Base Clock In MHz: %d\r\n", SDHostData->BaseClockInMHz));
+  DEBUG ((DEBUG_INFO, "Base Clock In MHz: %d\r\n", SDHostData->BaseClockInMHz));
 
   Data = (BIT0 | ((UINT32) FreqSelBits));
-  DEBUG ((EFI_D_INFO, "Data write to MMIO_CLKCTL: 0x%04x \r\n", Data));
+  DEBUG ((DEBUG_INFO, "Data write to MMIO_CLKCTL: 0x%04x \r\n", Data));
   PciIo->Mem.Write (
                PciIo,
                EfiPciIoWidthUint16,
@@ -910,7 +910,7 @@ SetClockFrequency (
     gBS->Stall (1 * 1000);
     TimeOutCount --;
     if (TimeOutCount == 0) {
-      DEBUG ((EFI_D_ERROR, "SetClockFrequency: Time out \r\n"));
+      DEBUG ((DEBUG_ERROR, "SetClockFrequency: Time out \r\n"));
       return EFI_TIMEOUT;
     }
   } while ((Data & BIT1) != BIT1);
@@ -953,12 +953,12 @@ SetBusWidth (
 
 
   if ((BusWidth != 1) && (BusWidth != 4) && (BusWidth != 8)) {
-    DEBUG ((EFI_D_ERROR, "SetBusWidth: Invalid parameter \r\n"));
+    DEBUG ((DEBUG_ERROR, "SetBusWidth: Invalid parameter \r\n"));
     return EFI_INVALID_PARAMETER;
   }
 
   if ((SDHostData->SDHostIo.HostCapability.BusWidth8 == FALSE) && (BusWidth == 8)) {
-     DEBUG ((EFI_D_ERROR, "SetBusWidth: Invalid parameter \r\n"));
+     DEBUG ((DEBUG_ERROR, "SetBusWidth: Invalid parameter \r\n"));
      return EFI_INVALID_PARAMETER;
   }
 
@@ -977,14 +977,14 @@ SetBusWidth (
   // If set, IOH supports 8-bit MMC. When cleared, IOH does not support this feature
   //
   if (BusWidth == 8) {
-    DEBUG ((EFI_D_INFO, "Bus Width is 8-bit ... \r\n"));
+    DEBUG ((DEBUG_INFO, "Bus Width is 8-bit ... \r\n"));
     Data |= BIT5;
   } else if (BusWidth == 4) {
-    DEBUG ((EFI_D_INFO, "Bus Width is 4-bit ... \r\n"));
+    DEBUG ((DEBUG_INFO, "Bus Width is 4-bit ... \r\n"));
     Data &= ~BIT5;
     Data |= BIT1;
   } else {
-    DEBUG ((EFI_D_INFO, "Bus Width is 1-bit ... \r\n"));
+    DEBUG ((DEBUG_INFO, "Bus Width is 1-bit ... \r\n"));
     Data &= ~BIT5;
     Data &= ~BIT1;
   }
@@ -1220,7 +1220,7 @@ ResetSDHost (
                );
 
   if (TimeOutCount == 0) {
-    DEBUG ((EFI_D_ERROR, "ResetSDHost: Time out \r\n"));
+    DEBUG ((DEBUG_ERROR, "ResetSDHost: Time out \r\n"));
     return EFI_TIMEOUT;
   }
 
@@ -1275,7 +1275,7 @@ SetBlockLength (
 
   SDHostData = SDHOST_DATA_FROM_THIS (This);
 
-  DEBUG ((EFI_D_INFO, "Block length on the host controller: %d \r\n", BlockLength));
+  DEBUG ((DEBUG_INFO, "Block length on the host controller: %d \r\n", BlockLength));
   SDHostData->BlockLength = BlockLength;
 
   return EFI_SUCCESS;
@@ -1323,36 +1323,36 @@ DetectCardAndInitHost (
     //
     // Has no card inserted
     //
-    DEBUG ((EFI_D_INFO, "DetectCardAndInitHost: No Cards \r\n"));
+    DEBUG ((DEBUG_INFO, "DetectCardAndInitHost: No Cards \r\n"));
     Status =  EFI_NOT_FOUND;
     goto Exit;
   }
-  DEBUG ((EFI_D_INFO, "DetectCardAndInitHost: Find Cards \r\n"));
+  DEBUG ((DEBUG_INFO, "DetectCardAndInitHost: Find Cards \r\n"));
 
   Status =  EFI_NOT_FOUND;
   for (Loop = 0; Loop < sizeof (Voltages); Loop++) {
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "DetectCardAndInitHost: SetHostVoltage %d.%dV \r\n",
       Voltages[Loop] / 10,
       Voltages[Loop] % 10
       ));
     Status = SetHostVoltage (This, Voltages[Loop]);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "DetectCardAndInitHost set voltages: [failed]\n"));
+      DEBUG ((DEBUG_INFO, "DetectCardAndInitHost set voltages: [failed]\n"));
     } else {
-      DEBUG ((EFI_D_INFO, "DetectCardAndInitHost set voltages: [success]\n"));
+      DEBUG ((DEBUG_INFO, "DetectCardAndInitHost set voltages: [success]\n"));
       break;
     }
   }
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "DetectCardAndInitHost: Fail to set voltage \r\n"));
+    DEBUG ((DEBUG_ERROR, "DetectCardAndInitHost: Fail to set voltage \r\n"));
     goto Exit;
   }
 
   Status = SetClockFrequency (This, FREQUENCY_OD);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "DetectCardAndInitHost: Fail to set frequency \r\n"));
+    DEBUG ((DEBUG_ERROR, "DetectCardAndInitHost: Fail to set frequency \r\n"));
     goto Exit;
   }
   SetBusWidth (This, 1);
@@ -1617,7 +1617,7 @@ SDControllerStart (
               &Data
               );
   SDHostData->SDHostIo.HostCapability.HostVersion = Data & 0xFF;
-  DEBUG ((EFI_D_INFO, "SdHostDriverBindingStart: HostVersion 0x%x \r\n", SDHostData->SDHostIo.HostCapability.HostVersion));
+  DEBUG ((DEBUG_INFO, "SdHostDriverBindingStart: HostVersion 0x%x \r\n", SDHostData->SDHostIo.HostCapability.HostVersion));
 
   PciIo->Mem.Read (
                PciIo,
@@ -1627,7 +1627,7 @@ SDControllerStart (
                1,
                &Data
                );
-  DEBUG ((EFI_D_INFO, "SdHostDriverBindingStart: MMIO_CAP 0x%x \r\n", Data));
+  DEBUG ((DEBUG_INFO, "SdHostDriverBindingStart: MMIO_CAP 0x%x \r\n", Data));
   if ((Data & BIT18) != 0) {
     SDHostData->SDHostIo.HostCapability.BusWidth8 = TRUE;
   }
@@ -1662,7 +1662,7 @@ SDControllerStart (
    }
 
   SDHostData->BlockLength = 512 << ((Data >> 16) & 0x03);
-  DEBUG ((EFI_D_INFO, "SdHostDriverBindingStart: BlockLength 0x%x \r\n", SDHostData->BlockLength));
+  DEBUG ((DEBUG_INFO, "SdHostDriverBindingStart: BlockLength 0x%x \r\n", SDHostData->BlockLength));
   SDHostData->IsAutoStopCmd  = TRUE;
 
   Status = gBS->InstallProtocolInterface (

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Sdio/Dxe/SDMediaDeviceDxe/CEATA.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Sdio/Dxe/SDMediaDeviceDxe/CEATA.c
@@ -277,7 +277,7 @@ SendATACommand (
              (UINT8*)TaskFile
              );
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "ReadWriteMultipleRegister 0x%x\n", Status));
+    DEBUG((DEBUG_ERROR, "ReadWriteMultipleRegister 0x%x\n", Status));
     goto Exit;
   }
 
@@ -303,7 +303,7 @@ SendATACommand (
   } while (TimeOut > 0);
 
   if (TimeOut == 0) {
-    DEBUG((EFI_D_ERROR, "ReadWriteMultipleRegister FastIO EFI_TIMEOUT 0x%x\n", Data));
+    DEBUG((DEBUG_ERROR, "ReadWriteMultipleRegister FastIO EFI_TIMEOUT 0x%x\n", Data));
     Status = EFI_TIMEOUT;
     goto Exit;
   }
@@ -317,7 +317,7 @@ SendATACommand (
                (UINT8*)Buffer
                );
     if (EFI_ERROR (Status)) {
-      DEBUG((EFI_D_ERROR, "ReadWriteMultipleBlock EFI_TIMEOUT 0x%x\n", Status));
+      DEBUG((DEBUG_ERROR, "ReadWriteMultipleBlock EFI_TIMEOUT 0x%x\n", Status));
       goto Exit;
     }
 
@@ -343,7 +343,7 @@ SendATACommand (
       TimeOut --;
     } while (TimeOut > 0);
     if (TimeOut == 0) {
-      DEBUG((EFI_D_ERROR, "ReadWriteMultipleBlock FastIO EFI_TIMEOUT 0x%x\n", Data));
+      DEBUG((DEBUG_ERROR, "ReadWriteMultipleBlock FastIO EFI_TIMEOUT 0x%x\n", Data));
       Status = EFI_TIMEOUT;
       goto Exit;
     }

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Sdio/Dxe/SDMediaDeviceDxe/CEATABlockIo.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Sdio/Dxe/SDMediaDeviceDxe/CEATABlockIo.c
@@ -39,7 +39,7 @@ CEATABlockReset (
   } else {
     Status = SDHostIo->ResetSDHost (SDHostIo, Reset_DAT_CMD);
     if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "CEATABlockReset: Fail to ResetSDHost\n" ));
+    DEBUG((DEBUG_ERROR, "CEATABlockReset: Fail to ResetSDHost\n" ));
       return Status;
     }
     Status = MMCSDCardInit (CardData);
@@ -99,19 +99,19 @@ CEATABlockReadBlocks (
 
   if (!Buffer) {
     Status = EFI_INVALID_PARAMETER;
-    DEBUG((EFI_D_ERROR, "CEATABlockReadBlocks:Invalid parameter\n" ));
+    DEBUG((DEBUG_ERROR, "CEATABlockReadBlocks:Invalid parameter\n" ));
     goto Exit;
   }
 
   if (MediaId != CardData->BlockIoMedia.MediaId) {
     Status = EFI_MEDIA_CHANGED;
-  DEBUG((EFI_D_ERROR, "CEATABlockReadBlocks:Media changed\n" ));
+  DEBUG((DEBUG_ERROR, "CEATABlockReadBlocks:Media changed\n" ));
     goto Exit;
   }
 
   if ((BufferSize % CardData->BlockIoMedia.BlockSize) != 0) {
     Status = EFI_BAD_BUFFER_SIZE;
-  DEBUG((EFI_D_ERROR, "CEATABlockReadBlocks:Bad buffer size\n" ));
+  DEBUG((DEBUG_ERROR, "CEATABlockReadBlocks:Bad buffer size\n" ));
     goto Exit;
   }
 
@@ -122,7 +122,7 @@ CEATABlockReadBlocks (
 
   if ((Address + BufferSize) > MultU64x32 (CardData->BlockIoMedia.LastBlock + 1, CardData->BlockIoMedia.BlockSize)) {
     Status = EFI_INVALID_PARAMETER;
-    DEBUG((EFI_D_ERROR, "CEATABlockReadBlocks:Invalid parameter\n" ));
+    DEBUG((DEBUG_ERROR, "CEATABlockReadBlocks:Invalid parameter\n" ));
     goto Exit;
   }
 
@@ -145,7 +145,7 @@ CEATABlockReadBlocks (
                (UINT16)(TransferSize / DATA_UNIT_SIZE)
                );
     if (EFI_ERROR (Status)) {
-     DEBUG((EFI_D_ERROR, "Read Failed at 0x%x, Index %d, Size 0x%x\n", Address, Index, TransferSize));
+     DEBUG((DEBUG_ERROR, "Read Failed at 0x%x, Index %d, Size 0x%x\n", Address, Index, TransferSize));
      This->Reset (This, TRUE);
      goto Exit;
     }
@@ -258,7 +258,7 @@ CEATABlockWriteBlocks (
                (UINT16)(TransferSize / DATA_UNIT_SIZE)
                );
     if (EFI_ERROR (Status)) {
-     DEBUG((EFI_D_ERROR, "Write Failed at 0x%x, Index %d, Size 0x%x\n", Address, Index, TransferSize));
+     DEBUG((DEBUG_ERROR, "Write Failed at 0x%x, Index %d, Size 0x%x\n", Address, Index, TransferSize));
      This->Reset (This, TRUE);
      goto Exit;
     }

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Sdio/Dxe/SDMediaDeviceDxe/MMCSDBlockIo.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Sdio/Dxe/SDMediaDeviceDxe/MMCSDBlockIo.c
@@ -76,7 +76,7 @@ MMCSDBlockReadBlocks (
   BOOLEAN                     SectorAddressing;
   UINTN                       TotalBlock;
 
-  DEBUG((EFI_D_INFO, "Read(LBA=%08lx, Buffer=%08x, Size=%08x)\n", LBA, Buffer, BufferSize));
+  DEBUG((DEBUG_INFO, "Read(LBA=%08lx, Buffer=%08x, Size=%08x)\n", LBA, Buffer, BufferSize));
   Status   = EFI_SUCCESS;
   CardData  = CARD_DATA_FROM_THIS(This);
   SDHostIo = CardData->SDHostIo;
@@ -111,13 +111,13 @@ MMCSDBlockReadBlocks (
 
   if (!Buffer) {
     Status = EFI_INVALID_PARAMETER;
-    DEBUG ((EFI_D_ERROR, "MMCSDBlockReadBlocks:Invalid parameter \r\n"));
+    DEBUG ((DEBUG_ERROR, "MMCSDBlockReadBlocks:Invalid parameter \r\n"));
     goto Done;
   }
 
   if ((BufferSize % CardData->BlockIoMedia.BlockSize) != 0) {
     Status = EFI_BAD_BUFFER_SIZE;
-    DEBUG ((EFI_D_ERROR, "MMCSDBlockReadBlocks: Bad buffer size \r\n"));
+    DEBUG ((DEBUG_ERROR, "MMCSDBlockReadBlocks: Bad buffer size \r\n"));
     goto Done;
   }
 
@@ -185,7 +185,7 @@ MMCSDBlockReadBlocks (
                  );
 
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "MMCSDBlockReadBlocks: READ_MULTIPLE_BLOCK -> Fail\n"));
+        DEBUG ((DEBUG_ERROR, "MMCSDBlockReadBlocks: READ_MULTIPLE_BLOCK -> Fail\n"));
         break;
       }
     } else {
@@ -207,7 +207,7 @@ MMCSDBlockReadBlocks (
                  (UINT32*)&(CardData->CardStatus)
                  );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "MMCSDBlockReadBlocks: READ_SINGLE_BLOCK -> Fail\n"));
+        DEBUG ((DEBUG_ERROR, "MMCSDBlockReadBlocks: READ_SINGLE_BLOCK -> Fail\n"));
         break;
       }
     }
@@ -262,7 +262,7 @@ MMCSDBlockReadBlocks (
 
 
 Done:
-  DEBUG((EFI_D_INFO, "MMCSDBlockReadBlocks: Status = %r\n", Status));
+  DEBUG((DEBUG_INFO, "MMCSDBlockReadBlocks: Status = %r\n", Status));
   return Status;
 }
 
@@ -305,7 +305,7 @@ MMCSDBlockWriteBlocks (
   UINT8                       *BufferPointer;
   BOOLEAN                     SectorAddressing;
 
-  DEBUG((EFI_D_INFO, "Write(LBA=%08lx, Buffer=%08x, Size=%08x)\n", LBA, Buffer, BufferSize));
+  DEBUG((DEBUG_INFO, "Write(LBA=%08lx, Buffer=%08x, Size=%08x)\n", LBA, Buffer, BufferSize));
   Status   = EFI_SUCCESS;
   CardData  = CARD_DATA_FROM_THIS(This);
   SDHostIo = CardData->SDHostIo;
@@ -328,13 +328,13 @@ MMCSDBlockWriteBlocks (
 
   if (!Buffer) {
     Status = EFI_INVALID_PARAMETER;
-    DEBUG ((EFI_D_ERROR, "MMCSDBlockWriteBlocks: Invalid parameter \r\n"));
+    DEBUG ((DEBUG_ERROR, "MMCSDBlockWriteBlocks: Invalid parameter \r\n"));
     goto Done;
   }
 
   if ((BufferSize % CardData->BlockIoMedia.BlockSize) != 0) {
     Status = EFI_BAD_BUFFER_SIZE;
-    DEBUG ((EFI_D_ERROR, "MMCSDBlockWriteBlocks: Bad buffer size \r\n"));
+    DEBUG ((DEBUG_ERROR, "MMCSDBlockWriteBlocks: Bad buffer size \r\n"));
     goto Done;
   }
 
@@ -345,7 +345,7 @@ MMCSDBlockWriteBlocks (
 
   if (This->Media->ReadOnly == TRUE) {
     Status = EFI_WRITE_PROTECTED;
-    DEBUG ((EFI_D_ERROR, "MMCSDBlockWriteBlocks: Write protected \r\n"));
+    DEBUG ((DEBUG_ERROR, "MMCSDBlockWriteBlocks: Write protected \r\n"));
     goto Done;
   }
 
@@ -410,7 +410,7 @@ MMCSDBlockWriteBlocks (
                  (UINT32*)&(CardData->CardStatus)
                  );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "MMCSDBlockWriteBlocks: WRITE_MULTIPLE_BLOCK -> Fail\n"));
+        DEBUG ((DEBUG_ERROR, "MMCSDBlockWriteBlocks: WRITE_MULTIPLE_BLOCK -> Fail\n"));
         break;
       }
     } else {

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Sdio/Dxe/SDMediaDeviceDxe/MMCSDTransfer.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Sdio/Dxe/SDMediaDeviceDxe/MMCSDTransfer.c
@@ -28,79 +28,79 @@ CheckCardStatus (
   CardStatus = (CARD_STATUS*)(&Status);
 
   if (CardStatus->ADDRESS_OUT_OF_RANGE) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: ADDRESS_OUT_OF_RANGE\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: ADDRESS_OUT_OF_RANGE\n"));
   }
 
   if (CardStatus->ADDRESS_MISALIGN) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: ADDRESS_MISALIGN\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: ADDRESS_MISALIGN\n"));
   }
 
   if (CardStatus->BLOCK_LEN_ERROR) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: BLOCK_LEN_ERROR\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: BLOCK_LEN_ERROR\n"));
   }
 
   if (CardStatus->ERASE_SEQ_ERROR) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: ERASE_SEQ_ERROR\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: ERASE_SEQ_ERROR\n"));
   }
 
   if (CardStatus->ERASE_PARAM) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: ERASE_PARAM\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: ERASE_PARAM\n"));
   }
 
   if (CardStatus->WP_VIOLATION) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: WP_VIOLATION\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: WP_VIOLATION\n"));
   }
 
   if (CardStatus->CARD_IS_LOCKED) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: CARD_IS_LOCKED\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: CARD_IS_LOCKED\n"));
   }
 
   if (CardStatus->LOCK_UNLOCK_FAILED) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: LOCK_UNLOCK_FAILED\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: LOCK_UNLOCK_FAILED\n"));
   }
 
   if (CardStatus->COM_CRC_ERROR) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: COM_CRC_ERROR\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: COM_CRC_ERROR\n"));
   }
 
   if (CardStatus->ILLEGAL_COMMAND) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: ILLEGAL_COMMAND\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: ILLEGAL_COMMAND\n"));
   }
 
   if (CardStatus->CARD_ECC_FAILED) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: CARD_ECC_FAILED\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: CARD_ECC_FAILED\n"));
   }
 
   if (CardStatus->CC_ERROR) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: CC_ERROR\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: CC_ERROR\n"));
   }
 
   if (CardStatus->ERROR) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: ERROR\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: ERROR\n"));
   }
 
   if (CardStatus->UNDERRUN) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: UNDERRUN\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: UNDERRUN\n"));
   }
 
   if (CardStatus->OVERRUN) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: OVERRUN\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: OVERRUN\n"));
   }
 
   if (CardStatus->CID_CSD_OVERWRITE) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: CID_CSD_OVERWRITE\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: CID_CSD_OVERWRITE\n"));
   }
 
   if (CardStatus->WP_ERASE_SKIP) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: WP_ERASE_SKIP\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: WP_ERASE_SKIP\n"));
   }
 
   if (CardStatus->ERASE_RESET) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: ERASE_RESET\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: ERASE_RESET\n"));
   }
 
   if (CardStatus->SWITCH_ERROR) {
-    DEBUG ((EFI_D_ERROR, "CardStatus: SWITCH_ERROR\n"));
+    DEBUG ((DEBUG_ERROR, "CardStatus: SWITCH_ERROR\n"));
   }
 
   if ((Status & 0xFCFFA080) != 0) {
@@ -517,7 +517,7 @@ CaculateCardParameter (
   }
 
   DEBUG((
-    EFI_D_INFO,
+    DEBUG_INFO,
           "CalculateCardParameter: Card Size: 0x%lx\n", MultU64x32 (CardData->BlockNumber, CardData->BlockLen)
     ));
 
@@ -582,7 +582,7 @@ MMCCardBusWidthTest (
               (UINT32*)&(CardData->CardStatus)
               );
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "MMCCardBusWidthTest:SendCommand BUSTEST_W 0x%x\n", *(UINT32*)&(CardData->CardStatus)));
+    DEBUG((DEBUG_ERROR, "MMCCardBusWidthTest:SendCommand BUSTEST_W 0x%x\n", *(UINT32*)&(CardData->CardStatus)));
     goto Exit;
   }
 
@@ -602,7 +602,7 @@ MMCCardBusWidthTest (
               (UINT32*)&(CardData->CardStatus)
               );
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "MMCCardBusWidthTest:SendCommand BUSTEST_R 0x%x\n", *(UINT32*)&(CardData->CardStatus)));
+    DEBUG((DEBUG_ERROR, "MMCCardBusWidthTest:SendCommand BUSTEST_R 0x%x\n", *(UINT32*)&(CardData->CardStatus)));
     goto Exit;
   }
   CopyMem (&Data, CardData->AlignedBuffer, Width);
@@ -673,7 +673,7 @@ GetCardType (
               NULL
               );
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "GO_IDLE_STATE Fail Status = 0x%x\n", Status));
+    DEBUG((DEBUG_ERROR, "GO_IDLE_STATE Fail Status = 0x%x\n", Status));
     goto Exit;
   }
 
@@ -705,12 +705,12 @@ GetCardType (
 
   if (EFI_ERROR (Status)) {
     if (Status != EFI_TIMEOUT) {
-       DEBUG((EFI_D_ERROR, "SEND_IF_COND Fail, none time out error\n"));
+       DEBUG((DEBUG_ERROR, "SEND_IF_COND Fail, none time out error\n"));
        goto Exit;
     }
   } else {
      if (ResponseData != Argument) {
-       DEBUG((EFI_D_ERROR, "SEND_IF_COND Fail, respond data does not match send data\n"));
+       DEBUG((DEBUG_ERROR, "SEND_IF_COND Fail, respond data does not match send data\n"));
        Status = EFI_DEVICE_ERROR;
        goto Exit;
     }
@@ -755,13 +755,13 @@ GetCardType (
       if ((Status == EFI_TIMEOUT) && (!SDCommand8Support)) {
         CardData->CardType = MMCCard;
         Status = EFI_SUCCESS;
-        DEBUG((EFI_D_INFO, "SD_SEND_OP_COND, MMC card was identified\n"));
+        DEBUG((DEBUG_INFO, "SD_SEND_OP_COND, MMC card was identified\n"));
       } else {
         //
         // Not as expected, MMC card should has no response, which means timeout.
         // SD card should pass this command
         //
-        DEBUG((EFI_D_ERROR, "SD_SEND_OP_COND Fail, check whether it is neither a MMC card nor a SD card\n"));
+        DEBUG((DEBUG_ERROR, "SD_SEND_OP_COND Fail, check whether it is neither a MMC card nor a SD card\n"));
       }
       goto Exit;
     }
@@ -775,7 +775,7 @@ GetCardType (
     gBS->Stall (50 * 1000);
     Count--;
     if (Count == 0) {
-      DEBUG((EFI_D_ERROR, "Card is always in busy state\n"));
+      DEBUG((DEBUG_ERROR, "Card is always in busy state\n"));
       Status = EFI_TIMEOUT;
       goto Exit;
     }
@@ -804,7 +804,7 @@ GetCardType (
      //No matched support voltage
      //
      PutCardInactive (CardData);
-     DEBUG((EFI_D_ERROR, "No matched voltage for this card\n"));
+     DEBUG((DEBUG_ERROR, "No matched voltage for this card\n"));
      Status = EFI_UNSUPPORTED;
      goto Exit;
   }
@@ -812,12 +812,12 @@ GetCardType (
   CardData->CardType = SDMemoryCard;
   if (SDCommand8Support == TRUE) {
    CardData->CardType = SDMemoryCard2;
-   DEBUG((EFI_D_INFO, "SD_SEND_OP_COND, SD 2.0 or above standard card was identified\n"));
+   DEBUG((DEBUG_INFO, "SD_SEND_OP_COND, SD 2.0 or above standard card was identified\n"));
   }
 
   if ((CardData->OCRRegister.AccessMode & BIT1) == BIT1) {
     CardData->CardType = SDMemoryCard2High;
-    DEBUG((EFI_D_INFO, "SD_SEND_OP_COND, SD 2.0 or above high capacity card was identified\n"));
+    DEBUG((DEBUG_INFO, "SD_SEND_OP_COND, SD 2.0 or above high capacity card was identified\n"));
   }
 
 
@@ -869,7 +869,7 @@ MMCCardVoltageSelection (
                   NULL
                   );
       if (EFI_ERROR (Status)) {
-        DEBUG((EFI_D_ERROR, "GO_IDLE_STATE Fail Status = 0x%x\n", Status));
+        DEBUG((DEBUG_ERROR, "GO_IDLE_STATE Fail Status = 0x%x\n", Status));
         continue;
       }
       //
@@ -897,7 +897,7 @@ MMCCardVoltageSelection (
     }
 
     if (Retry == 3) {
-      DEBUG((EFI_D_ERROR, "SEND_OP_COND Fail Status = 0x%x\n", Status));
+      DEBUG((DEBUG_ERROR, "SEND_OP_COND Fail Status = 0x%x\n", Status));
       Status = EFI_DEVICE_ERROR;
       goto Exit;
     }
@@ -920,7 +920,7 @@ MMCCardVoltageSelection (
                   (UINT32*)&(CardData->OCRRegister)
                   );
       if (EFI_ERROR (Status)) {
-        DEBUG((EFI_D_ERROR, "SEND_OP_COND Fail Status = 0x%x\n", Status));
+        DEBUG((DEBUG_ERROR, "SEND_OP_COND Fail Status = 0x%x\n", Status));
         goto Exit;
       }
 
@@ -928,14 +928,14 @@ MMCCardVoltageSelection (
       TimeOut--;
       if (TimeOut == 0) {
         Status = EFI_TIMEOUT;
-      DEBUG((EFI_D_ERROR, "Card is always in busy state\n"));
+      DEBUG((DEBUG_ERROR, "Card is always in busy state\n"));
         goto Exit;
       }
     } while (CardData->OCRRegister.Busy != 1);
 
   if (CardData->OCRRegister.AccessMode == 2) // eMMC Card uses Sector Addressing - High Capacity
     {
-    DEBUG((EFI_D_INFO, "eMMC Card is High Capacity\n"));
+    DEBUG((DEBUG_INFO, "eMMC Card is High Capacity\n"));
     CardData->CardType = MMCCardHighCap;
   }
 
@@ -1025,13 +1025,13 @@ MMCCardSetBusWidth (
                  (UINT32*)&(CardData->CardStatus)
                  );
     if (EFI_ERROR (Status)) {
-      DEBUG((EFI_D_ERROR, "SWITCH %d bits Fail\n", BusWidth));
+      DEBUG((DEBUG_ERROR, "SWITCH %d bits Fail\n", BusWidth));
       goto Exit;
     } else {
-      DEBUG((EFI_D_ERROR, "MMCCardSetBusWidth:SWITCH Card Status:0x%x\n", *(UINT32*)&(CardData->CardStatus)));
+      DEBUG((DEBUG_ERROR, "MMCCardSetBusWidth:SWITCH Card Status:0x%x\n", *(UINT32*)&(CardData->CardStatus)));
       Status = SDHostIo->SetBusWidth (SDHostIo, BusWidth);
       if (EFI_ERROR (Status)) {
-         DEBUG((EFI_D_ERROR, "SWITCH set %d bits Fail\n", BusWidth));
+         DEBUG((DEBUG_ERROR, "SWITCH set %d bits Fail\n", BusWidth));
          goto Exit;
       }
       gBS->Stall (5 * 1000);
@@ -1040,13 +1040,13 @@ MMCCardSetBusWidth (
 
   if (!EnableDDRMode) {     // CMD19 and CMD14 are illegal commands in ddr mode
   //if (EFI_ERROR (Status)) {
-  //  DEBUG((EFI_D_ERROR, "MMCCardBusWidthTest: Fail to enable high speed mode\n"));
+  //  DEBUG((DEBUG_ERROR, "MMCCardBusWidthTest: Fail to enable high speed mode\n"));
   //  goto Exit;
   //}
 
   Status = MMCCardBusWidthTest (CardData, BusWidth);
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "MMCCardBusWidthTest %d bit Fail\n", BusWidth));
+    DEBUG((DEBUG_ERROR, "MMCCardBusWidthTest %d bit Fail\n", BusWidth));
     goto Exit;
     }
   }
@@ -1120,18 +1120,18 @@ MMCSDCardInit (
               (UINT32*)&(CardData->CIDRegister)
               );
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "ALL_SEND_CID Fail Status = 0x%x\n", Status));
+    DEBUG((DEBUG_ERROR, "ALL_SEND_CID Fail Status = 0x%x\n", Status));
     goto Exit;
   } else {
     // Dump out the Card ID data
-    DEBUG((EFI_D_INFO, "Product Name: "));
+    DEBUG((DEBUG_INFO, "Product Name: "));
     for ( nIndex=0; nIndex<6; nIndex++ ) {
-      DEBUG((EFI_D_INFO, "%c", CardData->CIDRegister.PNM[nIndex]));
+      DEBUG((DEBUG_INFO, "%c", CardData->CIDRegister.PNM[nIndex]));
     }
-    DEBUG((EFI_D_INFO, "\nApplication ID : %d\n", CardData->CIDRegister.OID));
-    DEBUG((EFI_D_INFO, "Manufacturer ID: %d\n", CardData->CIDRegister.MID));
-    DEBUG((EFI_D_INFO, "Revision ID    : %d\n", CardData->CIDRegister.PRV));
-    DEBUG((EFI_D_INFO, "Serial Number  : %d\n", CardData->CIDRegister.PSN));
+    DEBUG((DEBUG_INFO, "\nApplication ID : %d\n", CardData->CIDRegister.OID));
+    DEBUG((DEBUG_INFO, "Manufacturer ID: %d\n", CardData->CIDRegister.MID));
+    DEBUG((DEBUG_INFO, "Revision ID    : %d\n", CardData->CIDRegister.PRV));
+    DEBUG((DEBUG_INFO, "Serial Number  : %d\n", CardData->CIDRegister.PSN));
   }
 
   //
@@ -1158,7 +1158,7 @@ MMCSDCardInit (
                 (UINT32*)&(CardData->CardStatus)
                 );
     if (EFI_ERROR (Status)) {
-      DEBUG((EFI_D_ERROR, "SET_RELATIVE_ADDR Fail Status = 0x%x\n", Status));
+      DEBUG((DEBUG_ERROR, "SET_RELATIVE_ADDR Fail Status = 0x%x\n", Status));
       goto Exit;
     }
   } else {
@@ -1175,7 +1175,7 @@ MMCSDCardInit (
                 &Data
                 );
     if (EFI_ERROR (Status)) {
-      DEBUG((EFI_D_ERROR, "SET_RELATIVE_ADDR Fail Status = 0x%x\n", Status));
+      DEBUG((DEBUG_ERROR, "SET_RELATIVE_ADDR Fail Status = 0x%x\n", Status));
       goto Exit;
     }
 
@@ -1186,7 +1186,7 @@ MMCSDCardInit (
     CardData->CardStatus.COM_CRC_ERROR   = (Data >> 15) & 0x1;
     Status = CheckCardStatus (*(UINT32*)&CardData->CardStatus);
     if (EFI_ERROR (Status)) {
-      DEBUG((EFI_D_ERROR, "SET_RELATIVE_ADDR Fail Status = 0x%x\n", Status));
+      DEBUG((DEBUG_ERROR, "SET_RELATIVE_ADDR Fail Status = 0x%x\n", Status));
       goto Exit;
     }
   }
@@ -1206,12 +1206,12 @@ MMCSDCardInit (
               (UINT32*)&(CardData->CSDRegister)
               );
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "SEND_CSD Fail Status = 0x%x\n", Status));
+    DEBUG((DEBUG_ERROR, "SEND_CSD Fail Status = 0x%x\n", Status));
     goto Exit;
   }
 
-  DEBUG((EFI_D_INFO, "CardData->CSDRegister.SPEC_VERS = 0x%x\n", CardData->CSDRegister.SPEC_VERS));
-  DEBUG((EFI_D_INFO, "CardData->CSDRegister.CSD_STRUCTURE = 0x%x\n", CardData->CSDRegister.CSD_STRUCTURE));
+  DEBUG((DEBUG_INFO, "CardData->CSDRegister.SPEC_VERS = 0x%x\n", CardData->CSDRegister.SPEC_VERS));
+  DEBUG((DEBUG_INFO, "CardData->CSDRegister.CSD_STRUCTURE = 0x%x\n", CardData->CSDRegister.CSD_STRUCTURE));
 
   Status = CaculateCardParameter (CardData);
   if (EFI_ERROR (Status)) {
@@ -1238,7 +1238,7 @@ MMCSDCardInit (
                 NULL
                 );
     if (EFI_ERROR (Status)) {
-      DEBUG((EFI_D_ERROR, "SET_DSR Fail Status = 0x%x\n", Status));
+      DEBUG((DEBUG_ERROR, "SET_DSR Fail Status = 0x%x\n", Status));
       //
       // Assume can operate even fail
       //
@@ -1249,7 +1249,7 @@ MMCSDCardInit (
   //
   Status = SDHostIo->SetClockFrequency (SDHostIo, CardData->MaxFrequency);
   if (EFI_ERROR (Status)) {
-  DEBUG((EFI_D_ERROR, "MMCSDCardInit:Fail to SetClockFrequency \n"));
+  DEBUG((DEBUG_ERROR, "MMCSDCardInit:Fail to SetClockFrequency \n"));
   goto Exit;
   }
 
@@ -1268,7 +1268,7 @@ MMCSDCardInit (
              (UINT32*)&(CardData->CardStatus)
              );
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "SELECT_DESELECT_CARD Fail Status = 0x%x\n", Status));
+    DEBUG((DEBUG_ERROR, "SELECT_DESELECT_CARD Fail Status = 0x%x\n", Status));
     goto Exit;
   }
 
@@ -1292,7 +1292,7 @@ MMCSDCardInit (
               (UINT32*)&(CardData->CardStatus)
               );
   if (EFI_ERROR (Status)) {
-     DEBUG((EFI_D_ERROR, "SELECT_DESELECT_CARD SEND_STATUS Fail Status = 0x%x\n", Status));
+     DEBUG((DEBUG_ERROR, "SELECT_DESELECT_CARD SEND_STATUS Fail Status = 0x%x\n", Status));
      goto Exit;
   }
   //
@@ -1322,7 +1322,7 @@ MMCSDCardInit (
                   (UINT32*)&(CardData->CardStatus)
                   );
       if (EFI_ERROR (Status)) {
-        DEBUG((EFI_D_ERROR, "SEND_EXT_CSD Fail Status = 0x%x\n", Status));
+        DEBUG((DEBUG_ERROR, "SEND_EXT_CSD Fail Status = 0x%x\n", Status));
         goto Exit;
       }
 
@@ -1340,7 +1340,7 @@ MMCSDCardInit (
         CardData->BlockNumber = Data;
       }
       DEBUG((DEBUG_INFO, "CardData->BlockNumber  %d\n", Data));
-      DEBUG((EFI_D_ERROR, "CardData->ExtCSDRegister.CARD_TYPE -> %d\n", (UINTN)CardData->ExtCSDRegister.CARD_TYPE));
+      DEBUG((DEBUG_ERROR, "CardData->ExtCSDRegister.CARD_TYPE -> %d\n", (UINTN)CardData->ExtCSDRegister.CARD_TYPE));
       if ((CardData->ExtCSDRegister.CARD_TYPE & BIT2)||
           (CardData->ExtCSDRegister.CARD_TYPE & BIT3)) {
           //DEBUG((DEBUG_INFO, "To enable DDR mode\n"));
@@ -1373,7 +1373,7 @@ MMCSDCardInit (
                     (UINT32*)&(CardData->CardStatus)
                     );
         if (EFI_ERROR (Status)) {
-          DEBUG((EFI_D_ERROR, "MMCSDCardInit:SWITCH frequency Fail Status = 0x%x\n", Status));
+          DEBUG((DEBUG_ERROR, "MMCSDCardInit:SWITCH frequency Fail Status = 0x%x\n", Status));
         }
 
         gBS->Stall (5 * 1000);
@@ -1393,10 +1393,10 @@ MMCSDCardInit (
                       );
           if (!EFI_ERROR (Status)) {
             if (EnableDDRMode) {
-              DEBUG((EFI_D_ERROR, "Enable ddr mode on host controller\n"));
+              DEBUG((DEBUG_ERROR, "Enable ddr mode on host controller\n"));
               SDHostIo->SetDDRMode (SDHostIo, TRUE);
             } else  {
-              DEBUG((EFI_D_ERROR, "Enable high speed mode on host controller\n"));
+              DEBUG((DEBUG_ERROR, "Enable high speed mode on host controller\n"));
               SDHostIo->SetHighSpeedMode (SDHostIo, TRUE);
             }
           //
@@ -1411,7 +1411,7 @@ MMCSDCardInit (
               Status = EFI_UNSUPPORTED;
             }
             if (EFI_ERROR (Status)) {
-              DEBUG((EFI_D_ERROR, "MMCSDCardInit:Fail to SetClockFrequency \n"));
+              DEBUG((DEBUG_ERROR, "MMCSDCardInit:Fail to SetClockFrequency \n"));
               goto Exit;
             }
             //
@@ -1504,7 +1504,7 @@ MMCSDCardInit (
                        (UINT32*)&(CardData->CardStatus)
                        );
            if (EFI_ERROR (Status)) {
-             DEBUG((EFI_D_ERROR, "SWITCH Power Class Fail Status = 0x%x\n", Status));
+             DEBUG((DEBUG_ERROR, "SWITCH Power Class Fail Status = 0x%x\n", Status));
            }
            //gBS->Stall (10 * 1000);
          }
@@ -1515,7 +1515,7 @@ MMCSDCardInit (
     } else {
 
 
-      DEBUG((EFI_D_ERROR, "MMC Card version %d only supportes 1 bits at lower transfer speed\n",CardData->CSDRegister.SPEC_VERS));
+      DEBUG((DEBUG_ERROR, "MMC Card version %d only supportes 1 bits at lower transfer speed\n",CardData->CSDRegister.SPEC_VERS));
     }
   } else {
       //
@@ -1535,7 +1535,7 @@ MMCSDCardInit (
                   (UINT32*)&(CardData->CardStatus)
                   );
       if (EFI_ERROR (Status)) {
-        DEBUG((EFI_D_ERROR, "SET_CLR_CARD_DETECT Fail Status = 0x%x\n", Status));
+        DEBUG((DEBUG_ERROR, "SET_CLR_CARD_DETECT Fail Status = 0x%x\n", Status));
         goto Exit;
       }
 
@@ -1582,7 +1582,7 @@ MMCSDCardInit (
                   (UINT32*)&(CardData->CardStatus)
                   );
       if (EFI_ERROR (Status)) {
-        DEBUG((EFI_D_ERROR, "SET_BUS_WIDTH 4 bits Fail Status = 0x%x\n", Status));
+        DEBUG((DEBUG_ERROR, "SET_BUS_WIDTH 4 bits Fail Status = 0x%x\n", Status));
         goto Exit;
       }
 
@@ -1695,7 +1695,7 @@ MMCSDCardInit (
               (UINT32*)&(CardData->CardStatus)
               );
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "SET_BLOCKLEN Fail Status = 0x%x\n", Status));
+    DEBUG((DEBUG_ERROR, "SET_BLOCKLEN Fail Status = 0x%x\n", Status));
     goto Exit;
   }
   }

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Sdio/Dxe/SDMediaDeviceDxe/SDMediaDevice.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Sdio/Dxe/SDMediaDeviceDxe/SDMediaDevice.c
@@ -138,20 +138,20 @@ SDMediaDeviceStart (
                   EFI_OPEN_PROTOCOL_BY_DRIVER
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SDMediaDeviceStart: Fail to open gEfiSDHostIoProtocolGuid \r\n"));
+    DEBUG ((DEBUG_ERROR, "SDMediaDeviceStart: Fail to open gEfiSDHostIoProtocolGuid \r\n"));
     goto Exit;
   }
 
   Status = SDHostIo->DetectCardAndInitHost (SDHostIo);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "SDMediaDeviceStart: Fail to DetectCardAndInitHost \r\n"));
+    DEBUG ((DEBUG_INFO, "SDMediaDeviceStart: Fail to DetectCardAndInitHost \r\n"));
     goto Exit;
   }
 
   CardData = (CARD_DATA*)AllocateZeroPool(sizeof (CARD_DATA));
   if (CardData == NULL) {
     Status =  EFI_OUT_OF_RESOURCES;
-    DEBUG ((EFI_D_ERROR, "SDMediaDeviceStart: Fail to AllocateZeroPool(CARD_DATA) \r\n"));
+    DEBUG ((DEBUG_ERROR, "SDMediaDeviceStart: Fail to AllocateZeroPool(CARD_DATA) \r\n"));
     goto Exit;
   }
 
@@ -165,7 +165,7 @@ SDMediaDeviceStart (
                   );
 
   if (CardData->RawBufferPointer == NULL) {
-    DEBUG ((EFI_D_ERROR, "SDMediaDeviceStart: Fail to AllocateZeroPool(2*x) \r\n"));
+    DEBUG ((DEBUG_ERROR, "SDMediaDeviceStart: Fail to AllocateZeroPool(2*x) \r\n"));
     Status =  EFI_OUT_OF_RESOURCES;
     goto Exit;
   }
@@ -176,10 +176,10 @@ SDMediaDeviceStart (
 
   Status = MMCSDCardInit (CardData);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SDMediaDeviceStart: Fail to MMCSDCardInit \r\n"));
+    DEBUG ((DEBUG_ERROR, "SDMediaDeviceStart: Fail to MMCSDCardInit \r\n"));
     goto Exit;
   }
-  DEBUG ((EFI_D_INFO, "SDMediaDeviceStart: MMCSDCardInit SuccessFul\n"));
+  DEBUG ((DEBUG_INFO, "SDMediaDeviceStart: MMCSDCardInit SuccessFul\n"));
 
   if (CardData->CardType == CEATACard) {
     Status = CEATABlockIoInit (CardData);
@@ -188,10 +188,10 @@ SDMediaDeviceStart (
   }
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SDMediaDeviceStart: Fail to BlockIoInit \r\n"));
+    DEBUG ((DEBUG_ERROR, "SDMediaDeviceStart: Fail to BlockIoInit \r\n"));
     goto Exit;
   }
-  DEBUG ((EFI_D_INFO, "SDMediaDeviceStart: BlockIo is successfully installed\n"));
+  DEBUG ((DEBUG_INFO, "SDMediaDeviceStart: BlockIo is successfully installed\n"));
 
 
   Status = gBS->InstallProtocolInterface (
@@ -201,7 +201,7 @@ SDMediaDeviceStart (
                   &CardData->BlockIo
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SDMediaDeviceStart: Fail to install gEfiBlockIoProtocolGuid \r\n"));
+    DEBUG ((DEBUG_ERROR, "SDMediaDeviceStart: Fail to install gEfiBlockIoProtocolGuid \r\n"));
     goto Exit;
   }
 
@@ -227,7 +227,7 @@ SDMediaDeviceStart (
 
 Exit:
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "SDMediaDeviceStart: End with failure\r\n"));
+    DEBUG ((DEBUG_INFO, "SDMediaDeviceStart: End with failure\r\n"));
     if (CardData != NULL) {
       if (CardData->RawBufferPointer != NULL) {
         gBS->FreePages ((EFI_PHYSICAL_ADDRESS) (UINTN) CardData->RawBufferPointer, EFI_SIZE_TO_PAGES (2 * SDHostIo->HostCapability.BoundarySize));

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Common/Pei/UsbPei.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Common/Pei/UsbPei.c
@@ -82,7 +82,7 @@ SwitchConfigFlag (
     EhciCapLen = MmioRead8 (UsbBaseAddr + R_IOH_EHCI_CAPLENGTH);
     MmioWrite32 (UsbBaseAddr + EhciCapLen + R_IOH_EHCI_CONFIGFLAGS, 0);
 
-    DEBUG ((EFI_D_INFO, "CF@EHCI = %x \n", UsbBaseAddr + EhciCapLen + R_IOH_EHCI_CONFIGFLAGS));
+    DEBUG ((DEBUG_INFO, "CF@EHCI = %x \n", UsbBaseAddr + EhciCapLen + R_IOH_EHCI_CONFIGFLAGS));
     //
     // Restore EHCI UsbBaseAddr in PCI space
     //
@@ -233,7 +233,7 @@ PeimInitializeIchUsb (
     );
 
   if (FeaturePcdGet (PcdEhciRecoveryEnabled)) {
-    DEBUG ((EFI_D_INFO, "UsbPei:EHCI is used for recovery\n"));
+    DEBUG ((DEBUG_INFO, "UsbPei:EHCI is used for recovery\n"));
     //
     // EHCI recovery is enabled
     //
@@ -249,7 +249,7 @@ PeimInitializeIchUsb (
     // Assign resources and enable Ehci controllers
     //
     for (i = 0; i < IOH_MAX_EHCI_USB_CONTROLLERS; i++) {
-      DEBUG ((EFI_D_INFO, "UsbPei:Enable the %dth EHCI controller for recovery\n", i));
+      DEBUG ((DEBUG_INFO, "UsbPei:Enable the %dth EHCI controller for recovery\n", i));
       PeiIohEhciDev->MmioBase[i] = PcdGet32(PcdPeiQNCUsbControllerMemoryBaseAddress) + IOH_USB_CONTROLLER_MMIO_RANGE * i;
       //
       // Assign base address register, Enable Bus Master and Memory Io
@@ -269,7 +269,7 @@ PeimInitializeIchUsb (
 
     ASSERT_EFI_ERROR (Status);
   } else {
-    DEBUG ((EFI_D_INFO, "UsbPei:OHCI is used for recovery\n"));
+    DEBUG ((DEBUG_INFO, "UsbPei:OHCI is used for recovery\n"));
     //
     // OHCI recovery is enabled
     //
@@ -285,7 +285,7 @@ PeimInitializeIchUsb (
     // Assign resources and enable OHCI controllers
     //
     for (i = 0; i < IOH_MAX_OHCI_USB_CONTROLLERS; i++) {
-      DEBUG ((EFI_D_INFO, "UsbPei:Enable the %dth OHCI controller for recovery\n", i));
+      DEBUG ((DEBUG_INFO, "UsbPei:Enable the %dth OHCI controller for recovery\n", i));
       PeiIohOhciDev->MmioBase[i] = PcdGet32(PcdPeiQNCUsbControllerMemoryBaseAddress) + IOH_USB_CONTROLLER_MMIO_RANGE * i;
       //
       // Assign base address register, Enable Bus Master and Memory Io

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Ohci/Dxe/Ohci.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Ohci/Dxe/Ohci.c
@@ -317,7 +317,7 @@ OhciControlTransfer (
   }
 
   if (*DataLength > MAX_BYTES_PER_TD) {
-    DEBUG ((EFI_D_ERROR, "OhciControlTransfer: Request data size is too large\r\n"));
+    DEBUG ((DEBUG_ERROR, "OhciControlTransfer: Request data size is too large\r\n"));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -333,13 +333,13 @@ OhciControlTransfer (
 
   Status = OhciSetHcControl (Ohc, CONTROL_ENABLE, 0);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: fail to disable CONTROL_ENABLE\r\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: fail to disable CONTROL_ENABLE\r\n"));
     *TransferResult = EFI_USB_ERR_SYSTEM;
     return EFI_DEVICE_ERROR;
   }
   Status = OhciSetHcCommandStatus (Ohc, CONTROL_LIST_FILLED, 0);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: fail to disable CONTROL_LIST_FILLED\r\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: fail to disable CONTROL_LIST_FILLED\r\n"));
     *TransferResult = EFI_USB_ERR_SYSTEM;
     return EFI_DEVICE_ERROR;
   }
@@ -349,7 +349,7 @@ OhciControlTransfer (
   Ed = OhciCreateED (Ohc);
   if (Ed == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to allocate ED buffer\r\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to allocate ED buffer\r\n"));
     goto CTRL_EXIT;
   }
   OhciSetEDField (Ed, ED_SKIP, 1);
@@ -373,14 +373,14 @@ OhciControlTransfer (
     MapOp = EfiPciIoOperationBusMasterRead;
     Status = Ohc->PciIo->Map (Ohc->PciIo, MapOp, (UINT8 *)Request, &ReqMapLength, &ReqMapPhyAddr, &ReqMapping);
     if (EFI_ERROR(Status)) {
-      DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to Map Request Buffer\r\n"));
+      DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to Map Request Buffer\r\n"));
       goto FREE_ED_BUFF;
     }
   }
   SetupTd = OhciCreateTD (Ohc);
   if (SetupTd == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to allocate Setup TD buffer\r\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to allocate Setup TD buffer\r\n"));
     goto UNMAP_SETUP_BUFF;
   }
   HeadTd = SetupTd;
@@ -407,7 +407,7 @@ OhciControlTransfer (
   if ((Data != NULL) && (DataMapLength != 0)) {
     Status = Ohc->PciIo->Map (Ohc->PciIo, MapOp, Data, &DataMapLength, &DataMapPhyAddr, &DataMapping);
     if (EFI_ERROR(Status)) {
-      DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail To Map Data Buffer\r\n"));
+      DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail To Map Data Buffer\r\n"));
       goto FREE_TD_BUFF;
     }
   }
@@ -424,7 +424,7 @@ OhciControlTransfer (
     }
     DataTd = OhciCreateTD (Ohc);
     if (DataTd == NULL) {
-      DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to allocate buffer for Data Stage TD\r\n"));
+      DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to allocate buffer for Data Stage TD\r\n"));
       Status = EFI_OUT_OF_RESOURCES;
       goto UNMAP_DATA_BUFF;
     }
@@ -451,7 +451,7 @@ OhciControlTransfer (
   //
   StatusTd = OhciCreateTD (Ohc);
   if (StatusTd == NULL) {
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to allocate buffer for Status Stage TD\r\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to allocate buffer for Status Stage TD\r\n"));
     Status = EFI_OUT_OF_RESOURCES;
     goto UNMAP_DATA_BUFF;
   }
@@ -503,14 +503,14 @@ OhciControlTransfer (
   OhciSetEDField (Ed, ED_SKIP, 0);
   Status = OhciSetHcControl (Ohc, CONTROL_ENABLE, 1);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: fail to enable CONTROL_ENABLE\r\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: fail to enable CONTROL_ENABLE\r\n"));
     *TransferResult = EFI_USB_ERR_SYSTEM;
     Status = EFI_DEVICE_ERROR;
     goto UNMAP_DATA_BUFF;
   }
   Status = OhciSetHcCommandStatus (Ohc, CONTROL_LIST_FILLED, 1);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: fail to enable CONTROL_LIST_FILLED\r\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: fail to enable CONTROL_LIST_FILLED\r\n"));
     *TransferResult = EFI_USB_ERR_SYSTEM;
     Status = EFI_DEVICE_ERROR;
     goto UNMAP_DATA_BUFF;
@@ -535,13 +535,13 @@ OhciControlTransfer (
 
   if (EdResult.ErrorCode != TD_NO_ERROR) {
     if (EdResult.ErrorCode == TD_TOBE_PROCESSED) {
-      DEBUG ((EFI_D_INFO, "Control pipe timeout, > %d mS\r\n", TimeOut));
+      DEBUG ((DEBUG_INFO, "Control pipe timeout, > %d mS\r\n", TimeOut));
     } else {
-      DEBUG ((EFI_D_INFO, "Control pipe broken\r\n"));
+      DEBUG ((DEBUG_INFO, "Control pipe broken\r\n"));
     }
     *DataLength = 0;
   } else {
-    DEBUG ((EFI_D_INFO, "Control transfer successed\r\n"));
+    DEBUG ((DEBUG_INFO, "Control transfer successed\r\n"));
   }
 
 UNMAP_DATA_BUFF:
@@ -676,13 +676,13 @@ OhciBulkTransfer(
 
   Status = OhciSetHcControl (Ohc, BULK_ENABLE, 0);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: fail to disable BULK_ENABLE\r\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: fail to disable BULK_ENABLE\r\n"));
     *TransferResult = EFI_USB_ERR_SYSTEM;
     return EFI_DEVICE_ERROR;
   }
   Status = OhciSetHcCommandStatus (Ohc, BULK_LIST_FILLED, 0);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: fail to disable BULK_LIST_FILLED\r\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: fail to disable BULK_LIST_FILLED\r\n"));
     *TransferResult = EFI_USB_ERR_SYSTEM;
     return EFI_DEVICE_ERROR;
   }
@@ -712,7 +712,7 @@ OhciBulkTransfer(
     MapLength = *DataLength;
     Status = Ohc->PciIo->Map (Ohc->PciIo, MapOp, (UINT8 *)Data, &MapLength, &MapPyhAddr, &Mapping);
     if (EFI_ERROR(Status)) {
-      DEBUG ((EFI_D_INFO, "OhciBulkTransfer: Fail to Map Data Buffer for Bulk\r\n"));
+      DEBUG ((DEBUG_INFO, "OhciBulkTransfer: Fail to Map Data Buffer for Bulk\r\n"));
       goto FREE_ED_BUFF;
     }
   }
@@ -730,7 +730,7 @@ OhciBulkTransfer(
     }
     DataTd = OhciCreateTD (Ohc);
     if (DataTd == NULL) {
-      DEBUG ((EFI_D_INFO, "OhciBulkTransfer: Fail to allocate buffer for Data Stage TD\r\n"));
+      DEBUG ((DEBUG_INFO, "OhciBulkTransfer: Fail to allocate buffer for Data Stage TD\r\n"));
       Status = EFI_OUT_OF_RESOURCES;
       goto FREE_OHCI_TDBUFF;
     }
@@ -763,7 +763,7 @@ OhciBulkTransfer(
   EmptyTd = OhciCreateTD (Ohc);
   if (EmptyTd == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
-    DEBUG ((EFI_D_INFO, "OhciBulkTransfer: Fail to allocate buffer for Empty TD\r\n"));
+    DEBUG ((DEBUG_INFO, "OhciBulkTransfer: Fail to allocate buffer for Empty TD\r\n"));
     goto FREE_OHCI_TDBUFF;
   }
   OhciSetTDField (EmptyTd, TD_PDATA, 0);
@@ -789,14 +789,14 @@ OhciBulkTransfer(
   if (EFI_ERROR(Status)) {
     *TransferResult = EFI_USB_ERR_SYSTEM;
     Status = EFI_DEVICE_ERROR;
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to enable BULK_LIST_FILLED\r\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to enable BULK_LIST_FILLED\r\n"));
     goto FREE_OHCI_TDBUFF;
   }
   Status = OhciSetHcControl (Ohc, BULK_ENABLE, 1);
   if (EFI_ERROR(Status)) {
     *TransferResult = EFI_USB_ERR_SYSTEM;
     Status = EFI_DEVICE_ERROR;
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to enable BULK_ENABLE\r\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to enable BULK_ENABLE\r\n"));
     goto FREE_OHCI_TDBUFF;
   }
   gBS->Stall(20 * 1000);
@@ -813,14 +813,14 @@ OhciBulkTransfer(
 
   if (EdResult.ErrorCode != TD_NO_ERROR) {
     if (EdResult.ErrorCode == TD_TOBE_PROCESSED) {
-      DEBUG ((EFI_D_INFO, "Bulk pipe timeout, > %d mS\r\n", TimeOut));
+      DEBUG ((DEBUG_INFO, "Bulk pipe timeout, > %d mS\r\n", TimeOut));
     } else {
-      DEBUG ((EFI_D_INFO, "Bulk pipe broken\r\n"));
+      DEBUG ((DEBUG_INFO, "Bulk pipe broken\r\n"));
       *DataToggle = EdResult.NextToggle;
     }
     *DataLength = 0;
   } else {
-    DEBUG ((EFI_D_INFO, "Bulk transfer successed\r\n"));
+    DEBUG ((DEBUG_INFO, "Bulk transfer successed\r\n"));
   }
   //*DataToggle = (UINT8) OhciGetEDField (Ed, ED_DTTOGGLE);
 
@@ -941,7 +941,7 @@ OhciInterruptTransfer (
 
 
   if (DataLength > MAX_BYTES_PER_TD) {
-    DEBUG ((EFI_D_ERROR, "OhciInterruptTransfer: Error param\r\n"));
+    DEBUG ((DEBUG_ERROR, "OhciInterruptTransfer: Error param\r\n"));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -974,7 +974,7 @@ OhciInterruptTransfer (
                          &Mapping
                          );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "OhciInterruptTransfer: Failt to PciIo->Map buffer \r\n"));
+    DEBUG ((DEBUG_ERROR, "OhciInterruptTransfer: Failt to PciIo->Map buffer \r\n"));
     goto EXIT;
   }
   Depth = 5;
@@ -993,7 +993,7 @@ OhciInterruptTransfer (
     Ed = OhciCreateED (Ohc);
     if (Ed == NULL) {
       Status = EFI_OUT_OF_RESOURCES;
-      DEBUG ((EFI_D_ERROR, "OhciInterruptTransfer: Fail to allocate buffer for ED\r\n"));
+      DEBUG ((DEBUG_ERROR, "OhciInterruptTransfer: Fail to allocate buffer for ED\r\n"));
       goto UNMAP_OHCI_XBUFF;
     }
     OhciSetEDField (Ed, ED_SKIP, 1);
@@ -1024,7 +1024,7 @@ OhciInterruptTransfer (
     DataTd = OhciCreateTD (Ohc);
     if (DataTd == NULL) {
       Status = EFI_OUT_OF_RESOURCES;
-      DEBUG ((EFI_D_ERROR, "OhciInterruptTransfer: Fail to allocate buffer for Data Stage TD\r\n"));
+      DEBUG ((DEBUG_ERROR, "OhciInterruptTransfer: Fail to allocate buffer for Data Stage TD\r\n"));
       goto FREE_OHCI_TDBUFF;
     }
     OhciSetTDField (DataTd, TD_PDATA, 0);
@@ -1054,7 +1054,7 @@ OhciInterruptTransfer (
   EmptTd = OhciCreateTD (Ohc);
   if (EmptTd == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
-    DEBUG ((EFI_D_ERROR, "OhciInterruptTransfer: Fail to allocate buffer for Empty Stage TD\r\n"));
+    DEBUG ((DEBUG_ERROR, "OhciInterruptTransfer: Fail to allocate buffer for Empty Stage TD\r\n"));
     goto FREE_OHCI_TDBUFF;
   }
   OhciSetTDField (EmptTd, TD_PDATA, 0);
@@ -2354,7 +2354,7 @@ OHCIDriverBindingStart (
                   &Ohc->UsbHc
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "Install protocol error"));
+    DEBUG ((DEBUG_INFO, "Install protocol error"));
     goto FREE_OHC;
   }
   //
@@ -2369,7 +2369,7 @@ OHCIDriverBindingStart (
                   &Ohc->ExitBootServiceEvent
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "Create exit boot event error"));
+    DEBUG ((DEBUG_INFO, "Create exit boot event error"));
     goto UNINSTALL_USBHC;
   }
   AddUnicodeString2 (

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Ohci/Dxe/OhciDebug.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Ohci/Dxe/OhciDebug.c
@@ -33,40 +33,40 @@ OhciDumpEdTdInfo (
   UINT32                  Index;
 
   if (Stage) {
-    DEBUG ((EFI_D_INFO, "\n Before executing command\n"));
+    DEBUG ((DEBUG_INFO, "\n Before executing command\n"));
   }else{
-    DEBUG ((EFI_D_INFO, "\n after executing command\n"));
+    DEBUG ((DEBUG_INFO, "\n after executing command\n"));
   }
   if (Ed != NULL) {
-    DEBUG ((EFI_D_INFO, "\nED Address:%p, ED buffer:\n", Ed));
-    DEBUG ((EFI_D_INFO, "DWord0  :TD Tail :TD Head :Next ED\n"));
+    DEBUG ((DEBUG_INFO, "\nED Address:%p, ED buffer:\n", Ed));
+    DEBUG ((DEBUG_INFO, "DWord0  :TD Tail :TD Head :Next ED\n"));
     for (Index = 0; Index < sizeof (ED_DESCRIPTOR)/4; Index ++) {
-      DEBUG ((EFI_D_INFO, "%8x ", *((UINT32*)(Ed) + Index)  ));
+      DEBUG ((DEBUG_INFO, "%8x ", *((UINT32*)(Ed) + Index)  ));
     }
-    DEBUG ((EFI_D_INFO, "\nNext TD buffer:%p\n", Td));
+    DEBUG ((DEBUG_INFO, "\nNext TD buffer:%p\n", Td));
   }
   while (Td != NULL) {
     if (Td->Word0.DirPID == TD_SETUP_PID) {
-      DEBUG ((EFI_D_INFO, "\nSetup PID "));
+      DEBUG ((DEBUG_INFO, "\nSetup PID "));
     }else if (Td->Word0.DirPID == TD_OUT_PID) {
-      DEBUG ((EFI_D_INFO, "\nOut PID "));
+      DEBUG ((DEBUG_INFO, "\nOut PID "));
     }else if (Td->Word0.DirPID == TD_IN_PID) {
-      DEBUG ((EFI_D_INFO, "\nIn PID "));
+      DEBUG ((DEBUG_INFO, "\nIn PID "));
     }else if (Td->Word0.DirPID == TD_NODATA_PID) {
-      DEBUG ((EFI_D_INFO, "\nNo data PID "));
+      DEBUG ((DEBUG_INFO, "\nNo data PID "));
     }
-    DEBUG ((EFI_D_INFO, "TD Address:%p, TD buffer:\n", Td));
-    DEBUG ((EFI_D_INFO, "DWord0  :CuBuffer:Next TD :Buff End:Next TD :DataBuff:ActLength\n"));
+    DEBUG ((DEBUG_INFO, "TD Address:%p, TD buffer:\n", Td));
+    DEBUG ((DEBUG_INFO, "DWord0  :CuBuffer:Next TD :Buff End:Next TD :DataBuff:ActLength\n"));
     for (Index = 0; Index < sizeof (TD_DESCRIPTOR)/4; Index ++) {
-      DEBUG ((EFI_D_INFO, "%8x ", *((UINT32*)(Td) + Index)  ));
+      DEBUG ((DEBUG_INFO, "%8x ", *((UINT32*)(Td) + Index)  ));
     }
-    DEBUG ((EFI_D_INFO, "\nCurrent TD Data buffer(size%d)\n", (UINT32)Td->ActualSendLength));
+    DEBUG ((DEBUG_INFO, "\nCurrent TD Data buffer(size%d)\n", (UINT32)Td->ActualSendLength));
     for (Index = 0; Index < Td->ActualSendLength; Index ++) {
-      DEBUG ((EFI_D_INFO, "%2x ", *(UINT8 *)(UINTN)(Td->DataBuffer + Index) ));
+      DEBUG ((DEBUG_INFO, "%2x ", *(UINT8 *)(UINTN)(Td->DataBuffer + Index) ));
     }
   Td = (TD_DESCRIPTOR *)(UINTN)(Td->NextTDPointer);
   }
-  DEBUG ((EFI_D_INFO, "\n TD buffer End\n"));
+  DEBUG ((DEBUG_INFO, "\n TD buffer End\n"));
 
   return EFI_SUCCESS;
 }

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Ohci/Dxe/OhciUrb.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Ohci/Dxe/OhciUrb.c
@@ -31,7 +31,7 @@ OhciCreateTD (
 
   Td = UsbHcAllocateMem(Ohc->MemPool, sizeof(TD_DESCRIPTOR));
   if (Td == NULL) {
-    DEBUG ((EFI_D_INFO, "STV allocate TD fail !\r\n"));
+    DEBUG ((DEBUG_INFO, "STV allocate TD fail !\r\n"));
     return NULL;
   }
   Td->CurrBufferPointer = 0;
@@ -85,7 +85,7 @@ OhciCreateED (
   ED_DESCRIPTOR   *Ed;
   Ed = UsbHcAllocateMem(Ohc->MemPool, sizeof (ED_DESCRIPTOR));
   if (Ed == NULL) {
-    DEBUG ((EFI_D_INFO, "STV allocate ED fail !\r\n"));
+    DEBUG ((DEBUG_INFO, "STV allocate ED fail !\r\n"));
     return NULL;
   }
   Ed->Word0.Skip = 1;

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Ohci/Dxe/UsbHcMem.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Ohci/Dxe/UsbHcMem.c
@@ -470,7 +470,7 @@ UsbHcAllocateMem (
   NewBlock = UsbHcAllocMemBlock (Pool, Pages);
 
   if (NewBlock == NULL) {
-    DEBUG ((EFI_D_INFO, "UsbHcAllocateMem: failed to allocate block\n"));
+    DEBUG ((DEBUG_INFO, "UsbHcAllocateMem: failed to allocate block\n"));
     return NULL;
   }
 

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Ohci/Pei/OhcPeim.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Ohci/Pei/OhcPeim.c
@@ -82,12 +82,12 @@ OhciControlTransfer (
       (DeviceSpeed != EFI_USB_SPEED_LOW && DeviceSpeed != EFI_USB_SPEED_FULL) ||
       (MaxPacketLength != 8 && MaxPacketLength != 16 &&
        MaxPacketLength != 32 && MaxPacketLength != 64)) {
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: EFI_INVALID_PARAMETER\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: EFI_INVALID_PARAMETER\n"));
     return EFI_INVALID_PARAMETER;
   }
 
   if (*DataLength > MAX_BYTES_PER_TD) {
-    DEBUG ((EFI_D_ERROR, "OhciControlTransfer: Request data size is too large\n"));
+    DEBUG ((DEBUG_ERROR, "OhciControlTransfer: Request data size is too large\n"));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -106,14 +106,14 @@ OhciControlTransfer (
     MicroSecondDelay (HC_1_MILLISECOND);
     if (OhciGetHcControl (Ohc, CONTROL_ENABLE) != 0) {
       *TransferResult = EFI_USB_ERR_SYSTEM;
-      DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to disable CONTROL transfer\n"));
+      DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to disable CONTROL transfer\n"));
       return EFI_DEVICE_ERROR;
     }
   }
   OhciSetMemoryPointer (Ohc, HC_CONTROL_HEAD, NULL);
   Ed = OhciCreateED (Ohc);
   if (Ed == NULL) {
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to allocate ED buffer\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to allocate ED buffer\n"));
     return EFI_OUT_OF_RESOURCES;
   }
   OhciSetEDField (Ed, ED_SKIP, 1);
@@ -138,7 +138,7 @@ OhciControlTransfer (
   SetupTd = OhciCreateTD (Ohc);
   if (SetupTd == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to allocate Setup TD buffer\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to allocate Setup TD buffer\n"));
     goto FREE_ED_BUFF;
   }
   HeadTd = SetupTd;
@@ -173,7 +173,7 @@ OhciControlTransfer (
     }
     DataTd = OhciCreateTD (Ohc);
     if (DataTd == NULL) {
-      DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to allocate Data TD buffer\n"));
+      DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to allocate Data TD buffer\n"));
       Status = EFI_OUT_OF_RESOURCES;
       goto FREE_TD_BUFF;
     }
@@ -200,7 +200,7 @@ OhciControlTransfer (
   //
   StatusTd = OhciCreateTD (Ohc);
   if (StatusTd == NULL) {
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to allocate Status TD buffer\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to allocate Status TD buffer\n"));
     Status = EFI_OUT_OF_RESOURCES;
     goto FREE_TD_BUFF;
   }
@@ -224,7 +224,7 @@ OhciControlTransfer (
   EmptyTd = OhciCreateTD (Ohc);
   if (EmptyTd == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
-    DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to allocate Empty TD buffer\n"));
+    DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to allocate Empty TD buffer\n"));
     goto FREE_TD_BUFF;
   }
   OhciSetTDField (EmptyTd, TD_PDATA, 0);
@@ -255,7 +255,7 @@ OhciControlTransfer (
     if (OhciGetHcControl (Ohc, CONTROL_ENABLE) != 1) {
       *TransferResult = EFI_USB_ERR_SYSTEM;
       Status = EFI_DEVICE_ERROR;
-      DEBUG ((EFI_D_INFO, "OhciControlTransfer: Fail to enable CONTROL transfer\n"));
+      DEBUG ((DEBUG_INFO, "OhciControlTransfer: Fail to enable CONTROL transfer\n"));
       goto FREE_TD_BUFF;
     }
   }
@@ -273,9 +273,9 @@ OhciControlTransfer (
 
   if (ErrorCode != TD_NO_ERROR) {
     if (ErrorCode == TD_TOBE_PROCESSED) {
-      DEBUG ((EFI_D_INFO, "Control pipe timeout, > %d mS\r\n", TimeOut));
+      DEBUG ((DEBUG_INFO, "Control pipe timeout, > %d mS\r\n", TimeOut));
     } else {
-      DEBUG ((EFI_D_INFO, "Control pipe broken\r\n"));
+      DEBUG ((DEBUG_INFO, "Control pipe broken\r\n"));
     }
 
     *DataLength = 0;
@@ -286,7 +286,7 @@ OhciControlTransfer (
   MicroSecondDelay (HC_1_MILLISECOND);
     if (OhciGetHcControl (Ohc, CONTROL_ENABLE) != 0) {
       *TransferResult = EFI_USB_ERR_SYSTEM;
-      DEBUG ((EFI_D_INFO, "OhciControlTransfer: Cannot disable CONTROL_ENABLE transfer\n"));
+      DEBUG ((DEBUG_INFO, "OhciControlTransfer: Cannot disable CONTROL_ENABLE transfer\n"));
       goto FREE_TD_BUFF;
     }
   }
@@ -399,7 +399,7 @@ OhciBulkTransfer (
 
   Ed = OhciCreateED (Ohc);
   if (Ed == NULL) {
-    DEBUG ((EFI_D_INFO, "OhcBulkTransfer: Fail to allocate ED buffer\r\n"));
+    DEBUG ((DEBUG_INFO, "OhcBulkTransfer: Fail to allocate ED buffer\r\n"));
     return EFI_OUT_OF_RESOURCES;
   }
   OhciSetEDField (Ed, ED_SKIP, 1);
@@ -435,7 +435,7 @@ OhciBulkTransfer (
     }
     DataTd = OhciCreateTD (Ohc);
     if (DataTd == NULL) {
-      DEBUG ((EFI_D_INFO, "OhcBulkTransfer: Fail to allocate Data TD buffer\r\n"));
+      DEBUG ((DEBUG_INFO, "OhcBulkTransfer: Fail to allocate Data TD buffer\r\n"));
       Status = EFI_OUT_OF_RESOURCES;
       goto FREE_TD_BUFF;
     }
@@ -468,7 +468,7 @@ OhciBulkTransfer (
   EmptyTd = OhciCreateTD (Ohc);
   if (EmptyTd == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
-      DEBUG ((EFI_D_INFO, "OhcBulkTransfer: Fail to allocate Empty TD buffer\r\n"));
+      DEBUG ((DEBUG_INFO, "OhcBulkTransfer: Fail to allocate Empty TD buffer\r\n"));
     goto FREE_TD_BUFF;
   }
   OhciSetTDField (EmptyTd, TD_PDATA, 0);
@@ -513,9 +513,9 @@ OhciBulkTransfer (
 
   if (ErrorCode != TD_NO_ERROR) {
     if (ErrorCode == TD_TOBE_PROCESSED) {
-      DEBUG ((EFI_D_INFO, "Bulk pipe timeout, > %d mS\r\n", TimeOut));
+      DEBUG ((DEBUG_INFO, "Bulk pipe timeout, > %d mS\r\n", TimeOut));
     } else {
-      DEBUG ((EFI_D_INFO, "Bulk pipe broken\r\n"));
+      DEBUG ((DEBUG_INFO, "Bulk pipe broken\r\n"));
     }
     *DataLength = 0;
   }
@@ -1336,7 +1336,7 @@ OhcPeimEntry (
                &TempPtr
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "OhcPeimEntry: Fail to allocate buffer for the %dth OHCI ControllerPpi\n", Index));
+      DEBUG ((DEBUG_INFO, "OhcPeimEntry: Fail to allocate buffer for the %dth OHCI ControllerPpi\n", Index));
       return EFI_OUT_OF_RESOURCES;
     }
     ZeroMem((VOID *)(UINTN)TempPtr, MemPages*PAGESIZE);
@@ -1355,7 +1355,7 @@ OhcPeimEntry (
                EFI_USB_HC_RESET_GLOBAL
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "OhcPeimEntry: Fail to init %dth OHCI ControllerPpi\n", Index));
+      DEBUG ((DEBUG_INFO, "OhcPeimEntry: Fail to init %dth OHCI ControllerPpi\n", Index));
       return Status;
     }
     //

--- a/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Ohci/Pei/UsbHcMem.c
+++ b/Silicon/Intel/QuarkSocPkg/QuarkSouthCluster/Usb/Ohci/Pei/UsbHcMem.c
@@ -402,7 +402,7 @@ UsbHcAllocateMem (
   NewBlock = UsbHcAllocMemBlock (Pool, Pages);
 
   if (NewBlock == NULL) {
-    DEBUG ((EFI_D_INFO, "UsbHcAllocateMem: failed to allocate block\n"));
+    DEBUG ((DEBUG_INFO, "UsbHcAllocateMem: failed to allocate block\n"));
     return NULL;
   }
 

--- a/Silicon/Intel/SimicsIch10Pkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/Silicon/Intel/SimicsIch10Pkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -21,7 +21,7 @@ AcpiPmControl (
   )
 {
   ASSERT (SuspendType < 6);
-  DEBUG((EFI_D_ERROR, "SuspendType = 0x%x\n", SuspendType));
+  DEBUG((DEBUG_ERROR, "SuspendType = 0x%x\n", SuspendType));
 
   IoBitFieldWrite16 (ICH10_PMBASE_IO + 4, 10, 13, (UINT16) SuspendType);
   IoOr16 (ICH10_PMBASE_IO + 0x04, BIT13);
@@ -43,11 +43,11 @@ ResetCold (
   VOID
   )
 {
-  DEBUG((EFI_D_ERROR, "ResetCold_CF9\n"));
+  DEBUG((DEBUG_ERROR, "ResetCold_CF9\n"));
   IoWrite8 (0xCF9, BIT3 | BIT2 | BIT1); // 1st choice: PIIX3 RCR, RCPU|SRST
   MicroSecondDelay (50);
 
-  DEBUG((EFI_D_ERROR, "ResetCold_Port64\n"));
+  DEBUG((DEBUG_ERROR, "ResetCold_Port64\n"));
   IoWrite8 (0x64, 0xfe);         // 2nd choice: keyboard controller
   CpuDeadLoop ();
 }
@@ -65,7 +65,7 @@ ResetWarm (
   VOID
   )
 {
-  DEBUG((EFI_D_ERROR, "ResetWarm\n"));
+  DEBUG((DEBUG_ERROR, "ResetWarm\n"));
   //
   //BUGBUG workaround for warm reset
   //
@@ -89,7 +89,7 @@ ResetShutdown (
   VOID
   )
 {
-  DEBUG((EFI_D_ERROR, "ResetShutdown\n"));
+  DEBUG((DEBUG_ERROR, "ResetShutdown\n"));
   AcpiPmControl (0);
   ASSERT (FALSE);
 }
@@ -109,7 +109,7 @@ EnterS3WithImmediateWake (
   VOID
   )
 {
-  DEBUG((EFI_D_ERROR, "EnterS3WithImmediateWake\n"));
+  DEBUG((DEBUG_ERROR, "EnterS3WithImmediateWake\n"));
   AcpiPmControl (1);
   ASSERT (FALSE);
 }
@@ -132,6 +132,6 @@ ResetPlatformSpecific (
   IN VOID    *ResetData
   )
 {
-  DEBUG((EFI_D_ERROR, "ResetPlatformSpecific\n"));
+  DEBUG((DEBUG_ERROR, "ResetPlatformSpecific\n"));
   ResetCold ();
 }

--- a/Silicon/Intel/SimicsIch10Pkg/SmmControl/RuntimeDxe/SmmControl2Dxe.c
+++ b/Silicon/Intel/SimicsIch10Pkg/SmmControl/RuntimeDxe/SmmControl2Dxe.c
@@ -244,7 +244,7 @@ SmmControl2DxeEntryPoint (
   //
   SmiEnableVal = IoRead32 (mSmiEnable);
   if ((SmiEnableVal & ICH10_SMI_EN_APMC_EN) != 0) {
-    DEBUG ((EFI_D_ERROR, "%a: this X58 implementation lacks SMI\n",
+    DEBUG ((DEBUG_ERROR, "%a: this X58 implementation lacks SMI\n",
       __FUNCTION__));
   }
 
@@ -267,7 +267,7 @@ SmmControl2DxeEntryPoint (
   //
   IoWrite32 (mSmiEnable, SmiEnableVal & ~(UINT32)ICH10_SMI_EN_GBL_SMI_EN);
   if (IoRead32 (mSmiEnable) != SmiEnableVal) {
-    DEBUG ((EFI_D_ERROR, "%a: failed to lock down GBL_SMI_EN\n",
+    DEBUG ((DEBUG_ERROR, "%a: failed to lock down GBL_SMI_EN\n",
       __FUNCTION__));
     goto FatalError;
   }
@@ -283,14 +283,14 @@ SmmControl2DxeEntryPoint (
                   OnS3SaveStateInstalled, NULL /* Context */,
                   &mS3SaveStateInstalled);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: CreateEvent: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: CreateEvent: %r\n", __FUNCTION__, Status));
     goto FatalError;
   }
 
   Status = gBS->RegisterProtocolNotify (&gEfiS3SaveStateProtocolGuid,
                   mS3SaveStateInstalled, &Registration);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: RegisterProtocolNotify: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: RegisterProtocolNotify: %r\n", __FUNCTION__,
       Status));
     goto ReleaseEvent;
   }
@@ -300,7 +300,7 @@ SmmControl2DxeEntryPoint (
   //
   Status = gBS->SignalEvent (mS3SaveStateInstalled);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: SignalEvent: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: SignalEvent: %r\n", __FUNCTION__, Status));
     goto ReleaseEvent;
   }
 
@@ -312,7 +312,7 @@ SmmControl2DxeEntryPoint (
                   &gEfiSmmControl2ProtocolGuid, &mControl2,
                   NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: InstallMultipleProtocolInterfaces: %r\n",
+    DEBUG ((DEBUG_ERROR, "%a: InstallMultipleProtocolInterfaces: %r\n",
       __FUNCTION__, Status));
     goto ReleaseEvent;
   }
@@ -377,7 +377,7 @@ OnS3SaveStateInstalled (
                           &SmiEnAndMask
                           );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: EFI_BOOT_SCRIPT_IO_READ_WRITE_OPCODE: %r\n",
+    DEBUG ((DEBUG_ERROR, "%a: EFI_BOOT_SCRIPT_IO_READ_WRITE_OPCODE: %r\n",
       __FUNCTION__, Status));
     ASSERT (FALSE);
     CpuDeadLoop ();
@@ -394,14 +394,14 @@ OnS3SaveStateInstalled (
                           &GenPmCon1AndMask
                           );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR,
+    DEBUG ((DEBUG_ERROR,
       "%a: EFI_BOOT_SCRIPT_PCI_CONFIG_READ_WRITE_OPCODE: %r\n", __FUNCTION__,
       Status));
     ASSERT (FALSE);
     CpuDeadLoop ();
   }
 
-  DEBUG ((EFI_D_VERBOSE, "%a: boot script fragment saved\n", __FUNCTION__));
+  DEBUG ((DEBUG_VERBOSE, "%a: boot script fragment saved\n", __FUNCTION__));
   gBS->CloseEvent (Event);
   mS3SaveStateInstalled = NULL;
 }

--- a/Silicon/Intel/SimicsIch10Pkg/SmmControl/RuntimeDxe/SmmControl2Dxe.c
+++ b/Silicon/Intel/SimicsIch10Pkg/SmmControl/RuntimeDxe/SmmControl2Dxe.c
@@ -245,7 +245,7 @@ SmmControl2DxeEntryPoint (
   SmiEnableVal = IoRead32 (mSmiEnable);
   if ((SmiEnableVal & ICH10_SMI_EN_APMC_EN) != 0) {
     DEBUG ((DEBUG_ERROR, "%a: this X58 implementation lacks SMI\n",
-      __FUNCTION__));
+      __func__));
   }
 
   //
@@ -268,7 +268,7 @@ SmmControl2DxeEntryPoint (
   IoWrite32 (mSmiEnable, SmiEnableVal & ~(UINT32)ICH10_SMI_EN_GBL_SMI_EN);
   if (IoRead32 (mSmiEnable) != SmiEnableVal) {
     DEBUG ((DEBUG_ERROR, "%a: failed to lock down GBL_SMI_EN\n",
-      __FUNCTION__));
+      __func__));
     goto FatalError;
   }
 
@@ -283,14 +283,14 @@ SmmControl2DxeEntryPoint (
                   OnS3SaveStateInstalled, NULL /* Context */,
                   &mS3SaveStateInstalled);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CreateEvent: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: CreateEvent: %r\n", __func__, Status));
     goto FatalError;
   }
 
   Status = gBS->RegisterProtocolNotify (&gEfiS3SaveStateProtocolGuid,
                   mS3SaveStateInstalled, &Registration);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: RegisterProtocolNotify: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: RegisterProtocolNotify: %r\n", __func__,
       Status));
     goto ReleaseEvent;
   }
@@ -300,7 +300,7 @@ SmmControl2DxeEntryPoint (
   //
   Status = gBS->SignalEvent (mS3SaveStateInstalled);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: SignalEvent: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: SignalEvent: %r\n", __func__, Status));
     goto ReleaseEvent;
   }
 
@@ -313,7 +313,7 @@ SmmControl2DxeEntryPoint (
                   NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: InstallMultipleProtocolInterfaces: %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     goto ReleaseEvent;
   }
 
@@ -378,7 +378,7 @@ OnS3SaveStateInstalled (
                           );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: EFI_BOOT_SCRIPT_IO_READ_WRITE_OPCODE: %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     ASSERT (FALSE);
     CpuDeadLoop ();
   }
@@ -395,13 +395,13 @@ OnS3SaveStateInstalled (
                           );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
-      "%a: EFI_BOOT_SCRIPT_PCI_CONFIG_READ_WRITE_OPCODE: %r\n", __FUNCTION__,
+      "%a: EFI_BOOT_SCRIPT_PCI_CONFIG_READ_WRITE_OPCODE: %r\n", __func__,
       Status));
     ASSERT (FALSE);
     CpuDeadLoop ();
   }
 
-  DEBUG ((DEBUG_VERBOSE, "%a: boot script fragment saved\n", __FUNCTION__));
+  DEBUG ((DEBUG_VERBOSE, "%a: boot script fragment saved\n", __func__));
   gBS->CloseEvent (Event);
   mS3SaveStateInstalled = NULL;
 }

--- a/Silicon/Intel/TigerlakeSiliconPkg/IpBlock/PchDmi/LibraryPrivate/PeiDxeSmmPchDmiLib/PchDmiLib.c
+++ b/Silicon/Intel/TigerlakeSiliconPkg/IpBlock/PchDmi/LibraryPrivate/PeiDxeSmmPchDmiLib/PchDmiLib.c
@@ -100,7 +100,7 @@ PchDmiSetLpcMemRange (
   )
 {
   if (IsPchDmiLocked ()) {
-    DEBUG ((DEBUG_ERROR, "%a Error. DMI is locked.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a Error. DMI is locked.\n", __func__));
     ASSERT (FALSE);
     return EFI_UNSUPPORTED;
   }
@@ -130,7 +130,7 @@ PchDmiSetEspiCs1MemRange (
   )
 {
   if (IsPchDmiLocked ()) {
-    DEBUG ((DEBUG_ERROR, "%a Error. DMI is locked.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a Error. DMI is locked.\n", __func__));
     ASSERT (FALSE);
     return EFI_UNSUPPORTED;
   }

--- a/Silicon/Intel/TigerlakeSiliconPkg/IpBlock/Spi/LibraryPrivate/BaseSpiCommonLib/SpiCommon.c
+++ b/Silicon/Intel/TigerlakeSiliconPkg/IpBlock/Spi/LibraryPrivate/BaseSpiCommonLib/SpiCommon.c
@@ -890,7 +890,7 @@ SpiProtocolFlashReadSfdp (
   UINT32            FlashAddress;
 
   if (SpiIsSafModeActive ()) {
-    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __func__));
     return EFI_UNSUPPORTED;
   }
 
@@ -949,7 +949,7 @@ SpiProtocolFlashReadJedecId (
   UINT32            Address;
 
   if (SpiIsSafModeActive ()) {
-    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __func__));
     return EFI_UNSUPPORTED;
   }
 
@@ -1003,7 +1003,7 @@ SpiProtocolFlashWriteStatus (
   EFI_STATUS        Status;
 
   if (SpiIsSafModeActive ()) {
-    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __func__));
     return EFI_UNSUPPORTED;
   }
 
@@ -1044,7 +1044,7 @@ SpiProtocolFlashReadStatus (
   EFI_STATUS        Status;
 
   if (SpiIsSafModeActive ()) {
-    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "Unallowed call to %a while SAF Mode is active.\n", __func__));
     return EFI_UNSUPPORTED;
   }
 

--- a/Silicon/Intel/TigerlakeSiliconPkg/Pch/Library/PeiDxeSmmPchCycleDecodingLib/PchCycleDecodingLib.c
+++ b/Silicon/Intel/TigerlakeSiliconPkg/Pch/Library/PeiDxeSmmPchCycleDecodingLib/PchCycleDecodingLib.c
@@ -147,7 +147,7 @@ LpcEspiMemRangeSetHelper (
   UINT32                                MemRangeAddr;
 
   if (((Address & (~B_LPC_CFG_LGMR_MA)) != 0) || (SlaveId >= SlaveId_Max)) {
-    DEBUG ((DEBUG_ERROR, "%a Error. Invalid Address: %x or invalid SlaveId\n", __FUNCTION__, Address));
+    DEBUG ((DEBUG_ERROR, "%a Error. Invalid Address: %x or invalid SlaveId\n", __func__, Address));
     ASSERT (FALSE);
     return EFI_INVALID_PARAMETER;
   }
@@ -266,7 +266,7 @@ LpcEspiMemRangeGetHelper (
   UINT32                                GenMemReg;
 
   if ((Address == NULL) || (SlaveId >= SlaveId_Max)) {
-    DEBUG ((DEBUG_ERROR, "%a Error. Invalid pointer or SlaveId.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a Error. Invalid pointer or SlaveId.\n", __func__));
     ASSERT (FALSE);
     return EFI_INVALID_PARAMETER;
   }

--- a/Silicon/Intel/WhitleySiliconPkg/SiliconPolicyInit/SiliconPolicyInitPreAndPostMem.c
+++ b/Silicon/Intel/WhitleySiliconPkg/SiliconPolicyInit/SiliconPolicyInitPreAndPostMem.c
@@ -54,7 +54,7 @@ SiliconPolicyInitPreAndPostMemPeimEntry (
   //
   Status = PeiServicesInstallPpi (&mSiliconPolicyInitLibPpiDescriptor);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EntryPoint: failed to register PPI!\n"));
+    DEBUG ((DEBUG_ERROR, "EntryPoint: failed to register PPI!\n"));
     ASSERT_EFI_ERROR (Status);
     return Status;
   }

--- a/Silicon/Marvell/Armada7k8k/Feature/Capsule/PlatformFlashAccessLib/PlatformFlashAccessLib.c
+++ b/Silicon/Marvell/Armada7k8k/Feature/Capsule/PlatformFlashAccessLib/PlatformFlashAccessLib.c
@@ -63,7 +63,7 @@ SpiFlashProbe (
 
   Status = SpiFlashProtocol->Init (SpiFlashProtocol, SpiFlash);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot initialize flash device\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot initialize flash device\n", __func__));
     return Status;
   }
 
@@ -87,7 +87,7 @@ CheckImageHeader (
   if (Header->Magic != MAIN_HDR_MAGIC) {
     DEBUG ((DEBUG_ERROR,
       "%a: Bad Image magic 0x%08x != 0x%08x\n",
-      __FUNCTION__,
+      __func__,
       Header->Magic,
       MAIN_HDR_MAGIC));
     return EFI_VOLUME_CORRUPTED;
@@ -100,7 +100,7 @@ CheckImageHeader (
   if (Checksum != ChecksumBackup) {
     DEBUG ((DEBUG_ERROR,
       "%a: Bad Image checksum. 0x%x != 0x%x\n",
-      __FUNCTION__,
+      __func__,
       Checksum,
       ChecksumBackup));
     return EFI_VOLUME_CORRUPTED;
@@ -164,7 +164,7 @@ PerformFlashWriteWithProgress (
   if (FlashAddressType != FlashAddressTypeAbsoluteAddress) {
     DEBUG ((DEBUG_ERROR,
       "%a: only FlashAddressTypeAbsoluteAddress supported\n",
-      __FUNCTION__));
+      __func__));
 
     return EFI_INVALID_PARAMETER;
   }
@@ -172,7 +172,7 @@ PerformFlashWriteWithProgress (
   if (FirmwareType != PlatformFirmwareTypeSystemFirmware) {
     DEBUG ((DEBUG_ERROR,
       "%a: only PlatformFirmwareTypeSystemFirmware supported\n",
-      __FUNCTION__));
+      __func__));
 
     return EFI_INVALID_PARAMETER;
   }
@@ -184,7 +184,7 @@ PerformFlashWriteWithProgress (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Cannot locate SpiFlash protocol\n",
-      __FUNCTION__));
+      __func__));
     return Status;
   }
 
@@ -194,7 +194,7 @@ PerformFlashWriteWithProgress (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Cannot locate SpiMaster protocol\n",
-      __FUNCTION__));
+      __func__));
     return Status;
   }
 
@@ -226,7 +226,7 @@ PerformFlashWriteWithProgress (
                                   PcdGet32 (PcdSpiFlashCs),
                                   PcdGet32 (PcdSpiFlashMode));
   if (SpiFlash == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate SPI device!\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate SPI device!\n", __func__));
     Status = EFI_DEVICE_ERROR;
     goto HeaderError;
   }
@@ -235,7 +235,7 @@ PerformFlashWriteWithProgress (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Error while performing SPI flash probe\n",
-      __FUNCTION__));
+      __func__));
     goto FlashProbeError;
   }
 
@@ -257,13 +257,13 @@ PerformFlashWriteWithProgress (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Error while performing flash update\n",
-      __FUNCTION__));
+      __func__));
     goto FlashProbeError;
   }
 
   DEBUG ((DEBUG_ERROR,
     "%a: Update %d bytes at offset 0x%x succeeded!\n",
-    __FUNCTION__,
+    __func__,
     Length,
     FlashAddress));
 

--- a/Silicon/Marvell/Armada7k8k/Library/Armada7k8kPciHostBridgeLib/PciHostBridgeLib.c
+++ b/Silicon/Marvell/Armada7k8k/Library/Armada7k8kPciHostBridgeLib/PciHostBridgeLib.c
@@ -91,7 +91,7 @@ PciHostBridgeGetRootBridges (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Cannot locate BoardDesc protocol\n",
-      __FUNCTION__));
+      __func__));
     return NULL;
   }
 
@@ -104,7 +104,7 @@ PciHostBridgeGetRootBridges (
   } else if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Cannot get Pcie board desc from BoardDesc protocol\n",
-      __FUNCTION__));
+      __func__));
     return NULL;
   }
 
@@ -112,7 +112,7 @@ PciHostBridgeGetRootBridges (
   PciRootBridges = AllocateZeroPool (BoardPcieDescription->PcieControllerCount *
                                      sizeof (PCI_ROOT_BRIDGE));
   if (PciRootBridges == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Fail to allocate resources\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Fail to allocate resources\n", __func__));
     return NULL;
   }
 

--- a/Silicon/Marvell/Armada7k8k/Library/Armada7k8kPciHostBridgeLib/PciHostBridgeLibConstructor.c
+++ b/Silicon/Marvell/Armada7k8k/Library/Armada7k8kPciHostBridgeLib/PciHostBridgeLibConstructor.c
@@ -91,12 +91,12 @@ WaitForLink (
   UINT32 Timeout;
 
   if (!(MmioRead32 (PcieDbiAddress + PCIE_PM_STATUS) & PCIE_PM_LTSSM_STAT_MASK)) {
-    DEBUG ((DEBUG_INIT, "%a: no PCIE device detected\n", __FUNCTION__));
+    DEBUG ((DEBUG_INIT, "%a: no PCIE device detected\n", __func__));
     return;
   }
 
   /* Wait for the link to establish itself. */
-  DEBUG ((DEBUG_INIT, "%a: waiting for PCIE link\n", __FUNCTION__));
+  DEBUG ((DEBUG_INIT, "%a: waiting for PCIE link\n", __func__));
 
   Mask = PCIE_GLOBAL_STATUS_RDLH_LINK_UP | PCIE_GLOBAL_STATUS_PHY_LINK_UP;
   Timeout = PCIE_LINK_UP_TIMEOUT_US / 10;
@@ -134,7 +134,7 @@ ResetPcieSlot (
   /* Get GPIO protocol. */
   Status = MvGpioGetProtocol (PcieResetGpio->ControllerType, &GpioProtocol);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Unable to find GPIO protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Unable to find GPIO protocol\n", __func__));
     return Status;
   }
 
@@ -197,7 +197,7 @@ Armada7k8kPciHostBridgeLibConstructor (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Cannot locate BoardDesc protocol\n",
-      __FUNCTION__));
+      __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -210,7 +210,7 @@ Armada7k8kPciHostBridgeLibConstructor (
   } else if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Cannot get Pcie board desc from BoardDesc protocol\n",
-      __FUNCTION__));
+      __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -226,7 +226,7 @@ Armada7k8kPciHostBridgeLibConstructor (
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR,
           "%a: Cannot reset Pcie Slot\n",
-          __FUNCTION__));
+          __func__));
         return EFI_DEVICE_ERROR;
       }
     }

--- a/Silicon/Marvell/Armada7k8k/Library/Armada7k8kSoCDescLib/Armada7k8kSoCDescLib.c
+++ b/Silicon/Marvell/Armada7k8k/Library/Armada7k8kSoCDescLib/Armada7k8kSoCDescLib.c
@@ -47,7 +47,7 @@ ArmadaSoCAp8xxBaseGet (
   )
 {
   if (ApIndex != ARMADA7K8K_AP806_INDEX) {
-    DEBUG ((DEBUG_ERROR, "%a: Only one AP806 in A7K/A8K SoC\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Only one AP806 in A7K/A8K SoC\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -70,7 +70,7 @@ ArmadaSoCDescComPhyGet (
 
   Desc = AllocateZeroPool (CpCount * sizeof (MV_SOC_COMPHY_DESC));
   if (Desc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -115,7 +115,7 @@ ArmadaSoCGpioGet (
   *Count = CpCount * MV_SOC_GPIO_PER_CP_COUNT + MV_SOC_AP806_COUNT;
   GpioInstance = AllocateZeroPool (*Count * sizeof (GPIO_CONTROLLER));
   if (GpioInstance == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -154,7 +154,7 @@ ArmadaSoCDescI2cGet (
   *DescCount = CpCount * MV_SOC_I2C_PER_CP_COUNT + MV_SOC_I2C_PER_AP_COUNT;
   Desc = AllocateZeroPool (*DescCount * sizeof (MV_SOC_I2C_DESC));
   if (Desc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -205,7 +205,7 @@ ArmadaSoCDescIcuGet (
   *IcuDesc = AllocateCopyPool (sizeof (mA7k8kIcuDescTemplate),
                &mA7k8kIcuDescTemplate);
   if (*IcuDesc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -226,7 +226,7 @@ ArmadaSoCDescMdioGet (
 
   Desc = AllocateZeroPool (CpCount * sizeof (MV_SOC_MDIO_DESC));
   if (Desc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -255,7 +255,7 @@ ArmadaSoCDescAhciGet (
 
   Desc = AllocateZeroPool (CpCount * sizeof (MV_SOC_AHCI_DESC));
   if (Desc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -300,7 +300,7 @@ ArmadaSoCPcieGet (
   *Count = CpCount * MV_SOC_PCIE_PER_CP_COUNT;
   BaseAddress = AllocateZeroPool (*Count * sizeof (EFI_PHYSICAL_ADDRESS));
   if (BaseAddress == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -330,7 +330,7 @@ ArmadaSoCDescPp2Get (
 
   Desc = AllocateZeroPool (CpCount * sizeof (MV_SOC_PP2_DESC));
   if (Desc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -360,7 +360,7 @@ ArmadaSoCDescSdMmcGet (
   *Count = CpCount * MV_SOC_SDMMC_PER_CP_COUNT + MV_SOC_AP806_COUNT;
   SdMmc = AllocateZeroPool (*Count * sizeof (MV_SOC_SDMMC_DESC));
   if (SdMmc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -398,7 +398,7 @@ ArmadaSoCDescUtmiGet (
   *DescCount = CpCount * MV_SOC_UTMI_PER_CP_COUNT;
   Desc = AllocateZeroPool (*DescCount * sizeof (MV_SOC_UTMI_DESC));
   if (Desc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -435,7 +435,7 @@ ArmadaSoCDescXhciGet (
   *DescCount = CpCount * MV_SOC_XHCI_PER_CP_COUNT;
   Desc = AllocateZeroPool (*DescCount * sizeof (MV_SOC_XHCI_DESC));
   if (Desc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 

--- a/Silicon/Marvell/Drivers/BoardDesc/MvBoardDescDxe.c
+++ b/Silicon/Marvell/Drivers/BoardDesc/MvBoardDescDxe.c
@@ -45,21 +45,21 @@ MvBoardDescComPhyGet (
 
   /* Check if PCD with ComPhy is correctly defined */
   if (ComPhyDeviceTableSize > ComPhyCount) {
-    DEBUG ((DEBUG_ERROR, "%a: Wrong PcdComPhyDevices format\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Wrong PcdComPhyDevices format\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
   /* Allocate and fill board description */
   BoardDesc = AllocateZeroPool (ComPhyDeviceTableSize * sizeof (MV_BOARD_COMPHY_DESC));
   if (BoardDesc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
   ComPhyIndex = 0;
   for (Index = 0; Index < ComPhyDeviceTableSize; Index++) {
     if (!ComPhyDeviceEnabled[Index]) {
-      DEBUG ((DEBUG_ERROR, "%a: Skip ComPhy controller %d\n", __FUNCTION__, Index));
+      DEBUG ((DEBUG_ERROR, "%a: Skip ComPhy controller %d\n", __func__, Index));
       continue;
     }
 
@@ -107,7 +107,7 @@ MvBoardGpioDescriptionGet (
   /* Allocate and fill board description. */
   mGpioDescription = AllocateZeroPool (sizeof (MV_BOARD_GPIO_DESCRIPTION));
   if (mGpioDescription == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -157,21 +157,21 @@ MvBoardDescI2cGet (
   if (I2cDeviceEnabledSize > I2cCount) {
     DEBUG ((DEBUG_ERROR,
       "%a: Wrong PcdI2cControllersEnabled format\n",
-      __FUNCTION__));
+      __func__));
     return EFI_INVALID_PARAMETER;
   }
 
   /* Allocate and fill board description */
   BoardDesc = AllocateZeroPool (I2cDeviceEnabledSize * sizeof (MV_BOARD_I2C_DESC));
   if (BoardDesc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
   I2cIndex = 0;
   for (Index = 0; Index < I2cDeviceEnabledSize; Index++) {
     if (!I2cDeviceEnabled[Index]) {
-      DEBUG ((DEBUG_INFO, "%a: Skip I2c controller %d\n", __FUNCTION__, Index));
+      DEBUG ((DEBUG_INFO, "%a: Skip I2c controller %d\n", __func__, Index));
       continue;
     }
 
@@ -207,7 +207,7 @@ MvBoardDescMdioGet (
   /* Allocate and fill board description */
   BoardDesc = AllocateZeroPool (MdioCount * sizeof (MV_BOARD_MDIO_DESC));
   if (BoardDesc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -255,21 +255,21 @@ MvBoardDescAhciGet (
 
   /* Check if PCD with AHCI controllers is correctly defined */
   if (AhciDeviceTableSize > AhciCount) {
-    DEBUG ((DEBUG_ERROR, "%a: Wrong PcdPciEAhci format\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Wrong PcdPciEAhci format\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
   /* Allocate and fill board description */
   BoardDesc = AllocateZeroPool (AhciDeviceTableSize * sizeof (MV_BOARD_AHCI_DESC));
   if (BoardDesc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
   AhciIndex = 0;
   for (Index = 0; Index < AhciDeviceTableSize; Index++) {
     if (!AhciDeviceEnabled[Index]) {
-      DEBUG ((DEBUG_INFO, "%a: Skip Ahci controller %d\n", __FUNCTION__, Index));
+      DEBUG ((DEBUG_INFO, "%a: Skip Ahci controller %d\n", __func__, Index));
       continue;
     }
 
@@ -307,7 +307,7 @@ MvBoardDescSdMmcGet (
   /* Get per-board configuration of the controllers */
   Status = ArmadaBoardDescSdMmcGet (&SdMmcDevCount, &BoardDesc);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: ArmadaBoardDescSdMmcGet filed\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: ArmadaBoardDescSdMmcGet filed\n", __func__));
     return Status;
   }
 
@@ -327,21 +327,21 @@ MvBoardDescSdMmcGet (
   /* Check if PCD with SDMMC controllers is correctly defined */
   if ((SdMmcDeviceTableSize > SdMmcCount) ||
       (SdMmcDeviceTableSize < SdMmcDevCount)) {
-    DEBUG ((DEBUG_ERROR, "%a: Wrong PcdPciESdhci format\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Wrong PcdPciESdhci format\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
   SdMmcIndex = 0;
   for (Index = 0; Index < SdMmcDeviceTableSize; Index++) {
     if (!SdMmcDeviceEnabled[Index]) {
-      DEBUG ((DEBUG_INFO, "%a: Skip SdMmc controller %d\n", __FUNCTION__, Index));
+      DEBUG ((DEBUG_INFO, "%a: Skip SdMmc controller %d\n", __func__, Index));
       continue;
     }
 
     if (SdMmcIndex >= SdMmcDevCount) {
       DEBUG ((DEBUG_ERROR,
         "%a: More enabled devices than returned by ArmadaBoardDescSdMmcGet\n",
-        __FUNCTION__));
+        __func__));
       return EFI_INVALID_PARAMETER;
     }
     BoardDesc[SdMmcIndex].SoC = &SoCDesc[Index];
@@ -389,21 +389,21 @@ MvBoardDescXhciGet (
 
   /* Check if PCD with XHCI controllers is correctly defined */
   if (XhciDeviceTableSize > XhciCount) {
-    DEBUG ((DEBUG_ERROR, "%a: Wrong PcdPciEXhci format\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Wrong PcdPciEXhci format\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
   /* Allocate and fill board description */
   BoardDesc = AllocateZeroPool (XhciDeviceTableSize * sizeof (MV_BOARD_XHCI_DESC));
   if (BoardDesc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
   XhciIndex = 0;
   for (Index = 0; Index < XhciDeviceTableSize; Index++) {
     if (!XhciDeviceEnabled[Index]) {
-      DEBUG ((DEBUG_INFO, "%a: Skip Xhci controller %d\n", __FUNCTION__, Index));
+      DEBUG ((DEBUG_INFO, "%a: Skip Xhci controller %d\n", __func__, Index));
       continue;
     }
 
@@ -465,7 +465,7 @@ MvBoardPcieDescriptionGet (
 
   /* Sanity check of the board description. */
   if (BoardPcieControllerCount > SoCPcieControllerCount) {
-    DEBUG ((DEBUG_ERROR, "%a: Too many controllers described\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Too many controllers described\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -480,7 +480,7 @@ MvBoardPcieDescriptionGet (
     if (SoCIndex == SoCPcieControllerCount) {
       DEBUG ((DEBUG_ERROR,
         "%a: Controller #%d base address invalid: 0x%x\n",
-        __FUNCTION__,
+        __func__,
         BoardIndex,
         PcieControllers[BoardIndex].PcieDbiAddress));
       return EFI_INVALID_PARAMETER;
@@ -490,7 +490,7 @@ MvBoardPcieDescriptionGet (
   /* Allocate and fill board description. */
   mPcieDescription = AllocateZeroPool (sizeof (MV_BOARD_PCIE_DESCRIPTION));
   if (mPcieDescription == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -536,14 +536,14 @@ MvBoardDescPp2Get (
 
   /* Check if PCD with PP2 NICs is correctly defined */
   if (Pp2DeviceTableSize > Pp2Count) {
-    DEBUG ((DEBUG_ERROR, "%a: Wrong PcdPp2Controllers format\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Wrong PcdPp2Controllers format\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
   /* Allocate and fill board description */
   BoardDesc = AllocateZeroPool (Pp2DeviceTableSize * sizeof (MV_BOARD_PP2_DESC));
   if (BoardDesc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -597,7 +597,7 @@ MvBoardDescUtmiGet (
   /* Make sure XHCI controllers table is present */
   XhciDeviceEnabled = PcdGetPtr (PcdPciEXhci);
   if (XhciDeviceEnabled == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Missing PcdPciEXhci\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Missing PcdPciEXhci\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -608,7 +608,7 @@ MvBoardDescUtmiGet (
       (UtmiDeviceTableSize > PcdGetSize (PcdPciEXhci))) {
     DEBUG ((DEBUG_ERROR,
       "%a: Wrong PcdUtmiControllersEnabled format\n",
-      __FUNCTION__));
+      __func__));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -616,14 +616,14 @@ MvBoardDescUtmiGet (
   UtmiPortType = PcdGetPtr (PcdUtmiPortType);
   if ((UtmiPortType == NULL) ||
       (PcdGetSize (PcdUtmiPortType) != UtmiDeviceTableSize)) {
-    DEBUG ((DEBUG_ERROR, "%a: Wrong PcdUtmiPortType format\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Wrong PcdUtmiPortType format\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
   /* Allocate and fill board description */
   BoardDesc = AllocateZeroPool (UtmiDeviceTableSize * sizeof (MV_BOARD_UTMI_DESC));
   if (BoardDesc == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -638,7 +638,7 @@ MvBoardDescUtmiGet (
       DEBUG ((DEBUG_ERROR,
              "%a: Disabled Xhci controller %d\n",
              Index,
-             __FUNCTION__));
+             __func__));
       return EFI_INVALID_PARAMETER;
     }
 

--- a/Silicon/Marvell/Drivers/Gpio/MvGpioDxe/MvGpioDxe.c
+++ b/Silicon/Marvell/Drivers/Gpio/MvGpioDxe/MvGpioDxe.c
@@ -63,7 +63,7 @@ MvGpioValidate (
   if (ControllerIndex >= mGpioInstance->GpioDeviceCount) {
     DEBUG ((DEBUG_ERROR,
       "%a: Invalid GPIO ControllerIndex: %d\n",
-      __FUNCTION__,
+      __func__,
       ControllerIndex));
     return EFI_INVALID_PARAMETER;
   }
@@ -71,7 +71,7 @@ MvGpioValidate (
   if (GpioPin >= mGpioInstance->SoCGpio[ControllerIndex].InternalGpioCount) {
     DEBUG ((DEBUG_ERROR,
       "%a: GPIO pin #%d not available in Controller#%d\n",
-      __FUNCTION__,
+      __func__,
       GpioPin,
       ControllerIndex));
     return EFI_INVALID_PARAMETER;
@@ -306,7 +306,7 @@ MvGpioEntryPoint (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Cannot locate BoardDesc protocol\n",
-      __FUNCTION__));
+      __func__));
     goto ErrLocateBoardDesc;
   }
 
@@ -315,7 +315,7 @@ MvGpioEntryPoint (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Cannot get GPIO board desc from BoardDesc protocol\n",
-      __FUNCTION__));
+      __func__));
     goto ErrLocateBoardDesc;
   }
 

--- a/Silicon/Marvell/Drivers/Gpio/MvPca95xxDxe/MvPca95xxDxe.c
+++ b/Silicon/Marvell/Drivers/Gpio/MvPca95xxDxe/MvPca95xxDxe.c
@@ -83,7 +83,7 @@ MvPca95xxValidate (
   if (ControllerIndex >= mPca95xxInstance->GpioExpanderCount) {
     DEBUG ((DEBUG_ERROR,
       "%a: Invalid GPIO ControllerIndex: %d\n",
-      __FUNCTION__,
+      __func__,
       ControllerIndex));
     return EFI_INVALID_PARAMETER;
   }
@@ -93,7 +93,7 @@ MvPca95xxValidate (
   if (GpioPin >= mPca95xxPinCount[ControllerId]) {
     DEBUG ((DEBUG_ERROR,
       "%a: GPIO pin #%d not available in Controller#%d\n",
-      __FUNCTION__,
+      __func__,
       GpioPin,
       ControllerIndex));
     return EFI_INVALID_PARAMETER;
@@ -125,7 +125,7 @@ MvPca95xxGetI2c (
                   &HandleCount,
                   &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Unable to locate handles\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Unable to locate handles\n", __func__));
     return Status;
   }
 
@@ -138,7 +138,7 @@ MvPca95xxGetI2c (
                     NULL,
                     EFI_OPEN_PROTOCOL_GET_PROTOCOL);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Unable to open protocol\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Unable to open protocol\n", __func__));
       gBS->FreePool (HandleBuffer);
       return Status;
     }
@@ -187,7 +187,7 @@ MvPca95xxI2cTransfer (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: transmission error: 0x%d\n",
-      __FUNCTION__,
+      __func__,
       Status));
   }
 
@@ -233,7 +233,7 @@ MvPca95xxSetOutputValue (
 
   Status = MvPca95xxGetI2c (ControllerIndex, &I2cIo);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: fail to get I2C protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: fail to get I2C protocol\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -241,7 +241,7 @@ MvPca95xxSetOutputValue (
 
   Status = MvPca95xxReadRegs (I2cIo, PCA95XX_OUTPUT_REG + Bank, &RegVal);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: fail to read device register\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: fail to read device register\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -253,7 +253,7 @@ MvPca95xxSetOutputValue (
 
   Status = MvPca95xxWriteRegs (I2cIo, PCA95XX_OUTPUT_REG + Bank, RegVal);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: fail to write device register\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: fail to write device register\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -275,7 +275,7 @@ MvPca95xxSetDirection (
 
   Status = MvPca95xxGetI2c (ControllerIndex, &I2cIo);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: fail to get I2C protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: fail to get I2C protocol\n", __func__));
     return Status;
   }
 
@@ -283,7 +283,7 @@ MvPca95xxSetDirection (
 
   Status = MvPca95xxReadRegs (I2cIo, PCA95XX_DIRECTION_REG + Bank, &RegVal);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: fail to read device register\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: fail to read device register\n", __func__));
     return Status;
   }
 
@@ -295,7 +295,7 @@ MvPca95xxSetDirection (
 
   Status = MvPca95xxWriteRegs (I2cIo, PCA95XX_DIRECTION_REG + Bank, RegVal);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: fail to write device register\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: fail to write device register\n", __func__));
     return Status;
   }
 
@@ -319,7 +319,7 @@ MvPca95xxReadMode (
 
   Status = MvPca95xxGetI2c (ControllerIndex, &I2cIo);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: fail to get I2C protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: fail to get I2C protocol\n", __func__));
     return Status;
   }
 
@@ -327,7 +327,7 @@ MvPca95xxReadMode (
 
   Status = MvPca95xxReadRegs (I2cIo, PCA95XX_DIRECTION_REG + Bank, &RegVal);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: fail to read device register\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: fail to read device register\n", __func__));
     return Status;
   }
 
@@ -336,7 +336,7 @@ MvPca95xxReadMode (
   } else {
     Status = MvPca95xxReadRegs (I2cIo, PCA95XX_INPUT_REG + Bank, &RegVal);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: fail to read device register\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: fail to read device register\n", __func__));
       return Status;
     }
 
@@ -389,7 +389,7 @@ MvPca95xxGetMode (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: fail to get pin %d of controller#%d mode\n",
-      __FUNCTION__,
+      __func__,
       GpioPin,
       ControllerIndex));
   }
@@ -436,7 +436,7 @@ MvPca95xxGet (
 
   Status = MvPca95xxGetI2c (ControllerIndex, &I2cIo);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: fail to get I2C protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: fail to get I2C protocol\n", __func__));
     return Status;
   }
 
@@ -444,7 +444,7 @@ MvPca95xxGet (
 
   Status = MvPca95xxReadRegs (I2cIo, PCA95XX_INPUT_REG + Bank, &RegVal);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: fail to read device register\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: fail to read device register\n", __func__));
     return Status;
   }
 
@@ -497,7 +497,7 @@ MvPca95xxSet (
   case GPIO_MODE_OUTPUT_1:
     Status = MvPca95xxSetOutputValue (ControllerIndex, GpioPin, Mode);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: fail to set ouput value\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: fail to set ouput value\n", __func__));
       return Status;
     }
 
@@ -505,7 +505,7 @@ MvPca95xxSet (
   case GPIO_MODE_INPUT:
     Status = MvPca95xxSetDirection (ControllerIndex, GpioPin, Mode);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: fail to set direction\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: fail to set direction\n", __func__));
       return Status;
     }
     break;
@@ -576,7 +576,7 @@ MvPca95xxEntryPoint (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Cannot locate BoardDesc protocol\n",
-      __FUNCTION__));
+      __func__));
     return Status;
   }
 
@@ -585,7 +585,7 @@ MvPca95xxEntryPoint (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Cannot get GPIO board desc from BoardDesc protocol\n",
-      __FUNCTION__));
+      __func__));
     return Status;
   } else if (GpioDescription->GpioExpanders == NULL) {
     /* Silently exit, if the board does not support the controllers */
@@ -597,7 +597,7 @@ MvPca95xxEntryPoint (
   if (Pca95xxDevicePath == NULL) {
     DEBUG ((DEBUG_ERROR,
       "%a: Fail to allocate Pca95xxDevicePath\n",
-      __FUNCTION__));
+      __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -605,7 +605,7 @@ MvPca95xxEntryPoint (
   if (mPca95xxInstance == NULL) {
     DEBUG ((DEBUG_ERROR,
       "%a: Fail to allocate mPca95xxInstance\n",
-      __FUNCTION__));
+      __func__));
     Status = EFI_OUT_OF_RESOURCES;
     goto ErrPca95xxInstanceAlloc;
   }

--- a/Silicon/Marvell/Drivers/I2c/MvI2cDxe/MvI2cDxe.c
+++ b/Silicon/Marvell/Drivers/I2c/MvI2cDxe/MvI2cDxe.c
@@ -174,7 +174,7 @@ OnEndOfDxe (
     Status = gBS->ConnectController (DeviceHandle, NULL, NULL, TRUE);
     DEBUG ((DEBUG_INFO,
       "%a: ConnectController () returned %r\n",
-      __FUNCTION__,
+      __func__,
       Status));
 
     DevicePath->Instance++;

--- a/Silicon/Marvell/Drivers/Net/MvPhyDxe/MvPhyDxe.c
+++ b/Silicon/Marvell/Drivers/Net/MvPhyDxe/MvPhyDxe.c
@@ -245,12 +245,12 @@ MvPhyConfigureAutonegotiation (
 
     DEBUG ((DEBUG_INFO,
       "%a: Waiting for PHY auto negotiation...",
-      __FUNCTION__));
+      __func__));
 
     /* Wait for autonegotiation to complete and read media status */
     for (Index = 0; !(Data & BMSR_ANEGCOMPLETE); Index++) {
       if (Index > PHY_AUTONEGOTIATE_TIMEOUT) {
-        DEBUG ((DEBUG_ERROR, "%a: Timeout\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: Timeout\n", __func__));
         PhyDevice->LinkUp = FALSE;
         return EFI_TIMEOUT;
       }
@@ -259,16 +259,16 @@ MvPhyConfigureAutonegotiation (
     }
 
     PhyDevice->LinkUp = TRUE;
-    DEBUG ((DEBUG_INFO, "%a: link up\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: link up\n", __func__));
   } else {
     Mdio->Read (Mdio, PhyDevice->Addr, PhyDevice->MdioIndex, MII_BMSR, &Data);
 
     if (Data & BMSR_LSTATUS) {
       PhyDevice->LinkUp = TRUE;
-      DEBUG ((DEBUG_INFO, "%a: link up\n", __FUNCTION__));
+      DEBUG ((DEBUG_INFO, "%a: link up\n", __func__));
     } else {
       PhyDevice->LinkUp = FALSE;
-      DEBUG ((DEBUG_INFO, "%a: link down\n", __FUNCTION__));
+      DEBUG ((DEBUG_INFO, "%a: link down\n", __func__));
     }
   }
 
@@ -420,7 +420,7 @@ MvPhyInit (
   if (PhyId >= MV_PHY_DEVICE_ID_MAX) {
     DEBUG ((DEBUG_ERROR,
       "%a, Incorrect PHY ID (0x%x) for PHY#%d\n",
-      __FUNCTION__,
+      __func__,
       PhyId,
       PhyIndex));
     return EFI_INVALID_PARAMETER;

--- a/Silicon/Marvell/Drivers/Net/Pp2Dxe/Pp2Dxe.c
+++ b/Silicon/Marvell/Drivers/Net/Pp2Dxe/Pp2Dxe.c
@@ -1438,7 +1438,7 @@ Pp2AipGetInformation (
     AdapterInfo->MediaState = EFI_NOT_READY;
     return EFI_SUCCESS;
   } else if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a Failed to get media status\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a Failed to get media status\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 

--- a/Silicon/Marvell/Drivers/SdMmc/XenonDxe/XenonSdMmcOverride.c
+++ b/Silicon/Marvell/Drivers/SdMmc/XenonDxe/XenonSdMmcOverride.c
@@ -378,7 +378,7 @@ InitializeXenonDxe (
 
   mSdMmcOverride = AllocateZeroPool (sizeof (EDKII_SD_MMC_OVERRIDE));
   if (mSdMmcOverride == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -393,7 +393,7 @@ InitializeXenonDxe (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Filed to install SdMmcOverride protocol\n",
-      __FUNCTION__));
+      __func__));
     return Status;
   }
 

--- a/Silicon/Marvell/Drivers/Spi/MvFvbDxe/MvFvbDxe.c
+++ b/Silicon/Marvell/Drivers/Spi/MvFvbDxe/MvFvbDxe.c
@@ -236,7 +236,7 @@ MvFvbValidateFvHeader (
       (FwVolHeader->FvLength  != FlashInstance->FvbSize)) {
     DEBUG ((DEBUG_ERROR,
       "%a: No Firmware Volume header present\n",
-      __FUNCTION__));
+      __func__));
     return EFI_NOT_FOUND;
   }
 
@@ -244,7 +244,7 @@ MvFvbValidateFvHeader (
   if (!CompareGuid (&FwVolHeader->FileSystemGuid, &gEfiSystemNvDataFvGuid)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Firmware Volume Guid non-compatible\n",
-      __FUNCTION__));
+      __func__));
     return EFI_NOT_FOUND;
   }
 
@@ -253,7 +253,7 @@ MvFvbValidateFvHeader (
   if (Checksum != 0) {
     DEBUG ((DEBUG_ERROR,
       "%a: FV checksum is invalid (Checksum:0x%x)\n",
-      __FUNCTION__,
+      __func__,
       Checksum));
     return EFI_NOT_FOUND;
   }
@@ -266,7 +266,7 @@ MvFvbValidateFvHeader (
                     &gEfiAuthenticatedVariableGuid)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Variable Store Guid non-compatible\n",
-      __FUNCTION__));
+      __func__));
     return EFI_NOT_FOUND;
   }
 
@@ -275,7 +275,7 @@ MvFvbValidateFvHeader (
   if (VariableStoreHeader->Size != VariableStoreLength) {
     DEBUG ((DEBUG_ERROR,
       "%a: Variable Store Length does not match\n",
-      __FUNCTION__));
+      __func__));
     return EFI_NOT_FOUND;
   }
 
@@ -519,7 +519,7 @@ MvFvbGetBlockSize (
   if (Lba > FlashInstance->Media.LastBlock) {
     DEBUG ((DEBUG_ERROR,
       "%a: Error: Requested LBA %ld is beyond the last available LBA (%ld).\n",
-      __FUNCTION__,
+      __func__,
       Lba,
       FlashInstance->Media.LastBlock));
     return EFI_INVALID_PARAMETER;
@@ -606,7 +606,7 @@ MvFvbRead (
       (Offset + *NumBytes) >  BlockSize) {
     DEBUG ((DEBUG_ERROR,
       "%a: Wrong buffer size: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n",
-      __FUNCTION__,
+      __func__,
       Offset,
       *NumBytes,
       BlockSize));
@@ -713,7 +713,7 @@ MvFvbWrite (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Failed to write to Spi device\n",
-      __FUNCTION__));
+      __func__));
     return Status;
   }
 
@@ -799,7 +799,7 @@ MvFvbEraseBlocks (
   if ((FlashFvbAttributes & EFI_FVB2_WRITE_STATUS) == 0) {
     DEBUG ((DEBUG_ERROR,
       "%a: Device is in WriteDisabled state.\n",
-      __FUNCTION__));
+      __func__));
     return EFI_ACCESS_DENIED;
   }
 
@@ -828,7 +828,7 @@ MvFvbEraseBlocks (
 
       DEBUG ((DEBUG_ERROR,
         "%a: Error: Requested LBA are beyond the last available LBA (%ld).\n",
-        __FUNCTION__,
+        __func__,
         FlashInstance->Media.LastBlock));
 
       VA_END (Args);
@@ -933,7 +933,7 @@ MvFvbFlashProbe (
 
   Status = SpiFlashProtocol->Init (SpiFlashProtocol, &FlashInstance->SpiDevice);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot initialize flash device\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot initialize flash device\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -967,10 +967,10 @@ MvFvbPrepareFvHeader (
   // Install the default FVB header if required
   if (EFI_ERROR (Status)) {
     // There is no valid header, so time to install one.
-    DEBUG ((DEBUG_ERROR, "%a: The FVB Header is not valid.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: The FVB Header is not valid.\n", __func__));
     DEBUG ((DEBUG_ERROR,
       "%a: Installing a correct one for this volume.\n",
-      __FUNCTION__));
+      __func__));
 
     // Erase entire region that is reserved for variable storage
     Status = FlashInstance->SpiFlashProtocol->Erase (&FlashInstance->SpiDevice,
@@ -1006,7 +1006,7 @@ MvFvbConfigureFlashInstance (
                   NULL,
                   (VOID **)&FlashInstance->SpiFlashProtocol);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot locate SpiFlash protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot locate SpiFlash protocol\n", __func__));
     return Status;
   }
 
@@ -1014,7 +1014,7 @@ MvFvbConfigureFlashInstance (
                   NULL,
                   (VOID **)&FlashInstance->SpiMasterProtocol);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot locate SpiMaster protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot locate SpiMaster protocol\n", __func__));
     return Status;
   }
 
@@ -1028,7 +1028,7 @@ MvFvbConfigureFlashInstance (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Error while performing SPI flash probe\n",
-      __FUNCTION__));
+      __func__));
     return Status;
   }
 
@@ -1132,7 +1132,7 @@ MvFvbEntryPoint (
   mFvbDevice = AllocateRuntimeCopyPool (sizeof (mMvFvbFlashInstanceTemplate),
                  &mMvFvbFlashInstanceTemplate);
   if (mFvbDevice == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -1141,7 +1141,7 @@ MvFvbEntryPoint (
   //
   Status = MvFvbConfigureFlashInstance (mFvbDevice);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Fail to configure Fvb SPI device\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Fail to configure Fvb SPI device\n", __func__));
     goto ErrorConfigureFlash;
   }
 
@@ -1156,7 +1156,7 @@ MvFvbEntryPoint (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Failed to install gEdkiiNvVarStoreFormattedGuid\n",
-      __FUNCTION__));
+      __func__));
     goto ErrorInstallNvVarStoreFormatted;
   }
 
@@ -1172,7 +1172,7 @@ MvFvbEntryPoint (
                     RuntimeMmioRegionSize,
                     EFI_MEMORY_UC | EFI_MEMORY_RUNTIME);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to add memory space\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to add memory space\n", __func__));
       goto ErrorAddSpace;
     }
 
@@ -1181,7 +1181,7 @@ MvFvbEntryPoint (
                     RuntimeMmioRegionSize,
                     EFI_MEMORY_UC | EFI_MEMORY_RUNTIME);
     if (EFI_ERROR (Status)) {
-     DEBUG ((DEBUG_ERROR, "%a: Failed to set memory attributes\n", __FUNCTION__));
+     DEBUG ((DEBUG_ERROR, "%a: Failed to set memory attributes\n", __func__));
       goto ErrorSetMemAttr;
     }
   }
@@ -1196,7 +1196,7 @@ MvFvbEntryPoint (
                   &gEfiEventVirtualAddressChangeGuid,
                   &mFvbVirtualAddrChangeEvent);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to register VA change event\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to register VA change event\n", __func__));
     goto ErrorSetMemAttr;
   }
 

--- a/Silicon/Marvell/Drivers/Spi/MvSpiFlashDxe/MvSpiFlashDxe.c
+++ b/Silicon/Marvell/Drivers/Spi/MvSpiFlashDxe/MvSpiFlashDxe.c
@@ -396,7 +396,7 @@ MvSpiFlashUpdateWithProgress (
 
   TmpBuf = (UINT8 *)AllocateZeroPool (SectorSize);
   if (TmpBuf == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -418,7 +418,7 @@ MvSpiFlashUpdateWithProgress (
                TmpBuf,
                SectorSize);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Error while updating\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Error while updating\n", __func__));
       return Status;
     }
   }
@@ -459,7 +459,7 @@ MvSpiFlashReadId (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Unrecognized JEDEC Id bytes: 0x%02x%02x%02x\n",
-      __FUNCTION__,
+      __func__,
       Id[0],
       Id[1],
       Id[2]));
@@ -617,7 +617,7 @@ MvSpiFlashEntryPoint (
                   &gEfiEventVirtualAddressChangeGuid,
                   &mMvSpiFlashVirtualAddrChangeEvent);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to register VA change event\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to register VA change event\n", __func__));
     goto ErrorCreateEvent;
   }
 

--- a/Silicon/Marvell/Drivers/Spi/MvSpiOrionDxe/MvSpiOrionDxe.c
+++ b/Silicon/Marvell/Drivers/Spi/MvSpiOrionDxe/MvSpiOrionDxe.c
@@ -220,7 +220,7 @@ MvSpiTransfer (
     }
 
     if (Iterator >= SPI_TIMEOUT) {
-      DEBUG ((DEBUG_ERROR, "%a: Timeout\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Timeout\n", __func__));
       return EFI_TIMEOUT;
     }
   }
@@ -337,7 +337,7 @@ MvSpiConfigRuntime (
                   SIZE_4KB,
                   EFI_MEMORY_UC | EFI_MEMORY_RUNTIME);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to add memory space\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to add memory space\n", __func__));
     return Status;
   }
 
@@ -345,7 +345,7 @@ MvSpiConfigRuntime (
                   SIZE_4KB,
                   EFI_MEMORY_UC | EFI_MEMORY_RUNTIME);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to set memory attributes\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to set memory attributes\n", __func__));
     gDS->RemoveMemorySpace (AlignedAddress, SIZE_4KB);
     return Status;
   }

--- a/Silicon/Marvell/Library/ComPhyLib/ComPhyLib.c
+++ b/Silicon/Marvell/Library/ComPhyLib/ComPhyLib.c
@@ -187,7 +187,7 @@ MvComPhyInit (
   ChipConfig = AllocateZeroPool (ComPhyBoardDesc->ComPhyDevCount *
                                  sizeof (CHIP_COMPHY_CONFIG));
   if (ChipConfig == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     BoardDescProtocol->BoardDescFree (ComPhyBoardDesc);
     return EFI_OUT_OF_RESOURCES;
   }
@@ -195,7 +195,7 @@ MvComPhyInit (
   LaneData = AllocateZeroPool (ComPhyBoardDesc->ComPhyDevCount *
                                sizeof (PCD_LANE_MAP));
   if (ChipConfig == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Cannot allocate memory\n", __func__));
     BoardDescProtocol->BoardDescFree (ComPhyBoardDesc);
     FreePool (ChipConfig);
     return EFI_OUT_OF_RESOURCES;

--- a/Silicon/Marvell/Library/ComPhyLib/ComPhyLib.c
+++ b/Silicon/Marvell/Library/ComPhyLib/ComPhyLib.c
@@ -120,7 +120,7 @@ GetChipComPhyInit (
     }
   }
 
-  return EFI_D_ERROR;
+  return DEBUG_ERROR;
 }
 
 STATIC

--- a/Silicon/Marvell/Library/MvGpioLib/MvGpioLib.c
+++ b/Silicon/Marvell/Library/MvGpioLib/MvGpioLib.c
@@ -79,7 +79,7 @@ MvGpioGetProtocol (
                   &HandleCount,
                   &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Unable to locate handles\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Unable to locate handles\n", __func__));
     return Status;
   }
 
@@ -93,7 +93,7 @@ MvGpioGetProtocol (
                     NULL,
                     EFI_OPEN_PROTOCOL_GET_PROTOCOL);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Unable to find DevicePath\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Unable to find DevicePath\n", __func__));
       continue;
     }
 
@@ -111,7 +111,7 @@ MvGpioGetProtocol (
     } else if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR,
         "%a: Unable to open GPIO protocol\n",
-        __FUNCTION__));
+        __func__));
     }
 
     gBS->FreePool (HandleBuffer);

--- a/Silicon/Marvell/Library/UtmiPhyLib/UtmiPhyLib.c
+++ b/Silicon/Marvell/Library/UtmiPhyLib/UtmiPhyLib.c
@@ -199,16 +199,16 @@ UtmiPhyPowerUp (
   Data = MmioRead32 (UtmiPllAddr + UTMI_CALIB_CTRL_REG);
   if ((Data & UTMI_CALIB_CTRL_IMPCAL_DONE_MASK) == 0) {
     DEBUG((DEBUG_ERROR, "UtmiPhy: Impedance calibration is not done\n"));
-    Status = EFI_D_ERROR;
+    Status = DEBUG_ERROR;
   }
   if ((Data & UTMI_CALIB_CTRL_PLLCAL_DONE_MASK) == 0) {
     DEBUG((DEBUG_ERROR, "UtmiPhy: PLL calibration is not done\n"));
-    Status = EFI_D_ERROR;
+    Status = DEBUG_ERROR;
   }
   Data = MmioRead32 (UtmiPllAddr + UTMI_PLL_CTRL_REG);
   if ((Data & UTMI_PLL_CTRL_PLL_RDY_MASK) == 0) {
     DEBUG((DEBUG_ERROR, "UtmiPhy: PLL is not ready\n"));
-    Status = EFI_D_ERROR;
+    Status = DEBUG_ERROR;
   }
 
   return Status;

--- a/Silicon/Maxim/Library/Ds1307RtcLib/Ds1307RtcLib.c
+++ b/Silicon/Maxim/Library/Ds1307RtcLib/Ds1307RtcLib.c
@@ -289,7 +289,7 @@ I2cDriverRegistrationEvent (
     if (EFI_ERROR (Status)) {
       if (Status != EFI_NOT_FOUND) {
         DEBUG ((DEBUG_WARN, "%a: gBS->LocateHandle () returned %r\n",
-          __FUNCTION__, Status));
+          __func__, Status));
       }
       break;
     }
@@ -298,7 +298,7 @@ I2cDriverRegistrationEvent (
       continue;
     }
 
-    DEBUG ((DEBUG_INFO, "%a: found I2C master!\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: found I2C master!\n", __func__));
 
     gBS->CloseEvent (Event);
 
@@ -310,7 +310,7 @@ I2cDriverRegistrationEvent (
     Status = I2cMaster->Reset (I2cMaster);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: I2CMaster->Reset () failed - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
       break;
     }
 
@@ -318,7 +318,7 @@ I2cDriverRegistrationEvent (
     Status = I2cMaster->SetBusFrequency (I2cMaster, &BusFrequency);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: I2CMaster->SetBusFrequency () failed - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
       break;
     }
 

--- a/Silicon/NXP/LS1043A/Library/SocLib/SerDes.c
+++ b/Silicon/NXP/LS1043A/Library/SocLib/SerDes.c
@@ -113,7 +113,7 @@ GetSerDesProtocolMap (
              );
 
   if (Status != EFI_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "%a: failed for SerDes1 \n",__FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed for SerDes1 \n",__func__));
     *SerDesProtocolMap = 0;
   }
 }

--- a/Silicon/NXP/LS1046A/Library/SocLib/SerDes.c
+++ b/Silicon/NXP/LS1046A/Library/SocLib/SerDes.c
@@ -113,7 +113,7 @@ GetSerDesProtocolMap (
              );
 
   if (Status != EFI_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "%a: failed for SerDes1 \n",__FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed for SerDes1 \n",__func__));
     *SerDesProtocolMap = 0;
   }
 }

--- a/Silicon/NXP/LX2160A/Library/SocLib/SerDes.c
+++ b/Silicon/NXP/LX2160A/Library/SocLib/SerDes.c
@@ -175,7 +175,7 @@ GetSerDesProtocolMap (
              );
 
   if (Status != EFI_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "%a: failed for SerDes1 \n",__FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed for SerDes1 \n",__func__));
     *SerDesProtocolMap = 0;
   }
 
@@ -190,7 +190,7 @@ GetSerDesProtocolMap (
              );
 
   if (Status != EFI_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "%a: failed for SerDes2 \n",__FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed for SerDes2 \n",__func__));
     *SerDesProtocolMap = 0;
   }
 
@@ -205,7 +205,7 @@ GetSerDesProtocolMap (
              );
 
   if (Status != EFI_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "%a: failed for SerDes3 \n",__FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: failed for SerDes3 \n",__func__));
     *SerDesProtocolMap = 0;
   }
 }

--- a/Silicon/NXP/Library/Pcf8563RealTimeClockLib/Pcf8563RealTimeClockLib.c
+++ b/Silicon/NXP/Library/Pcf8563RealTimeClockLib/Pcf8563RealTimeClockLib.c
@@ -293,7 +293,7 @@ I2cMasterRegistrationEvent (
     if (EFI_ERROR (Status)) {
       if (Status != EFI_NOT_FOUND) {
         DEBUG ((DEBUG_WARN, "%a: gBS->LocateHandle () returned %r\n",
-          __FUNCTION__, Status));
+          __func__, Status));
       }
       break;
     }
@@ -302,7 +302,7 @@ I2cMasterRegistrationEvent (
       continue;
     }
 
-    DEBUG ((DEBUG_INFO, "%a: found I2C master!\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: found I2C master!\n", __func__));
 
     gBS->CloseEvent (Event);
 
@@ -314,7 +314,7 @@ I2cMasterRegistrationEvent (
     Status = I2cMaster->Reset (I2cMaster);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: I2CMaster->Reset () failed - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
       break;
     }
 
@@ -322,7 +322,7 @@ I2cMasterRegistrationEvent (
     Status = I2cMaster->SetBusFrequency (I2cMaster, &BusFrequency);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: I2CMaster->SetBusFrequency () failed - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
       break;
     }
 

--- a/Silicon/NXP/Library/SerDesHelperLib/SerDesHelperLib.c
+++ b/Silicon/NXP/Library/SerDesHelperLib/SerDesHelperLib.c
@@ -147,7 +147,7 @@ GetSerDesMap (
   Status = IsSerDesProtocolValid (SerDes, SerDesProtocol, SerDesNumLanes, Config);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: SERDES%d[PRTCL] = 0x%x is not valid, Status = %r \n",
-            __FUNCTION__, SerDes + 1, SerDesProtocol, Status));
+            __func__, SerDes + 1, SerDesProtocol, Status));
     return Status;
   }
 

--- a/Silicon/Qemu/SbsaQemu/Drivers/SbsaQemuPlatformDxe/SbsaQemuPlatformDxe.c
+++ b/Silicon/Qemu/SbsaQemu/Drivers/SbsaQemuPlatformDxe/SbsaQemuPlatformDxe.c
@@ -29,7 +29,7 @@ InitializeSbsaQemuPlatformDxe (
   GicInfo          GicInfo;
   PlatformVersion  PlatVer;
 
-  DEBUG ((DEBUG_INFO, "%a: InitializeSbsaQemuPlatformDxe called\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: InitializeSbsaQemuPlatformDxe called\n", __func__));
 
   Base = (VOID *)(UINTN)PcdGet64 (PcdPlatformAhciBase);
   ASSERT (Base != NULL);
@@ -39,7 +39,7 @@ InitializeSbsaQemuPlatformDxe (
   DEBUG ((
     DEBUG_INFO,
     "%a: Got platform AHCI %llx %u\n",
-    __FUNCTION__,
+    __func__,
     Base,
     Size
     ));
@@ -58,7 +58,7 @@ InitializeSbsaQemuPlatformDxe (
     DEBUG ((
       DEBUG_ERROR,
       "%a: NonDiscoverable: Cannot install AHCI device @%p (Staus == %r)\n",
-      __FUNCTION__,
+      __func__,
       Base,
       Status
       ));
@@ -87,7 +87,7 @@ InitializeSbsaQemuPlatformDxe (
     DEBUG ((
       DEBUG_INFO,
       "%a: Got platform XHCI %llx %u\n",
-      __FUNCTION__,
+      __func__,
       Base,
       Size
       ));
@@ -106,7 +106,7 @@ InitializeSbsaQemuPlatformDxe (
       DEBUG ((
         DEBUG_ERROR,
         "%a: NonDiscoverable: Cannot install XHCI device @%p (Status == %r)\n",
-        __FUNCTION__,
+        __func__,
         Base,
         Status
         ));

--- a/Silicon/Qemu/SbsaQemu/Drivers/SbsaQemuSmbiosDxe/SbsaQemuSmbiosDxe.c
+++ b/Silicon/Qemu/SbsaQemu/Drivers/SbsaQemuSmbiosDxe/SbsaQemuSmbiosDxe.c
@@ -292,7 +292,7 @@ MemDevInfoUpdateSmbiosType17 (
   // PhyMemArrayInfoUpdateSmbiosType16 must be called before MemDevInfoUpdateSmbiosType17
   //
   if (mPhyMemArrayInfoType16Handle == SMBIOS_HANDLE_PI_RESERVED) {
-    DEBUG ((DEBUG_ERROR, "%a: mPhyMemArrayInfoType16Handle is not initialized\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: mPhyMemArrayInfoType16Handle is not initialized\n", __func__));
     return;
   }
 
@@ -345,7 +345,7 @@ MemArrMapInfoUpdateSmbiosType19 (
   // PhyMemArrayInfoUpdateSmbiosType16 must be called before MemDevInfoUpdateSmbiosType17
   //
   if (mPhyMemArrayInfoType16Handle == SMBIOS_HANDLE_PI_RESERVED) {
-    DEBUG ((DEBUG_ERROR, "%a: mPhyMemArrayInfoType16Handle is not initialized\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: mPhyMemArrayInfoType16Handle is not initialized\n", __func__));
     return;
   }
 

--- a/Silicon/Qemu/SbsaQemu/Library/SbsaQemuHardwareInfoLib/SbsaQemuHardwareInfoLib.c
+++ b/Silicon/Qemu/SbsaQemu/Library/SbsaQemuHardwareInfoLib/SbsaQemuHardwareInfoLib.c
@@ -29,11 +29,11 @@ GetCpuCount (
   ArmMonitorCall (&SmcArgs);
 
   if (SmcArgs.Arg0 != SMC_SIP_CALL_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "%a: SIP_SVC_GET_CPU_COUNT call failed. We have no cpu information.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: SIP_SVC_GET_CPU_COUNT call failed. We have no cpu information.\n", __func__));
     ResetShutdown ();
   }
 
-  DEBUG ((DEBUG_INFO, "%a: We have %d cpus.\n", __FUNCTION__, SmcArgs.Arg1));
+  DEBUG ((DEBUG_INFO, "%a: We have %d cpus.\n", __func__, SmcArgs.Arg1));
 
   return SmcArgs.Arg1;
 }
@@ -57,11 +57,11 @@ GetMpidr (
   ArmMonitorCall (&SmcArgs);
 
   if (SmcArgs.Arg0 != SMC_SIP_CALL_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "%a: SIP_SVC_GET_CPU_NODE call failed. We have no MPIDR for CPU%d.\n", __FUNCTION__, CpuId));
+    DEBUG ((DEBUG_ERROR, "%a: SIP_SVC_GET_CPU_NODE call failed. We have no MPIDR for CPU%d.\n", __func__, CpuId));
     ResetShutdown ();
   }
 
-  DEBUG ((DEBUG_INFO, "%a: MPIDR for CPU%d: = %d\n", __FUNCTION__, CpuId, SmcArgs.Arg2));
+  DEBUG ((DEBUG_INFO, "%a: MPIDR for CPU%d: = %d\n", __func__, CpuId, SmcArgs.Arg2));
 
   return SmcArgs.Arg2;
 }
@@ -85,11 +85,11 @@ GetCpuNumaNode (
   ArmMonitorCall (&SmcArgs);
 
   if (SmcArgs.Arg0 != SMC_SIP_CALL_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "%a: SIP_SVC_GET_CPU_NODE call failed. Could not find information for CPU%d.\n", __FUNCTION__, CpuId));
+    DEBUG ((DEBUG_ERROR, "%a: SIP_SVC_GET_CPU_NODE call failed. Could not find information for CPU%d.\n", __func__, CpuId));
     return 0;
   }
 
-  DEBUG ((DEBUG_INFO, "%a: NUMA node for CPU%d: = %d\n", __FUNCTION__, CpuId, SmcArgs.Arg1));
+  DEBUG ((DEBUG_INFO, "%a: NUMA node for CPU%d: = %d\n", __func__, CpuId, SmcArgs.Arg1));
 
   return SmcArgs.Arg1;
 }
@@ -105,11 +105,11 @@ GetMemNodeCount (
   ArmMonitorCall (&SmcArgs);
 
   if (SmcArgs.Arg0 != SMC_SIP_CALL_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "%a: SIP_SVC_GET_MEMORY_NODE_COUNT call failed. We have no memory information.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: SIP_SVC_GET_MEMORY_NODE_COUNT call failed. We have no memory information.\n", __func__));
     ResetShutdown ();
   }
 
-  DEBUG ((DEBUG_INFO, "%a: The number of the memory nodes is %ld\n", __FUNCTION__, SmcArgs.Arg1));
+  DEBUG ((DEBUG_INFO, "%a: The number of the memory nodes is %ld\n", __func__, SmcArgs.Arg1));
   return (UINT32)SmcArgs.Arg1;
 }
 
@@ -126,7 +126,7 @@ GetMemInfo (
   ArmMonitorCall (&SmcArgs);
 
   if (SmcArgs.Arg0 != SMC_SIP_CALL_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "%a: SIP_SVC_GET_MEMORY_NODE call failed. We have no memory information.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: SIP_SVC_GET_MEMORY_NODE call failed. We have no memory information.\n", __func__));
     ResetShutdown ();
   } else {
     MemInfo->NodeId      = SmcArgs.Arg1;
@@ -137,7 +137,7 @@ GetMemInfo (
   DEBUG ((
     DEBUG_INFO,
     "%a: NUMA node for System RAM:%d = 0x%lx - 0x%lx\n",
-    __FUNCTION__,
+    __func__,
     MemInfo->NodeId,
     MemInfo->AddressBase,
     MemInfo->AddressBase + MemInfo->AddressSize -1
@@ -194,7 +194,7 @@ GetCpuTopology (
   ArmMonitorCall (&SmcArgs);
 
   if (SmcArgs.Arg0 != SMC_SIP_CALL_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "%a: SIP_SVC_GET_CPU_TOPOLOGY call failed. We have no cpu topology information.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: SIP_SVC_GET_CPU_TOPOLOGY call failed. We have no cpu topology information.\n", __func__));
     ResetShutdown ();
   } else {
     CpuTopo->Sockets  = SmcArgs.Arg1;
@@ -206,7 +206,7 @@ GetCpuTopology (
   DEBUG ((
     DEBUG_INFO,
     "%a: CPU Topology: sockets: %d, clusters: %d, cores: %d, threads: %d\n",
-    __FUNCTION__,
+    __func__,
     CpuTopo->Sockets,
     CpuTopo->Clusters,
     CpuTopo->Cores,

--- a/Silicon/Qemu/SbsaQemu/Library/SbsaQemuLib/SbsaQemuMem.c
+++ b/Silicon/Qemu/SbsaQemu/Library/SbsaQemuLib/SbsaQemuMem.c
@@ -81,7 +81,7 @@ ArmPlatformGetVirtualMemoryMap (
                          );
 
   if (VirtualMemoryTable == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Error: Failed AllocatePool()\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Error: Failed AllocatePool()\n", __func__));
     return;
   }
 
@@ -97,7 +97,7 @@ ArmPlatformGetVirtualMemoryMap (
     "\tPhysicalBase: 0x%lX\n"
     "\tVirtualBase: 0x%lX\n"
     "\tLength: 0x%lX\n",
-    __FUNCTION__,
+    __func__,
     VirtualMemoryTable[0].PhysicalBase,
     VirtualMemoryTable[0].VirtualBase,
     VirtualMemoryTable[0].Length

--- a/Silicon/RISC-V/ProcessorPkg/Library/RiscVExceptionLib/CpuExceptionHandlerLib.c
+++ b/Silicon/RISC-V/ProcessorPkg/Library/RiscVExceptionLib/CpuExceptionHandlerLib.c
@@ -74,7 +74,7 @@ RegisterCpuInterruptHandler (
   IN EFI_CPU_INTERRUPT_HANDLER  InterruptHandler
   )
 {
-  DEBUG ((DEBUG_INFO, "%a: Type:%x Handler: %x\n", __FUNCTION__, InterruptType, InterruptHandler));
+  DEBUG ((DEBUG_INFO, "%a: Type:%x Handler: %x\n", __func__, InterruptType, InterruptHandler));
   mInterruptHandlers[InterruptType] = InterruptHandler;
   return EFI_SUCCESS;
 }

--- a/Silicon/RISC-V/ProcessorPkg/Universal/FdtDxe/FdtDxe.c
+++ b/Silicon/RISC-V/ProcessorPkg/Universal/FdtDxe/FdtDxe.c
@@ -49,7 +49,7 @@ FixDtb (
     DEBUG ((
       DEBUG_ERROR,
       "Device Tree can't be expanded to accommodate new node\n",
-      __FUNCTION__
+      __func__
       ));
     return EFI_OUT_OF_RESOURCES;
   }
@@ -83,7 +83,7 @@ InstallFdtFromHob (
     DEBUG ((
       DEBUG_ERROR,
       "Failed to find RISC-V DTB Hob\n",
-      __FUNCTION__
+      __func__
       ));
     return EFI_NOT_FOUND;
   }
@@ -101,7 +101,7 @@ InstallFdtFromHob (
     DEBUG ((
       DEBUG_ERROR,
       "%a: failed to install FDT configuration table\n",
-      __FUNCTION__
+      __func__
       ));
   }
 

--- a/Silicon/RISC-V/ProcessorPkg/Universal/SmbiosDxe/RiscVSmbiosDxe.c
+++ b/Silicon/RISC-V/ProcessorPkg/Universal/SmbiosDxe/RiscVSmbiosDxe.c
@@ -46,7 +46,7 @@ BuildSmbiosType7 (
   Type7DataHob->EndingZero                  = 0;
   Status                                    = mSmbios->Add (mSmbios, NULL, &Handle, &Type7DataHob->SmbiosType7Cache.Hdr);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Fail to add SMBIOS Type 7\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Fail to add SMBIOS Type 7\n", __func__));
     return Status;
   }
 
@@ -306,7 +306,7 @@ RiscVSmbiosBuilderEntry (
   RISC_V_PROCESSOR_TYPE4_HOB_DATA  *Type4HobData;
   SMBIOS_HANDLE                    Processor;
 
-  DEBUG ((DEBUG_INFO, "%a: entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: entry\n", __func__));
 
   Status = gBS->LocateProtocol (
                   &gEfiSmbiosProtocolGuid,
@@ -345,6 +345,6 @@ RiscVSmbiosBuilderEntry (
     GuidHob = GetNextGuidHob ((EFI_GUID *)PcdGetPtr (PcdProcessorSmbiosType4GuidHobGuid), GET_NEXT_HOB (GuidHob));
   } while (GuidHob != NULL);
 
-  DEBUG ((DEBUG_INFO, "%a: exit\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: exit\n", __func__));
   return Status;
 }

--- a/Silicon/SiFive/U54/Library/PeiCoreInfoHobLib/CoreInfoHob.c
+++ b/Silicon/SiFive/U54/Library/PeiCoreInfoHobLib/CoreInfoHob.c
@@ -57,7 +57,7 @@ CreateU54E51CoreProcessorSpecificDataHob (
   EFI_RISCV_OPENSBI_FIRMWARE_CONTEXT *FirmwareContext;
   EFI_RISCV_FIRMWARE_CONTEXT_HART_SPECIFIC *FirmwareContextHartSpecific;
 
-  DEBUG ((DEBUG_INFO, "%a: Entry.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Entry.\n", __func__));
 
   if (GuidHobData == NULL) {
     return EFI_INVALID_PARAMETER;

--- a/Silicon/Socionext/SynQuacer/Drivers/Fip006Dxe/NorFlashDxe.c
+++ b/Silicon/Socionext/SynQuacer/Drivers/Fip006Dxe/NorFlashDxe.c
@@ -85,9 +85,9 @@ NorFlashFvbInitialize (
   // Install the Default FVB header if required
   if (EFI_ERROR(Status)) {
     // There is no valid header, so time to install one.
-    DEBUG ((DEBUG_INFO, "%a: The FVB Header is not valid.\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: The FVB Header is not valid.\n", __func__));
     DEBUG ((DEBUG_INFO, "%a: Installing a correct one for this volume.\n",
-      __FUNCTION__));
+      __func__));
 
     // Erase all the NorFlash that is reserved for variable storage
     FvbNumLba = (PcdGet32(PcdFlashNvStorageVariableSize) +
@@ -119,7 +119,7 @@ NorFlashFvbInitialize (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: Failed to install gEdkiiNvVarStoreFormattedGuid\n",
-      __FUNCTION__));
+      __func__));
       return Status;
   }
 

--- a/Silicon/Socionext/SynQuacer/Drivers/Fip006Dxe/NorFlashFvb.c
+++ b/Silicon/Socionext/SynQuacer/Drivers/Fip006Dxe/NorFlashFvb.c
@@ -145,14 +145,14 @@ ValidateFvHeader (
       )
   {
     DEBUG ((DEBUG_INFO, "%a: No Firmware Volume header present\n",
-      __FUNCTION__));
+      __func__));
     return EFI_NOT_FOUND;
   }
 
   // Check the Firmware Volume Guid
   if (!CompareGuid (&FwVolHeader->FileSystemGuid, &gEfiSystemNvDataFvGuid)) {
     DEBUG ((DEBUG_INFO, "%a: Firmware Volume Guid non-compatible\n",
-      __FUNCTION__));
+      __func__));
     return EFI_NOT_FOUND;
   }
 
@@ -160,7 +160,7 @@ ValidateFvHeader (
   Checksum = CalculateSum16((UINT16*)FwVolHeader, FwVolHeader->HeaderLength);
   if (Checksum != 0) {
     DEBUG ((DEBUG_INFO, "%a: FV checksum is invalid (Checksum:0x%X)\n",
-      __FUNCTION__, Checksum));
+      __func__, Checksum));
     return EFI_NOT_FOUND;
   }
 
@@ -172,7 +172,7 @@ ValidateFvHeader (
       !CompareGuid (&VariableStoreHeader->Signature,
         &gEfiAuthenticatedVariableGuid)) {
     DEBUG ((DEBUG_INFO, "%a: Variable Store Guid non-compatible\n",
-      __FUNCTION__));
+      __func__));
     return EFI_NOT_FOUND;
   }
 
@@ -180,7 +180,7 @@ ValidateFvHeader (
                         FwVolHeader->HeaderLength;
   if (VariableStoreHeader->Size != VariableStoreLength) {
     DEBUG ((DEBUG_INFO, "%a: Variable Store Length does not match\n",
-      __FUNCTION__));
+      __func__));
     return EFI_NOT_FOUND;
   }
 

--- a/Silicon/Socionext/SynQuacer/Drivers/Fip006Dxe/NorFlashSmm.c
+++ b/Silicon/Socionext/SynQuacer/Drivers/Fip006Dxe/NorFlashSmm.c
@@ -69,9 +69,9 @@ NorFlashFvbInitialize (
   Status = ValidateFvHeader (Instance);
   if (EFI_ERROR (Status)) {
     // There is no valid header, so time to install one.
-    DEBUG ((DEBUG_INFO, "%a: The FVB Header is not valid.\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: The FVB Header is not valid.\n", __func__));
     DEBUG ((DEBUG_INFO, "%a: Installing a correct one for this volume.\n",
-      __FUNCTION__));
+      __func__));
 
     // Erase all the NorFlash that is reserved for variable storage
     FvbNumLba = (PcdGet32(PcdFlashNvStorageVariableSize) +

--- a/Silicon/Socionext/SynQuacer/Drivers/Net/NetsecDxe/NetsecDxe.c
+++ b/Silicon/Socionext/SynQuacer/Drivers/Net/NetsecDxe/NetsecDxe.c
@@ -1069,7 +1069,7 @@ NetsecInit (
   Status = Probe (DriverBindingHandle, LanDriver);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
-      "NETSEC:%a(): Probe failed with status %d\n", __FUNCTION__, Status));
+      "NETSEC:%a(): Probe failed with status %d\n", __func__, Status));
     goto CloseDeviceProtocol;
   }
 
@@ -1149,7 +1149,7 @@ NetsecInit (
   // Say what the status of loading the protocol structure is
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: InstallMultipleProtocolInterfaces failed - %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     ogma_terminate (LanDriver->Handle);
     goto CloseDeviceProtocol;
   }

--- a/Silicon/Socionext/SynQuacer/Drivers/PlatformDxe/Pci.c
+++ b/Silicon/Socionext/SynQuacer/Drivers/PlatformDxe/Pci.c
@@ -90,7 +90,7 @@ RetrainAsm1184eDownstreamPort (
 
   DEBUG ((DEBUG_INFO,
     "%a: retraining ASM118x downstream PCIe port at %04x:%02x:%02x to Gen2\n",
-    __FUNCTION__, SegmentNumber, BusNumber, DeviceNumber));
+    __func__, SegmentNumber, BusNumber, DeviceNumber));
 
   Status = PciIo->Pci.Read (PciIo, EfiPciIoWidthUint16,
                         ASM118x_PCIE_LINK_CONTROL_OFFSET, 1, &LinkControl);
@@ -113,7 +113,7 @@ EnableAsm1061SpreadSpectrum (
   UINT8       SscVal;
 
   DEBUG ((DEBUG_INFO, "%a: enabling spread spectrum mode 0 for ASM1061\n",
-    __FUNCTION__));
+    __func__));
 
   // SSC mode 0~-4000 ppm, 1:1 modulation
 
@@ -161,7 +161,7 @@ OnPciIoProtocolNotify (
                           ARRAY_SIZE (PciVidPid), &PciVidPid);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_WARN, "%a: failed to read PCI vendor/product ID - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
       continue;
     }
 

--- a/Silicon/Socionext/SynQuacer/Drivers/PlatformDxe/PlatformDxe.c
+++ b/Silicon/Socionext/SynQuacer/Drivers/PlatformDxe/PlatformDxe.c
@@ -288,12 +288,12 @@ EnableSettingsForm (
                     EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS,
                     sizeof (Settings), &Settings);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_WARN, "%a: EfiSetVariable failed - %r\n", __FUNCTION__,
+      DEBUG ((DEBUG_WARN, "%a: EfiSetVariable failed - %r\n", __func__,
         Status));
       return Status;
     }
   } else if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_WARN, "%a: EfiGetVariable failed - %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_WARN, "%a: EfiGetVariable failed - %r\n", __func__,
       Status));
     return Status;
   }
@@ -324,7 +324,7 @@ InstallAcpiTables (
                           &TableKey);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_WARN, "%a: failed to install SSDT table for eMMC - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
     }
   }
 
@@ -333,7 +333,7 @@ InstallAcpiTables (
                           &TableKey);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_WARN, "%a: failed to install SSDT table for OP-TEE - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
     }
   }
 }
@@ -405,7 +405,7 @@ PlatformDxeEntryPoint (
     }
     if (EFI_ERROR (Status)) {
        DEBUG ((DEBUG_ERROR,
-        "%a: failed to install FDT configuration table - %r\n", __FUNCTION__,
+        "%a: failed to install FDT configuration table - %r\n", __func__,
         Status));
     }
   } else {
@@ -418,7 +418,7 @@ PlatformDxeEntryPoint (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR,
         "%a: failed to install gEdkiiPlatformHasAcpiGuid as a protocol\n",
-        __FUNCTION__));
+        __func__));
     }
   }
 

--- a/Silicon/Socionext/SynQuacer/Drivers/SynQuacerI2cDxe/SynQuacerI2cDxe.c
+++ b/Silicon/Socionext/SynQuacer/Drivers/SynQuacerI2cDxe/SynQuacerI2cDxe.c
@@ -161,27 +161,27 @@ SynQuacerI2cMasterStart (
     MmioWrite8 (I2c->MmioBase + F_I2C_REG_DAR, SlaveAddress << 1);
   }
 
-  DEBUG ((DEBUG_INFO, "%a: slave:0x%02x\n", __FUNCTION__,
+  DEBUG ((DEBUG_INFO, "%a: slave:0x%02x\n", __func__,
     SlaveAddress));
 
   Bsr = MmioRead8 (I2c->MmioBase + F_I2C_REG_BSR);
   Bcr = MmioRead8 (I2c->MmioBase + F_I2C_REG_BCR);
 
   if ((Bsr & F_I2C_BSR_BB) && !(Bcr & F_I2C_BCR_MSS)) {
-    DEBUG ((DEBUG_INFO, "%a: bus is busy\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: bus is busy\n", __func__));
     return EFI_ALREADY_STARTED;
   }
 
   if (Bsr & F_I2C_BSR_BB) { // Bus is busy
-    DEBUG ((DEBUG_INFO, "%a: Continuous Start\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Continuous Start\n", __func__));
     MmioWrite8 (I2c->MmioBase + F_I2C_REG_BCR, Bcr | F_I2C_BCR_SCC);
   } else {
     if (Bcr & F_I2C_BCR_MSS) {
       DEBUG ((DEBUG_WARN,
-        "%a: is not in master mode\n", __FUNCTION__));
+        "%a: is not in master mode\n", __func__));
       return EFI_DEVICE_ERROR;
     }
-    DEBUG ((DEBUG_INFO, "%a: Start Condition\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Start Condition\n", __func__));
     MmioWrite8 (I2c->MmioBase + F_I2C_REG_BCR,
                 Bcr | F_I2C_BCR_MSS | F_I2C_BCR_INTE | F_I2C_BCR_BEIE);
   }
@@ -323,12 +323,12 @@ SynQuacerI2cStartRequest (
     Status = WaitForInterrupt (I2c);
     if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_WARN, "%a: Timeout waiting for interrupt - %r\n",
-          __FUNCTION__, Status));
+          __func__, Status));
       break;
     }
 
     if (MmioRead8 (I2c->MmioBase + F_I2C_REG_BSR) & F_I2C_BSR_LRB) {
-      DEBUG ((DEBUG_WARN, "%a: No ack received\n", __FUNCTION__));
+      DEBUG ((DEBUG_WARN, "%a: No ack received\n", __func__));
       Status = EFI_DEVICE_ERROR;
       break;
     }
@@ -339,13 +339,13 @@ SynQuacerI2cStartRequest (
       Bcr = MmioRead8 (I2c->MmioBase + F_I2C_REG_BCR);
 
       if (Bcr & F_I2C_BCR_BER) {
-        DEBUG ((DEBUG_WARN, "%a: Bus error detected\n", __FUNCTION__));
+        DEBUG ((DEBUG_WARN, "%a: Bus error detected\n", __func__));
         Status = EFI_DEVICE_ERROR;
         break;
       }
 
       if ((Bsr & F_I2C_BSR_AL) || !(Bcr & F_I2C_BCR_MSS)) {
-        DEBUG ((DEBUG_WARN, "%a: Arbitration lost\n", __FUNCTION__));
+        DEBUG ((DEBUG_WARN, "%a: Arbitration lost\n", __func__));
         Status = EFI_DEVICE_ERROR;
         break;
       }
@@ -362,7 +362,7 @@ SynQuacerI2cStartRequest (
         Status = WaitForInterrupt (I2c);
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_WARN,
-            "%a: Timeout waiting for interrupt - %r\n", __FUNCTION__, Status));
+            "%a: Timeout waiting for interrupt - %r\n", __func__, Status));
           break;
         }
 
@@ -377,12 +377,12 @@ SynQuacerI2cStartRequest (
         Status = WaitForInterrupt (I2c);
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_WARN,
-            "%a: Timeout waiting for interrupt - %r\n", __FUNCTION__, Status));
+            "%a: Timeout waiting for interrupt - %r\n", __func__, Status));
           break;
         }
 
         if (MmioRead8 (I2c->MmioBase + F_I2C_REG_BSR) & F_I2C_BSR_LRB) {
-          DEBUG ((DEBUG_WARN, "%a: No ack received\n", __FUNCTION__));
+          DEBUG ((DEBUG_WARN, "%a: No ack received\n", __func__));
           Status = EFI_DEVICE_ERROR;
           break;
         }
@@ -480,7 +480,7 @@ SynQuacerI2cInit (
                     EFI_MEMORY_UC | EFI_MEMORY_RUNTIME);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_WARN, "%a: failed to add memory space - %r\n",
-        __FUNCTION__, Status));
+        __func__, Status));
     }
 
     Status = gDS->SetMemorySpaceAttributes (

--- a/Silicon/Socionext/SynQuacer/Library/SynQuacerDtbLoaderLib/SynQuacerDtbLoaderLib.c
+++ b/Silicon/Socionext/SynQuacer/Library/SynQuacerDtbLoaderLib/SynQuacerDtbLoaderLib.c
@@ -29,13 +29,13 @@ EnableDtNode (
   Node = fdt_path_offset (Dtb, NodePath);
   if (Node < 0) {
     DEBUG ((DEBUG_ERROR, "%a: failed to locate DT path '%a': %a\n",
-      __FUNCTION__, NodePath, fdt_strerror (Node)));
+      __func__, NodePath, fdt_strerror (Node)));
     return;
   }
   Rc = fdt_setprop_string (Dtb, Node, "status", "okay");
   if (Rc < 0) {
     DEBUG ((DEBUG_ERROR, "%a: failed to set status to 'disabled' on '%a': %a\n",
-      __FUNCTION__, NodePath, fdt_strerror (Rc)));
+      __func__, NodePath, fdt_strerror (Rc)));
   }
 }
 
@@ -81,7 +81,7 @@ DtPlatformLoadDtb (
 
   Rc = fdt_open_into (OrigDtb, CopyDtb, CopyDtbSize);
   if (Rc < 0) {
-    DEBUG ((DEBUG_ERROR, "%a: fdt_open_into () failed: %a\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: fdt_open_into () failed: %a\n", __func__,
       fdt_strerror (Rc)));
     return EFI_NOT_FOUND;
   }

--- a/Silicon/Socionext/SynQuacer/Library/SynQuacerMemoryInitPeiLib/SynQuacerMemoryInitPeiLib.c
+++ b/Silicon/Socionext/SynQuacer/Library/SynQuacerMemoryInitPeiLib/SynQuacerMemoryInitPeiLib.c
@@ -210,11 +210,11 @@ CheckCapsule (
                         CapsuleBufferLength);
     if (!EFI_ERROR (Status)) {
       DEBUG ((DEBUG_INFO, "%a: Coalesced capsule @ %p (0x%lx)\n",
-        __FUNCTION__, *CapsuleBuffer, *CapsuleBufferLength));
+        __func__, *CapsuleBuffer, *CapsuleBufferLength));
       return TRUE;
     } else {
       DEBUG ((DEBUG_WARN, "%a: failed to coalesce() capsule (Status == %r)\n",
-        __FUNCTION__, Status));
+        __func__, Status));
     }
   }
   return FALSE;
@@ -273,7 +273,7 @@ MemoryPeim (
 
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_WARN, "%a: Capsule->CreateState failed (Status == %r)\n",
-        __FUNCTION__, Status));
+        __func__, Status));
     }
   }
 

--- a/Silicon/Socionext/SynQuacer/Library/SynQuacerPlatformFlashAccessLib/SynQuacerPlatformFlashAccessLib.c
+++ b/Silicon/Socionext/SynQuacer/Library/SynQuacerPlatformFlashAccessLib/SynQuacerPlatformFlashAccessLib.c
@@ -97,7 +97,7 @@ GetFvbByAddress (
     if (EFI_ERROR (Status) || !(Attributes & EFI_FVB2_WRITE_STATUS)) {
       DEBUG ((DEBUG_INFO,
         "%a: ignoring read-only FVB protocol implementation\n",
-        __FUNCTION__));
+        __func__));
       Status = EFI_NOT_FOUND;
       continue;
     }
@@ -105,14 +105,14 @@ GetFvbByAddress (
     Status = Fvb->GetBlockSize (Fvb, 0, BlockSize, &NumberOfBlocks);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_INFO, "%a: failed to get FVB blocksize - %r, ignoring\n",
-        __FUNCTION__, Status));
+        __func__, Status));
       continue;
     }
 
     if ((Length % *BlockSize) != 0) {
       DEBUG ((DEBUG_INFO,
         "%a: Length 0x%lx is not a multiple of the blocksize 0x%lx, ignoring\n",
-        __FUNCTION__, Length, *BlockSize));
+        __func__, Length, *BlockSize));
       Status = EFI_INVALID_PARAMETER;
       continue;
     }
@@ -224,7 +224,7 @@ PerformFlashWriteWithProgress (
 
   if (FlashAddressType != FlashAddressTypeAbsoluteAddress) {
     DEBUG ((DEBUG_ERROR, "%a: only FlashAddressTypeAbsoluteAddress supported\n",
-      __FUNCTION__));
+      __func__));
 
     return EFI_INVALID_PARAMETER;
   }
@@ -232,7 +232,7 @@ PerformFlashWriteWithProgress (
   if (FirmwareType != PlatformFirmwareTypeSystemFirmware) {
     DEBUG ((DEBUG_ERROR,
       "%a: only PlatformFirmwareTypeSystemFirmware supported\n",
-      __FUNCTION__));
+      __func__));
 
     return EFI_INVALID_PARAMETER;
   }
@@ -246,7 +246,7 @@ PerformFlashWriteWithProgress (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,
       "%a: failed to locate FVB handle for address 0x%llx - %r\n",
-      __FUNCTION__, FlashAddress, Status));
+      __func__, FlashAddress, Status));
     return Status;
   }
 
@@ -257,13 +257,13 @@ PerformFlashWriteWithProgress (
                   FlashAddress, Length, EFI_MEMORY_UC);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_WARN, "%a: gDS->AddMemorySpace () failed - %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
   }
 
   Status = gDS->SetMemorySpaceAttributes (FlashAddress, Length, EFI_MEMORY_UC);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: gDS->SetMemorySpaceAttributes () failed - %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     return Status;
   }
 
@@ -281,13 +281,13 @@ PerformFlashWriteWithProgress (
   // Erase the region
   //
   DEBUG ((DEBUG_INFO, "%a: erasing 0x%llx bytes at address %llx (LBA 0x%lx)\n",
-    __FUNCTION__, Length, FlashAddress, Lba));
+    __func__, Length, FlashAddress, Lba));
 
   Status = Fvb->EraseBlocks (Fvb, Lba, Length / BlockSize,
                   EFI_LBA_LIST_TERMINATOR);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Fvb->EraseBlocks () failed - %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     return Status;
   }
 
@@ -296,7 +296,7 @@ PerformFlashWriteWithProgress (
     // Write the new data
     //
     DEBUG ((DEBUG_INFO, "%a: writing 0x%llx bytes at LBA 0x%lx\n",
-      __FUNCTION__, BlockSize, Lba));
+      __func__, BlockSize, Lba));
 
     NumBytes = BlockSize;
     if (BufferHasData (Buffer, NumBytes)) {
@@ -304,7 +304,7 @@ PerformFlashWriteWithProgress (
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR,
           "%a: write of LBA 0x%lx failed - %r (NumBytes == 0x%lx)\n",
-          __FUNCTION__, Lba, Status, NumBytes));
+          __func__, Lba, Status, NumBytes));
       }
     }
 

--- a/Silicon/Socionext/SynQuacer/Library/SynQuacerPlatformPeiLib/SynQuacerPlatformPeiLib.c
+++ b/Silicon/Socionext/SynQuacer/Library/SynQuacerPlatformPeiLib/SynQuacerPlatformPeiLib.c
@@ -114,14 +114,14 @@ ReadGpioInput (
   Status = Gpio->Set (Gpio, Pin, GPIO_MODE_INPUT);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_WARN, "%a: failed to set GPIO %d as input - %r\n",
-      __FUNCTION__, Pin, Status));
+      __func__, Pin, Status));
     return Status;
   }
 
   Status = Gpio->Get (Gpio, Pin, Value);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_WARN, "%a: failed to get GPIO %d state - %r\n",
-      __FUNCTION__, Pin, Status));
+      __func__, Pin, Status));
   }
   return Status;
 }
@@ -144,7 +144,7 @@ PlatformPeim (
 
   Status = ReadGpioInput (Gpio, FixedPcdGet8 (PcdClearSettingsGpioPin), &Value);
   if (!EFI_ERROR (Status) && Value == CLEAR_SETTINGS_GPIO_ASSERTED) {
-    DEBUG ((DEBUG_INFO, "%a: clearing NVRAM\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: clearing NVRAM\n", __func__));
     PeiServicesSetBootMode (BOOT_WITH_DEFAULT_SETTINGS);
   }
 
@@ -152,7 +152,7 @@ PlatformPeim (
              &Value);
   if (!EFI_ERROR (Status) && Value == PCIE_GPIO_CARD_PRESENT) {
     DEBUG ((DEBUG_INFO,
-      "%a: card detected in PCIe RC #0, enabling\n", __FUNCTION__));
+      "%a: card detected in PCIe RC #0, enabling\n", __func__));
     Status = PcdSet8S (PcdPcieEnableMask, PcdGet8 (PcdPcieEnableMask) | BIT0);
     ASSERT_EFI_ERROR (Status);
   }

--- a/Silicon/Synopsys/DesignWare/Drivers/DwEmacSnpDxe/DriverBinding.c
+++ b/Silicon/Synopsys/DesignWare/Drivers/DwEmacSnpDxe/DriverBinding.c
@@ -145,14 +145,14 @@ DriverStart (
     Status = DmaAllocateBuffer (EfiBootServicesData,
                EFI_SIZE_TO_PAGES (sizeof (DESIGNWARE_HW_DESCRIPTOR)), (VOID *)&Snp->MacDriver.TxdescRing[Index]);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a () for TxdescRing: %r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a () for TxdescRing: %r\n", __func__, Status));
       return Status;
     }
 
     Status = DmaMap (MapOperationBusMasterCommonBuffer, Snp->MacDriver.TxdescRing[Index],
                &DescriptorSize, &Snp->MacDriver.TxdescRingMap[Index].AddrMap, &Snp->MacDriver.TxdescRingMap[Index].Mapping);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a () for TxdescRing: %r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a () for TxdescRing: %r\n", __func__, Status));
       return Status;
     }
 
@@ -160,14 +160,14 @@ DriverStart (
     Status = DmaAllocateBuffer (EfiBootServicesData,
                EFI_SIZE_TO_PAGES (sizeof (DESIGNWARE_HW_DESCRIPTOR)), (VOID *)&Snp->MacDriver.RxdescRing[Index]);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a () for RxdescRing: %r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a () for RxdescRing: %r\n", __func__, Status));
       return Status;
     }
 
     Status = DmaMap (MapOperationBusMasterCommonBuffer, Snp->MacDriver.RxdescRing[Index],
                &DescriptorSize, &Snp->MacDriver.RxdescRingMap[Index].AddrMap, &Snp->MacDriver.RxdescRingMap[Index].Mapping);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a () for RxdescRing: %r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a () for RxdescRing: %r\n", __func__, Status));
       return Status;
     }
 
@@ -176,7 +176,7 @@ DriverStart (
     Status = DmaMap (MapOperationBusMasterWrite,  (VOID *) RxBufferAddr,
                &BufferSize, &RxBufferAddrMap, &Snp->MacDriver.RxBufNum[Index].Mapping);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a () for Rxbuffer: %r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a () for Rxbuffer: %r\n", __func__, Status));
       return Status;
     }
     Snp->MacDriver.RxBufNum[Index].AddrMap= RxBufferAddrMap;
@@ -319,7 +319,7 @@ DriverStop (
                   (VOID **)&SnpProtocol
                 );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a (): HandleProtocol: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a (): HandleProtocol: %r\n", __func__, Status));
     return Status;
   }
 
@@ -331,7 +331,7 @@ DriverStop (
                   &Snp->Snp,
                   NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a (): UninstallMultipleProtocolInterfaces: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a (): UninstallMultipleProtocolInterfaces: %r\n", __func__, Status));
     return Status;
   }
 

--- a/Silicon/Synopsys/DesignWare/Drivers/DwEmacSnpDxe/DwEmacSnpDxe.c
+++ b/Silicon/Synopsys/DesignWare/Drivers/DwEmacSnpDxe/DwEmacSnpDxe.c
@@ -45,7 +45,7 @@ SnpStart (
 {
   SIMPLE_NETWORK_DRIVER    *Snp;
 
-  DEBUG ((DEBUG_INFO,"SNP:DXE: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO,"SNP:DXE: %a ()\r\n", __func__));
 
   // Check Snp instance
   if (This == NULL) {
@@ -94,7 +94,7 @@ SnpStop (
 {
   SIMPLE_NETWORK_DRIVER    *Snp;
 
-  DEBUG ((DEBUG_INFO, "SNP:DXE: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:DXE: %a ()\r\n", __func__));
 
   // Check Snp Instance
   if (This == NULL) {
@@ -168,7 +168,7 @@ SnpInitialize (
   EFI_STATUS                  Status;
   SIMPLE_NETWORK_DRIVER       *Snp;
 
-  DEBUG ((DEBUG_INFO, "SNP:DXE: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:DXE: %a ()\r\n", __func__));
 
   // Check Snp Instance
   if (This == NULL) {
@@ -252,7 +252,7 @@ SnpReset (
 
   Snp = INSTANCE_FROM_SNP_THIS (This);
 
-  DEBUG ((DEBUG_INFO, "SNP:DXE: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:DXE: %a ()\r\n", __func__));
 
   // Check Snp Instance
   if (This == NULL) {
@@ -304,7 +304,7 @@ SnpShutdown (
 {
   SIMPLE_NETWORK_DRIVER     *Snp;
 
-  DEBUG ((DEBUG_INFO, "SNP:DXE: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:DXE: %a ()\r\n", __func__));
 
   // Check Snp Instance
   if (This == NULL) {
@@ -571,7 +571,7 @@ SnpStatistics (
 
   Snp = INSTANCE_FROM_SNP_THIS (This);
 
-  DEBUG ((DEBUG_INFO, "SNP:DXE: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:DXE: %a ()\r\n", __func__));
 
   // Check Snp instance
   if (This == NULL) {
@@ -648,7 +648,7 @@ SnpMcastIptoMac (
   )
 {
 
-  DEBUG ((DEBUG_INFO, "SNP:DXE: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:DXE: %a ()\r\n", __func__));
 
   // Check Snp instance
   if (This == NULL) {
@@ -997,7 +997,7 @@ SnpTransmit (
   Status = DmaMap (MapOperationBusMasterRead, (VOID *)(UINTN)TxDescriptor->Addr,
              &BufferSizeBuf, &TxBufferAddrMap, &Snp->MappingTxbuf);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a () for Txbuffer: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a () for Txbuffer: %r\n", __func__, Status));
     return Status;
   }
   TxDescriptorMap->Addr = TxBufferAddrMap;
@@ -1242,7 +1242,7 @@ SnpReceive (
   Status = DmaMap (MapOperationBusMasterWrite,  (VOID *)RxBufferAddr,
              &BufferSizeBuf, &RxBufferAddrMap, &Snp->MacDriver.RxBufNum[DescNum].Mapping);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a () for Rxbuffer: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a () for Rxbuffer: %r\n", __func__, Status));
     return Status;
   }
   Snp->MacDriver.RxBufNum[DescNum].AddrMap = RxBufferAddrMap;

--- a/Silicon/Synopsys/DesignWare/Drivers/DwEmacSnpDxe/EmacDxeUtil.c
+++ b/Silicon/Synopsys/DesignWare/Drivers/DwEmacSnpDxe/EmacDxeUtil.c
@@ -28,7 +28,7 @@ EmacSetMacAddress (
   IN  UINTN             MacBaseAddress
   )
 {
-  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __func__));
 
   // Note: This MAC_ADDR0 registers programming sequence cannot be swap:
   // Must program HIGH Offset first before LOW Offset
@@ -62,7 +62,7 @@ EmacReadMacAddress (
   UINT32          MacAddrHighValue;
   UINT32          MacAddrLowValue;
 
-  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __func__));
 
   // Read the Mac Addr high register
   MacAddrHighValue = (MmioRead32 (MacBaseAddress + DW_EMAC_GMACGRP_MAC_ADDRESS0_HIGH_OFST) & 0xFFFF);
@@ -90,7 +90,7 @@ EmacDxeInitialization (
   IN  UINTN         MacBaseAddress
   )
 {
-  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __func__));
 
   // Init EMAC DMA
   EmacDmaInit (EmacDriver, MacBaseAddress);
@@ -110,7 +110,7 @@ EmacDmaInit (
   UINT32 DmaOpmode;
   UINT32 InterruptEnable;
 
-  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __func__));
 
   // This section provides the instructions for initializing the DMA registers in the proper sequence. This
   // initialization sequence can be done after the EMAC interface initialization has been completed. Perform
@@ -298,7 +298,7 @@ EmacStartTransmission (
   IN  UINTN   MacBaseAddress
   )
 {
-  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __func__));
   MmioOr32 (MacBaseAddress +
             DW_EMAC_GMACGRP_MAC_CONFIGURATION_OFST,
             DW_EMAC_GMACGRP_MAC_CONFIGURATION_RE_SET_MSK |
@@ -449,7 +449,7 @@ EmacStopTxRx (
    IN  UINTN   MacBaseAddress
   )
 {
-  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __func__));
 
   // Stop DMA TX
   MmioAnd32 (MacBaseAddress +
@@ -620,7 +620,7 @@ EmacGetStatistic (
 {
   EFI_NETWORK_STATISTICS   *Stats;
 
-  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:MAC: %a ()\r\n", __func__));
 
   // Allocate Resources
   Stats = AllocateZeroPool (sizeof (EFI_NETWORK_STATISTICS));

--- a/Silicon/Synopsys/DesignWare/Drivers/DwEmacSnpDxe/PhyDxeUtil.c
+++ b/Silicon/Synopsys/DesignWare/Drivers/DwEmacSnpDxe/PhyDxeUtil.c
@@ -31,7 +31,7 @@ PhyDxeInitialization (
 {
   EFI_STATUS   Status;
 
-  DEBUG ((DEBUG_INFO, "SNP:PHY: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:PHY: %a ()\r\n", __func__));
 
   // initialize the phyaddr
   PhyDriver->PhyAddr = 0;
@@ -60,7 +60,7 @@ PhyDetectDevice (
   UINT32       PhyAddr;
   EFI_STATUS   Status;
 
-  DEBUG ((DEBUG_INFO, "SNP:PHY: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:PHY: %a ()\r\n", __func__));
 
   for (PhyAddr = 0; PhyAddr < 32; PhyAddr++) {
     Status = PhyReadId (PhyAddr, MacBaseAddress);
@@ -87,7 +87,7 @@ PhyConfig (
 {
   EFI_STATUS  Status;
 
-  DEBUG ((DEBUG_INFO, "SNP:PHY: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:PHY: %a ()\r\n", __func__));
 
   Status = PhySoftReset (PhyDriver, MacBaseAddress);
   if (EFI_ERROR (Status)) {
@@ -123,7 +123,7 @@ PhySoftReset (
   UINT32        Data32;
   EFI_STATUS    Status;
 
-  DEBUG ((DEBUG_INFO, "SNP:PHY: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:PHY: %a ()\r\n", __func__));
 
   // PHY Basic Control Register reset
   PhyWrite (PhyDriver->PhyAddr, PHY_BASIC_CTRL, PHYCTRL_RESET, MacBaseAddress);
@@ -289,7 +289,7 @@ PhyAutoNego (
   UINT32        PhyStatus;
   UINT32        Features;
 
-  DEBUG ((DEBUG_INFO, "SNP:PHY: %a ()\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "SNP:PHY: %a ()\r\n", __func__));
 
   // Read PHY Status
   Status = PhyRead (PhyDriver->PhyAddr, PHY_BASIC_STATUS, &PhyStatus, MacBaseAddress);

--- a/Silicon/TexasInstruments/Omap35xxPkg/Flash/Flash.c
+++ b/Silicon/TexasInstruments/Omap35xxPkg/Flash/Flash.c
@@ -170,7 +170,7 @@ NandDetectPart (
   }
 
   if (Found == FALSE) {
-    DEBUG ((EFI_D_ERROR, "Nand part is not currently supported. Manufacture id: %x, Device id: %x\n", PartInfo[0], PartInfo[1]));
+    DEBUG ((DEBUG_ERROR, "Nand part is not currently supported. Manufacture id: %x, Device id: %x\n", PartInfo[0], PartInfo[1]));
     return EFI_NOT_FOUND;
   }
 
@@ -182,21 +182,21 @@ NandDetectPart (
   if (PAGE_SIZE(NandInfo) == PAGE_SIZE_2K_VAL) {
     gNandFlashInfo->PageSize = PAGE_SIZE_2K;
   } else {
-    DEBUG ((EFI_D_ERROR, "Unknown Page size.\n"));
+    DEBUG ((DEBUG_ERROR, "Unknown Page size.\n"));
     return EFI_DEVICE_ERROR;
   }
 
   if (SPARE_AREA_SIZE(NandInfo) == SPARE_AREA_SIZE_64B_VAL) {
     gNandFlashInfo->SparePageSize = SPARE_AREA_SIZE_64B;
   } else {
-    DEBUG ((EFI_D_ERROR, "Unknown Spare area size.\n"));
+    DEBUG ((DEBUG_ERROR, "Unknown Spare area size.\n"));
     return EFI_DEVICE_ERROR;
   }
 
   if (BLOCK_SIZE(NandInfo) == BLOCK_SIZE_128K_VAL) {
     gNandFlashInfo->BlockSize = BLOCK_SIZE_128K;
   } else {
-    DEBUG ((EFI_D_ERROR, "Unknown Block size.\n"));
+    DEBUG ((DEBUG_ERROR, "Unknown Block size.\n"));
     return EFI_DEVICE_ERROR;
   }
 
@@ -310,7 +310,7 @@ NandReadPage (
   }
 
   if (Timeout == 0) {
-    DEBUG ((EFI_D_ERROR, "Read page timed out.\n"));
+    DEBUG ((DEBUG_ERROR, "Read page timed out.\n"));
     return EFI_TIMEOUT;
   }
 
@@ -409,7 +409,7 @@ NandWritePage (
   }
 
   if (Timeout == 0) {
-    DEBUG ((EFI_D_ERROR, "Program page timed out.\n"));
+    DEBUG ((DEBUG_ERROR, "Program page timed out.\n"));
     return EFI_TIMEOUT;
   }
 
@@ -462,7 +462,7 @@ NandEraseBlock (
   }
 
   if (Timeout == 0) {
-    DEBUG ((EFI_D_ERROR, "Erase block timed out for Block: %d.\n", BlockIndex));
+    DEBUG ((DEBUG_ERROR, "Erase block timed out for Block: %d.\n", BlockIndex));
     return EFI_TIMEOUT;
   }
 
@@ -602,7 +602,7 @@ NandFlashReadBlocks (
   //Read block
   Status = NandReadBlock((UINTN)Lba, EndBlockIndex, Buffer, SpareBuffer);
   if (EFI_ERROR(Status)) {
-    DEBUG((EFI_D_ERROR, "Read block fails: %x\n", Status));
+    DEBUG((DEBUG_ERROR, "Read block fails: %x\n", Status));
     goto exit;
   }
 
@@ -658,7 +658,7 @@ NandFlashWriteBlocks (
   for (BlockIndex = (UINTN)Lba; BlockIndex <= EndBlockIndex; BlockIndex++) {
     Status = NandEraseBlock(BlockIndex);
     if (EFI_ERROR(Status)) {
-      DEBUG((EFI_D_ERROR, "Erase block failed. Status: %x\n", Status));
+      DEBUG((DEBUG_ERROR, "Erase block failed. Status: %x\n", Status));
       goto exit;
     }
   }
@@ -666,7 +666,7 @@ NandFlashWriteBlocks (
   // Program data
   Status = NandWriteBlock((UINTN)Lba, EndBlockIndex, Buffer, SpareBuffer);
   if (EFI_ERROR(Status)) {
-    DEBUG((EFI_D_ERROR, "Block write fails: %x\n", Status));
+    DEBUG((DEBUG_ERROR, "Block write fails: %x\n", Status));
     goto exit;
   }
 
@@ -731,7 +731,7 @@ NandFlashInitialize (
   //Detect NAND part and populate gNandFlashInfo structure
   Status = NandDetectPart ();
   if (EFI_ERROR(Status)) {
-    DEBUG((EFI_D_ERROR, "Nand part id detection failure: Status: %x\n", Status));
+    DEBUG((DEBUG_ERROR, "Nand part id detection failure: Status: %x\n", Status));
     return Status;
   }
 

--- a/Silicon/TexasInstruments/Omap35xxPkg/InterruptDxe/HardwareInterrupt.c
+++ b/Silicon/TexasInstruments/Omap35xxPkg/InterruptDxe/HardwareInterrupt.c
@@ -308,7 +308,7 @@ CpuArchEventProtocolNotify (
   //
   Status = gBS->LocateProtocol (&gEfiCpuArchProtocolGuid, NULL, (VOID **)&Cpu);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: gBS->LocateProtocol() - %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: gBS->LocateProtocol() - %r\n", __func__,
       Status));
     ASSERT (FALSE);
     return;
@@ -320,7 +320,7 @@ CpuArchEventProtocolNotify (
   Status = Cpu->RegisterInterruptHandler (Cpu, EXCEPT_ARM_IRQ, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Cpu->RegisterInterruptHandler() - %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     ASSERT (FALSE);
     return;
   }
@@ -332,7 +332,7 @@ CpuArchEventProtocolNotify (
                   IrqInterruptHandler);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Cpu->RegisterInterruptHandler() - %r\n",
-      __FUNCTION__, Status));
+      __func__, Status));
     ASSERT (FALSE);
     return;
   }

--- a/Silicon/TexasInstruments/Omap35xxPkg/Library/Omap35xxTimerLib/TimerLib.c
+++ b/Silicon/TexasInstruments/Omap35xxPkg/Library/Omap35xxTimerLib/TimerLib.c
@@ -42,7 +42,7 @@ TimerConstructor (
 
     // Disable OMAP Watchdog timer (WDT2)
     MmioWrite32 (WDTIMER2_BASE + WSPR, 0xAAAA);
-    DEBUG ((EFI_D_ERROR, "Magic delay to disable watchdog timers properly.\n"));
+    DEBUG ((DEBUG_ERROR, "Magic delay to disable watchdog timers properly.\n"));
     MmioWrite32 (WDTIMER2_BASE + WSPR, 0x5555);
   }
   return EFI_SUCCESS;

--- a/Silicon/TexasInstruments/Omap35xxPkg/Library/OmapDmaLib/OmapDmaLib.c
+++ b/Silicon/TexasInstruments/Omap35xxPkg/Library/OmapDmaLib/OmapDmaLib.c
@@ -152,7 +152,7 @@ DisableDmaChannel (
     Reg = MmioRead32 (DMA4_CSR(Channel));
     if ((Reg & ErrorMask) != 0) {
       Status = EFI_DEVICE_ERROR;
-      DEBUG ((EFI_D_ERROR, "DMA Error (%d) %x\n", Channel, Reg));
+      DEBUG ((DEBUG_ERROR, "DMA Error (%d) %x\n", Channel, Reg));
       break;
     }
   } while ((Reg & SuccessMask) != SuccessMask);

--- a/Silicon/TexasInstruments/Omap35xxPkg/MmcHostDxe/MmcHostDxe.c
+++ b/Silicon/TexasInstruments/Omap35xxPkg/MmcHostDxe/MmcHostDxe.c
@@ -339,7 +339,7 @@ MMCSendCommand (
 
   MmcCmd = TranslateCommand(MmcCmd);
 
-  //DEBUG ((EFI_D_ERROR, "MMCSendCommand(%d)\n", MmcCmd));
+  //DEBUG ((DEBUG_ERROR, "MMCSendCommand(%d)\n", MmcCmd));
 
   // Check if command line is in use or not. Poll till command line is available.
   while ((MmioRead32 (MMCHS_PSTATE) & DATI_MASK) == DATI_NOT_ALLOWED);
@@ -376,7 +376,7 @@ MMCSendCommand (
       MmioOr32 (MMCHS_SYSCTL, SRC);
       while ((MmioRead32 (MMCHS_SYSCTL) & SRC));
 
-      //DEBUG ((EFI_D_INFO, "MmcStatus: 0x%x\n", MmcStatus));
+      //DEBUG ((DEBUG_INFO, "MmcStatus: 0x%x\n", MmcStatus));
       return EFI_DEVICE_ERROR;
     }
 

--- a/Silicon/TexasInstruments/Omap35xxPkg/SmbusDxe/Smbus.c
+++ b/Silicon/TexasInstruments/Omap35xxPkg/SmbusDxe/Smbus.c
@@ -306,7 +306,7 @@ InitializeSmbus (
   //Configure I2C controller.
   Status = ConfigureI2c();
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "InitializeI2c fails.\n"));
+    DEBUG ((DEBUG_ERROR, "InitializeI2c fails.\n"));
     return Status;
   }
 


### PR DESCRIPTION
Update code to be more C11 compliant by using `__func__`
    
`__FUNCTION__` is a pre-standard extension that gcc and Visual C++ among
others support, while `__func__` was standardized in C99.

Since it's more standard, replace `__FUNCTION__` with `__func__` throughout
edk2-platforms.

------

Replace deprecated EFI_D_* with DEBUG_*
    
Replaced the deprecated EFI_D_{INFO,WARN,ERROR,VERBOSE} usage with
DEBUG_{INFO,WARN,ERROR,VERBOSE}.