### PR TITLE
Github workflow: update actions/checkout to latest

### DIFF
--- a/.github/workflows/AssignReviewers.yml
+++ b/.github/workflows/AssignReviewers.yml
@@ -27,7 +27,7 @@ jobs:
           app-id: ${{ secrets.TIANOCORE_ASSIGN_REVIEWERS_APPLICATION_ID }}
           private-key: ${{ secrets.TIANOCORE_ASSIGN_REVIEWERS_APPLICATION_PRIVATE_KEY }}
       - name: Checkout Pull Request Target
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Assign Reviewers
         uses: mdkinney/github-action-assign-reviewers@main
         with:


### PR DESCRIPTION
Move from v2 to v4 gets rid of warnings present in each workflow run:

The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2.

The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v2,