### PR TITLE
Platform/RISC-V: Add PCD variables related to PCI

### DIFF
--- a/Platform/RISC-V/PlatformPkg/Include/RiscVBitOp.h
+++ b/Platform/RISC-V/PlatformPkg/Include/RiscVBitOp.h
@@ -1,0 +1,15 @@
+/** @file
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2024, Bosc. All rights reserved.<BR>
+ *
+ */
+
+#ifndef RISCV_BIT_OP_H
+#define RISCV_BIT_OP_H
+
+#define BIT(nr)         (1UL << (nr))
+#define GENMASK(h, l) \
+    (((~0UL) - (1UL << (l)) + 1) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+
+#endif

--- a/Platform/RISC-V/PlatformPkg/RiscVPlatformPkg.dec
+++ b/Platform/RISC-V/PlatformPkg/RiscVPlatformPkg.dec
@@ -84,6 +84,25 @@
 
   gUefiRiscVPlatformPkgTokenSpaceGuid.PcdDeviceTreeAddress|0|UINT32|0x00001106
 
+  #
+  # PCI configuration info
+  #
+  gUefiRiscVPlatformPkgTokenSpaceGuid.PcdPciConfigBase|0x0|UINT64|0x00001200
+  gUefiRiscVPlatformPkgTokenSpaceGuid.PcdPciConfigSize|0x0|UINT64|0x00001201
+
+  gUefiRiscVPlatformPkgTokenSpaceGuid.PcdPciIoBase|0x0|UINT64|0x00001202
+  gUefiRiscVPlatformPkgTokenSpaceGuid.PcdPciIoSize|0x0|UINT64|0x00001203
+  gUefiRiscVPlatformPkgTokenSpaceGuid.PcdPciMmio32Base|0x0|UINT32|0x00001204
+  gUefiRiscVPlatformPkgTokenSpaceGuid.PcdPciMmio32Size|0x0|UINT32|0x00001205
+  gUefiRiscVPlatformPkgTokenSpaceGuid.PcdPciMmio64Base|0x0|UINT64|0x00001206
+  gUefiRiscVPlatformPkgTokenSpaceGuid.PcdPciMmio64Size|0x0|UINT64|0x00001207
+
+  #
+  # Inclusive range of allowed PCI buses.
+  #
+  gUefiRiscVPlatformPkgTokenSpaceGuid.PcdPciBusMin|0x0|UINT32|0x0000120a
+  gUefiRiscVPlatformPkgTokenSpaceGuid.PcdPciBusMax|0x0|UINT32|0x0000120b
+
 [PcdsPatchableInModule]
 
 [PcdsFeatureFlag]


### PR DESCRIPTION
    Pcihostbridgelib uses the general PCD variable.
    Like PcdPciBusMin PcdPciBusMax ...

These PCDs made part of generic RISC-V package itself , so that they don't need to be added for every platform in the future.

    Reviewed-by: Sunil V L <sunilvl@ventanamicro.com>
    Cc: Leif Lindholm <quic_llindhol@quicinc.com>
    Cc: Michael D Kinney <michael.d.kinney@intel.com>
    Cc: Daniel Schaefer <git@danielschaefer.me>
    Cc: Ray Ni <ray.ni@intel.com>
