### PR TITLE
Addition of PcdStandaloneMmEnable has broken build of BoardPkg(s)

### DIFF
--- a/Platform/Intel/MinPlatformPkg/Include/Dsc/MinPlatformFeaturesPcd.dsc.inc
+++ b/Platform/Intel/MinPlatformPkg/Include/Dsc/MinPlatformFeaturesPcd.dsc.inc
@@ -7,7 +7,7 @@
 # A board can enable a feature by configuring the PCD in the board DSC file
 # after this file has been included.
 #
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -23,3 +23,5 @@
  gMinPlatformPkgTokenSpaceGuid.PcdTpm2Enable                    |FALSE
 
  gMinPlatformPkgTokenSpaceGuid.PcdPerformanceEnable             |FALSE
+
+ gMinPlatformPkgTokenSpaceGuid.PcdStandaloneMmEnable            |FALSE


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4853

When the PcdStandaloneMmEnable FeaturePcd was added, it was not added to MinPlatformFeaturesPcd.dsc.inc

Because of this, any existing BoardPkg that does not have Standalone MM support will no longer build because the default value of FALSE is not declared during DSC parsing.

The fix is to add the PCD to MinPlatformFeaturesPcd.dsc.inc