### PR TITLE
RISC-V/PlatformPkg:Added Bit operation header file

### DIFF
--- a/Platform/RISC-V/PlatformPkg/Include/RiscVBitOp.h
+++ b/Platform/RISC-V/PlatformPkg/Include/RiscVBitOp.h
@@ -1,0 +1,15 @@
+/** @file
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2024, Bosc. All rights reserved.<BR>
+ *
+ */
+
+#ifndef RISCV_BIT_OP_H
+#define RISCV_BIT_OP_H
+
+#define BIT(nr)         (1UL << (nr))
+#define GENMASK(h, l) \
+    (((~0UL) - (1UL << (l)) + 1) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+
+#endif


### PR DESCRIPTION
Add bit operated macro,like BIT...

Add in generic RISC-V include file under Platform/RISC-V/PlatformPkg/Include/ .That will help in future for any new platforms to avoid duplicating the definition.

Reviewed-by: Sunil V L <sunilvl@ventanamicro.com>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Daniel Schaefer <git@danielschaefer.me>
Cc: Ray Ni <ray.ni@intel.com>