### PR TITLE
Platform/RPi4: Allocate more space for UEFI image

### DIFF
--- a/Platform/RaspberryPi/RPi4/RPi4.dsc
+++ b/Platform/RaspberryPi/RPi4/RPi4.dsc
@@ -284,6 +284,11 @@
   gEfiMdePkgTokenSpaceGuid.PcdPerformanceLibraryPropertyMask|1
   gEfiMdePkgTokenSpaceGuid.PcdPostCodePropertyMask|0
   gEfiMdePkgTokenSpaceGuid.PcdUefiLibMaxPrintBufferSize|320
+  #
+  # Follows right after the FD image. (bump the size again)
+  #
+  gRaspberryPiTokenSpaceGuid.PcdFdtBaseAddress|0x003e0000
+
 
   # DEBUG_ASSERT_ENABLED       0x01
   # DEBUG_PRINT_ENABLED        0x02
@@ -403,14 +408,14 @@
   gArmPlatformTokenSpaceGuid.PcdSystemMemoryUefiRegionSize|0x04000000
   #
   # 0x00000000 - 0x001F0000  FD (PcdFdBaseAddress, PcdFdSize)
-  # 0x001F0000 - 0x00200000 DTB (PcdFdtBaseAddress, PcdFdtSize)
-  # 0x00200000 - ...        RAM (PcdSystemMemoryBase, PcdSystemMemorySize)
+  # 0x003E0000 - 0x00400000 DTB (PcdFdtBaseAddress, PcdFdtSize)
+  # 0x00400000 - ...        RAM (PcdSystemMemoryBase, PcdSystemMemorySize)
   #
   # This matches PcdFvBaseAddress, since everything less is the FD, and
   # will be reserved away.
   #
-  gArmTokenSpaceGuid.PcdSystemMemoryBase|0x00200000
-  gArmTokenSpaceGuid.PcdSystemMemorySize|0x3fe00000
+  gArmTokenSpaceGuid.PcdSystemMemoryBase|0x00400000
+  gArmTokenSpaceGuid.PcdSystemMemorySize|0x3fc00000
 
   #
   # Device specific addresses

--- a/Platform/RaspberryPi/RPi4/RPi4.fdf
+++ b/Platform/RaspberryPi/RPi4/RPi4.fdf
@@ -25,11 +25,11 @@
 
 [FD.RPI_EFI]
 BaseAddress   = 0x00000000|gArmTokenSpaceGuid.PcdFdBaseAddress
-Size          = 0x001f0000|gArmTokenSpaceGuid.PcdFdSize
+Size          = 0x003e0000|gArmTokenSpaceGuid.PcdFdSize
 ErasePolarity = 1
 
 BlockSize     = 0x00001000|gRaspberryPiTokenSpaceGuid.PcdFirmwareBlockSize
-NumBlocks     = 0x1f0
+NumBlocks     = 0x3e0
 
 ################################################################################
 #
@@ -56,7 +56,7 @@ FILE = $(TFA_BUILD_BL31)
 #
 # UEFI image
 #
-0x00020000|0x001b0000
+0x00020000|0x00390000
 gArmTokenSpaceGuid.PcdFvBaseAddress|gArmTokenSpaceGuid.PcdFvSize
 FV = FVMAIN_COMPACT
 
@@ -70,7 +70,7 @@ FV = FVMAIN_COMPACT
 #
 
 # NV_VARIABLE_STORE
-0x001d0000|0x0000e000
+0x003b0000|0x0000e000
 gRaspberryPiTokenSpaceGuid.PcdNvStorageVariableBase|gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
 
 DATA = {
@@ -113,11 +113,11 @@ DATA = {
 }
 
 # NV_EVENT_LOG
-0x001de000|0x00001000
+0x003be000|0x00001000
 gRaspberryPiTokenSpaceGuid.PcdNvStorageEventLogBase|gRaspberryPiTokenSpaceGuid.PcdNvStorageEventLogSize
 
 # NV_FTW_WORKING header
-0x001df000|0x00001000
+0x003bf000|0x00001000
 gRaspberryPiTokenSpaceGuid.PcdNvStorageFtwWorkingBase|gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize
 
 DATA = {
@@ -132,14 +132,18 @@ DATA = {
 }
 
 # NV_FTW_WORKING data
-0x001e0000|0x00010000
+0x003c0000|0x00010000
 gRaspberryPiTokenSpaceGuid.PcdNvStorageFtwSpareBase|gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize
+
+# reserve some future RAM for the ACPI PCC channel structures, immediately before the DTB
+# 0x003d0000|0x00010000
+# gRaspberryPiTokenSpaceGuid.PcdPccBaseAddress|gRaspberryPiTokenSpaceGuid.PcdPccSize
 
 #
 # This is just for documentation purposes! The DTB reserved space is not part of the FD,
 # but this is exactly where it is expected to be.
 #
-# 0x001f0000|0x10000
+# 0x003e0000|0x20000
 # gRaspberryPiTokenSpaceGuid.PcdFdtBaseAddress|gRaspberryPiTokenSpaceGuid.PcdFdtSize
 #
 

--- a/Platform/RaspberryPi/RPi4/Readme.md
+++ b/Platform/RaspberryPi/RPi4/Readme.md
@@ -55,8 +55,8 @@ Build instructions from the top level edk2-platforms Readme.md apply.
     enable_gic=1
     armstub=RPI_EFI.fd
     disable_commandline_tags=2
-    device_tree_address=0x1f0000
-    device_tree_end=0x200000
+    device_tree_address=0x3e0000
+    device_tree_end=0x400000
     ```
     Additionally, if you want to use PL011 instead of the miniUART, you can add the lines:
     ```
@@ -91,12 +91,12 @@ the SD or USB, and then edit your `config.txt` so that it looks like:
 ```
 (...)
 disable_commandline_tags=2
-device_tree_address=0x1f0000
-device_tree_end=0x200000
+device_tree_address=0x3e0000
+device_tree_end=0x400000
 device_tree=your_fdt_file.dtb
 ```
 
-Note: the address range **must** be `[0x1f0000:0x200000]`. `dtoverlay` and `dtparam` parameters are also supported.
+Note: the address range **must** be `[0x3e0000:0x400000]`. `dtoverlay` and `dtparam` parameters are also supported.
 
 ## Custom `bootargs`
 


### PR DESCRIPTION
The Pi's UEFI image was sized without thought for much future growth, and its become apparent that its largly outgrown the allocated space when various debug options or edk2 featurees are enabled. Since these images tend to exist on disks which are usually in the GB+ ranges doubling the size of the RPI_EFI.fd image shouldn't be a problem.

This change must be accompanied by build edk2-non-osi changes to TFA which update the RPI3_PRELOADED_DTB_BASE=0x3f0000 and config.txt changes as documented in the README being patched.

Since we are adjusting the image size, lets reserve a 64k block for future PCC channel data structures that are shared between TFA and ACPI as well immediately before the DTB.