### PR TITLE
SbsaQemu: ArmPlatformIsPrimaryCore code is gone

### DIFF
--- a/Silicon/Qemu/SbsaQemu/Library/SbsaQemuLib/SbsaQemuLib.c
+++ b/Silicon/Qemu/SbsaQemu/Library/SbsaQemuLib/SbsaQemuLib.c
@@ -90,10 +90,6 @@ ArmPlatformInitialize (
   IN  UINTN  MpId
   )
 {
-  if (!ArmPlatformIsPrimaryCore (MpId)) {
-    return RETURN_SUCCESS;
-  }
-
   return RETURN_SUCCESS;
 }
 


### PR DESCRIPTION
ArmPlatformIsPrimaryCore() was removed in
8676e88233d41323ed3b3a9087288e83cc87ebf7 commit:

> Remove all the ArmPlatformLib routines that are no longer used now
> that the MPCore SEC drivers have been retired. The prototypes will be
> removed from the ArmPlatformLib library class in a subsequent EDK2
> change.