### PR TITLE
CODEOWNERS: Move @bcran from reviewer to maintainer role

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,8 +25,8 @@
 /Platform/AMD/VanGoghBoard/** @abdattar @changab @exinghr @pbgrimes
 
 # Ampere Computing
-/Platform/Ampere/** @nhivp
-/Silicon/Ampere/** @nhivp
+/Platform/Ampere/** @nhivp @bcran
+/Silicon/Ampere/** @nhivp @bcran
 
 # ARM
 /Platform/ARM/** @samimujawar

--- a/REVIEWERS
+++ b/REVIEWERS
@@ -9,8 +9,8 @@
 /Platform/AMD/VanGoghBoard/** @fhh200000 @mingxzha @YSHRong
 
 # Ampere
-/Platform/Ampere/** @bcran @chuongtranle @leiflindholm
-/Silicon/Ampere/** @bcran @chuongtranle @leiflindholm
+/Platform/Ampere/** @chuongtranle @leiflindholm
+/Silicon/Ampere/** @chuongtranle @leiflindholm
 
 # ARM
 # Add Thomas Abraham


### PR DESCRIPTION
Move myself (@bcran) from a reviewer of Ampere code to a maintainer role.