### PR TITLE
CODEOWNERS: Move @chuongtranle from reviewer to maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,8 +25,8 @@
 /Platform/AMD/VanGoghBoard/** @abdattar @changab @exinghr @pbgrimes
 
 # Ampere Computing
-/Platform/Ampere/** @nhivp @bcran
-/Silicon/Ampere/** @nhivp @bcran
+/Platform/Ampere/** @nhivp @bcran @chuongtranle
+/Silicon/Ampere/** @nhivp @bcran @chuongtranle
 
 # ARM
 /Platform/ARM/** @samimujawar

--- a/REVIEWERS
+++ b/REVIEWERS
@@ -9,8 +9,8 @@
 /Platform/AMD/VanGoghBoard/** @fhh200000 @mingxzha @YSHRong
 
 # Ampere
-/Platform/Ampere/** @chuongtranle @leiflindholm
-/Silicon/Ampere/** @chuongtranle @leiflindholm
+/Platform/Ampere/** @leiflindholm
+/Silicon/Ampere/** @leiflindholm
 
 # ARM
 # Add Thomas Abraham


### PR DESCRIPTION
This updates Chuong's role from reviewer to maintainer as he has consistently contributed to the project through active reviews, valuable feedback, and continuous improvement efforts.
