### PR TITLE
 Platform/ARM/Juno: Use RngDxeLib

### DIFF
--- a/Platform/ARM/JunoPkg/ArmJuno.dsc
+++ b/Platform/ARM/JunoPkg/ArmJuno.dsc
@@ -219,7 +219,7 @@
   #
   # Juno Support Trng. Override PcdEnforceSecureRngAlgorithms.
   #
-  gEfiNetworkPkgTokenSpaceGuid.PcdEnforceSecureRngAlgorithms|TRUE
+  gEfiMdePkgTokenSpaceGuid.PcdEnforceSecureRngAlgorithms|TRUE
 
 [PcdsPatchableInModule]
   # Console Resolution (Full HD)

--- a/Platform/ARM/JunoPkg/ArmJuno.dsc
+++ b/Platform/ARM/JunoPkg/ArmJuno.dsc
@@ -25,9 +25,10 @@
   SKUID_IDENTIFIER               = DEFAULT
   FLASH_DEFINITION               = Platform/ARM/JunoPkg/ArmJuno.fdf
 
+!include MdePkg/MdeLibs.dsc.inc
+
 # On RTSM, most peripherals are VExpress Motherboard peripherals
 !include Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
-!include MdePkg/MdeLibs.dsc.inc
 
 !ifdef DYNAMIC_TABLES_FRAMEWORK
 !include DynamicTablesPkg/DynamicTables.dsc.inc

--- a/Platform/ARM/JunoPkg/ArmJuno.dsc
+++ b/Platform/ARM/JunoPkg/ArmJuno.dsc
@@ -45,6 +45,8 @@
   # Trng Supports.
   ArmMonitorLib|ArmPkg/Library/ArmMonitorLib/ArmMonitorLib.inf
   ArmTrngLib|ArmPkg/Library/ArmTrngLib/ArmTrngLib.inf
+  # Rng
+  RngLib|MdePkg/Library/DxeRngLib/DxeRngLib.inf
 
   NorFlashDeviceLib|Platform/ARM/Library/P30NorFlashDeviceLib/P30NorFlashDeviceLib.inf
   NorFlashPlatformLib|Platform/ARM/JunoPkg/Library/NorFlashJunoLib/NorFlashJunoLib.inf
@@ -406,6 +408,18 @@
 
   # SCMI Driver
   ArmPkg/Drivers/ArmScmiDxe/ArmScmiDxe.inf
+
+  #
+  # Rng
+  #
+  SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.inf {
+    <LibraryClasses>
+    !if $(ENABLE_UNSAFE_RNGLIB) == TRUE
+      RngLib|MdeModulePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
+    !else
+      RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
+    !endif
+  }
 
 [Components.AARCH64]
   #

--- a/Platform/ARM/Morello/MorelloPlatformFvp.dsc
+++ b/Platform/ARM/Morello/MorelloPlatformFvp.dsc
@@ -30,13 +30,13 @@
   # Network definition
   DEFINE NETWORK_ISCSI_ENABLE    = FALSE
 
+# include common/basic libraries from MdePkg.
+!include MdePkg/MdeLibs.dsc.inc
+
 !include Platform/ARM/Morello/MorelloPlatform.dsc.inc
 !include Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
 !include DynamicTablesPkg/DynamicTables.dsc.inc
 !include Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerFvp.dsc.inc
-
-# include common/basic libraries from MdePkg.
-!include MdePkg/MdeLibs.dsc.inc
 
 [LibraryClasses.common]
   # Virtio Support

--- a/Platform/ARM/N1Sdp/N1SdpPlatform.dsc
+++ b/Platform/ARM/N1Sdp/N1SdpPlatform.dsc
@@ -27,8 +27,8 @@
   FLASH_DEFINITION               = Platform/ARM/N1Sdp/N1SdpPlatform.fdf
   BUILD_NUMBER                   = 1
 
-!include Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
 !include MdePkg/MdeLibs.dsc.inc
+!include Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
 
 !include DynamicTablesPkg/DynamicTables.dsc.inc
 

--- a/Platform/ARM/SgiPkg/RdE1Edge/RdE1Edge.dsc
+++ b/Platform/ARM/SgiPkg/RdE1Edge/RdE1Edge.dsc
@@ -24,12 +24,12 @@
 
   DEFINE PCIE_ENABLE             = TRUE
 
+# include common/basic libraries from MdePkg.
+!include MdePkg/MdeLibs.dsc.inc
+
 # include common definitions from SgiPlatform.dsc
 !include Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
 !include Platform/ARM/SgiPkg/SgiMemoryMap.dsc.inc
-
-# include common/basic libraries from MdePkg.
-!include MdePkg/MdeLibs.dsc.inc
 
 ################################################################################
 #

--- a/Platform/ARM/SgiPkg/RdN1Edge/RdN1Edge.dsc
+++ b/Platform/ARM/SgiPkg/RdN1Edge/RdN1Edge.dsc
@@ -24,12 +24,12 @@
 
   DEFINE PCIE_ENABLE             = TRUE
 
+# include common/basic libraries from MdePkg.
+!include MdePkg/MdeLibs.dsc.inc
+
 # include common definitions from SgiPlatform.dsc
 !include Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
 !include Platform/ARM/SgiPkg/SgiMemoryMap.dsc.inc
-
-# include common/basic libraries from MdePkg.
-!include MdePkg/MdeLibs.dsc.inc
 
 ################################################################################
 #

--- a/Platform/ARM/SgiPkg/RdN1EdgeX2/RdN1EdgeX2.dsc
+++ b/Platform/ARM/SgiPkg/RdN1EdgeX2/RdN1EdgeX2.dsc
@@ -24,12 +24,12 @@
 
   DEFINE PCIE_ENABLE             = TRUE
 
+# include common/basic libraries from MdePkg.
+!include MdePkg/MdeLibs.dsc.inc
+
 # include common definitions from SgiPlatform.dsc
 !include Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
 !include Platform/ARM/SgiPkg/SgiMemoryMap.dsc.inc
-
-# include common/basic libraries from MdePkg.
-!include MdePkg/MdeLibs.dsc.inc
 
 ################################################################################
 #

--- a/Platform/ARM/SgiPkg/RdN2/RdN2.dsc
+++ b/Platform/ARM/SgiPkg/RdN2/RdN2.dsc
@@ -22,12 +22,12 @@
   BOARD_DXE_FV_COMPONENTS        = Platform/ARM/SgiPkg/RdN2/RdN2.fdf.inc
   BUILD_NUMBER                   = 1
 
+# include common/basic libraries from MdePkg.
+!include MdePkg/MdeLibs.dsc.inc
+
 # include common definitions from SgiPlatform.dsc
 !include Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
 !include Platform/ARM/SgiPkg/SgiMemoryMap2.dsc.inc
-
-# include common/basic libraries from MdePkg.
-!include MdePkg/MdeLibs.dsc.inc
 
 ################################################################################
 #

--- a/Platform/ARM/SgiPkg/RdN2Cfg1/RdN2Cfg1.dsc
+++ b/Platform/ARM/SgiPkg/RdN2Cfg1/RdN2Cfg1.dsc
@@ -24,12 +24,12 @@
   BOARD_DXE_FV_COMPONENTS        = Platform/ARM/SgiPkg/RdN2Cfg1/RdN2Cfg1.fdf.inc
   BUILD_NUMBER                   = 1
 
+# include common/basic libraries from MdePkg.
+!include MdePkg/MdeLibs.dsc.inc
+
 # include common definitions from SgiPlatform.dsc
 !include Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
 !include Platform/ARM/SgiPkg/SgiMemoryMap2.dsc.inc
-
-# include common/basic libraries from MdePkg.
-!include MdePkg/MdeLibs.dsc.inc
 
 ################################################################################
 #

--- a/Platform/ARM/SgiPkg/RdN2Cfg2/RdN2Cfg2.dsc
+++ b/Platform/ARM/SgiPkg/RdN2Cfg2/RdN2Cfg2.dsc
@@ -22,12 +22,12 @@
   BOARD_DXE_FV_COMPONENTS        = Platform/ARM/SgiPkg/RdN2Cfg2/RdN2Cfg2.fdf.inc
   BUILD_NUMBER                   = 1
 
+# include common/basic libraries from MdePkg.
+!include MdePkg/MdeLibs.dsc.inc
+
 # include common definitions from SgiPlatform.dsc
 !include Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
 !include Platform/ARM/SgiPkg/SgiMemoryMap2.dsc.inc
-
-# include common/basic libraries from MdePkg.
-!include MdePkg/MdeLibs.dsc.inc
 
 ################################################################################
 #

--- a/Platform/ARM/SgiPkg/RdN2Cfg3/RdN2Cfg3.dsc
+++ b/Platform/ARM/SgiPkg/RdN2Cfg3/RdN2Cfg3.dsc
@@ -22,12 +22,12 @@
   BOARD_DXE_FV_COMPONENTS        = Platform/ARM/SgiPkg/RdN2Cfg3/RdN2Cfg3.fdf.inc
   BUILD_NUMBER                   = 1
 
+# include common/basic libraries from MdePkg.
+!include MdePkg/MdeLibs.dsc.inc
+
 # include common definitions from SgiPlatform.dsc
 !include Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
 !include Platform/ARM/SgiPkg/SgiMemoryMap2.dsc.inc
-
-# include common/basic libraries from MdePkg.
-!include MdePkg/MdeLibs.dsc.inc
 
 ################################################################################
 #

--- a/Platform/ARM/SgiPkg/RdV1/RdV1.dsc
+++ b/Platform/ARM/SgiPkg/RdV1/RdV1.dsc
@@ -24,12 +24,12 @@
 
   DEFINE PCIE_ENABLE             = TRUE
 
+# include common/basic libraries from MdePkg.
+!include MdePkg/MdeLibs.dsc.inc
+
 # include common definitions from SgiPlatform.dsc
 !include Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
 !include Platform/ARM/SgiPkg/SgiMemoryMap.dsc.inc
-
-# include common/basic libraries from MdePkg.
-!include MdePkg/MdeLibs.dsc.inc
 
 ################################################################################
 #

--- a/Platform/ARM/SgiPkg/RdV1Mc/RdV1Mc.dsc
+++ b/Platform/ARM/SgiPkg/RdV1Mc/RdV1Mc.dsc
@@ -24,12 +24,12 @@
 
   DEFINE PCIE_ENABLE             = TRUE
 
+# include common/basic libraries from MdePkg.
+!include MdePkg/MdeLibs.dsc.inc
+
 # include common definitions from SgiPlatform.dsc
 !include Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
 !include Platform/ARM/SgiPkg/SgiMemoryMap.dsc.inc
-
-# include common/basic libraries from MdePkg.
-!include MdePkg/MdeLibs.dsc.inc
 
 ################################################################################
 #

--- a/Platform/ARM/SgiPkg/RdV3/RdV3.dsc
+++ b/Platform/ARM/SgiPkg/RdV3/RdV3.dsc
@@ -22,12 +22,12 @@
   BOARD_DXE_FV_COMPONENTS        = Platform/ARM/SgiPkg/RdV3/RdV3.fdf.inc
   BUILD_NUMBER                   = 1
 
+# include common/basic libraries from MdePkg.
+!include MdePkg/MdeLibs.dsc.inc
+
 # include common definitions from SgiPlatform.dsc
 !include Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
 !include Platform/ARM/SgiPkg/SgiMemoryMap3.dsc.inc
-
-# include common/basic libraries from MdePkg.
-!include MdePkg/MdeLibs.dsc.inc
 
 ################################################################################
 #

--- a/Platform/ARM/SgiPkg/Sgi575/Sgi575.dsc
+++ b/Platform/ARM/SgiPkg/Sgi575/Sgi575.dsc
@@ -24,12 +24,12 @@
 
   DEFINE PCIE_ENABLE             = TRUE
 
+# include common/basic libraries from MdePkg.
+!include MdePkg/MdeLibs.dsc.inc
+
 # include common definitions from SgiPlatform.dsc
 !include Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
 !include Platform/ARM/SgiPkg/SgiMemoryMap.dsc.inc
-
-# include common/basic libraries from MdePkg.
-!include MdePkg/MdeLibs.dsc.inc
 
 ################################################################################
 #

--- a/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
@@ -40,8 +40,8 @@
 
   DT_SUPPORT                     = FALSE
 
-!include Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
 !include MdePkg/MdeLibs.dsc.inc
+!include Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
 !include DynamicTablesPkg/DynamicTables.dsc.inc
 
 [LibraryClasses.common]

--- a/Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
@@ -452,7 +452,7 @@
   #
 
 !if $(ENABLE_UNSAFE_RNGLIB) == TRUE
-  gEfiNetworkPkgTokenSpaceGuid.PcdEnforceSecureRngAlgorithms|FALSE
+  gEfiMdePkgTokenSpaceGuid.PcdEnforceSecureRngAlgorithms|FALSE
 !endif
 
 [PcdsDynamicHii.common.DEFAULT]


### PR DESCRIPTION
Juno's RngLib implementation is:

- BaseRngLib.inf if a secure RngLib is enforced
- BaseRngLibTimerLib.inf if a non-secure RngLib is tolerated

BaseRngLib.inf relies on the Arm's RNDR instruction. The instruction
returns a DRBG-generated random number. The DRBG used is considered
as secure.
The RNDR instruction is available if FEAT_RNG is set. The Juno doesn't
support it.

When security is enforced (i.e. ENABLE_UNSAFE_RNGLIB is not set),
the Juno cannot generate secure random numbers through the RngLib.
Secure random numbers could be generated by using the Juno's TRNG.
This can be done by:

- using the RngDxeLib implementation of the RngLib
- RngDxeLib relies on the RngDxe
- the RngDxe has access to the TRNG
