### PR TITLE
IntelSiliconPkg: Code Quality Improvements

### DIFF
--- a/Silicon/Intel/IntelSiliconPkg/Feature/SmmAccess/Library/PeiSmmAccessLib/PeiSmmAccessLib.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/SmmAccess/Library/PeiSmmAccessLib/PeiSmmAccessLib.c
@@ -108,7 +108,7 @@ Close (
 {
   SMM_ACCESS_PRIVATE_DATA *SmmAccess;
   BOOLEAN                 OpenState;
-  UINT8                   Index;
+  UINTN                   Index;
 
   SmmAccess = SMM_ACCESS_PRIVATE_DATA_FROM_THIS (This);
   if (DescriptorIndex >= SmmAccess->NumberRegions) {

--- a/Silicon/Intel/IntelSiliconPkg/Feature/SmmAccess/SmmAccessDxe/SmmAccessDriver.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/SmmAccess/SmmAccessDxe/SmmAccessDriver.c
@@ -166,7 +166,7 @@ Close (
 {
   SMM_ACCESS_PRIVATE_DATA *SmmAccess;
   BOOLEAN                 OpenState;
-  UINT8                   Index;
+  UINTN                   Index;
   UINTN                   DescriptorIndex;
 
   SmmAccess = SMM_ACCESS_PRIVATE_DATA_FROM_THIS (This);

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDmarPei/IntelVTdDmarPei.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDmarPei/IntelVTdDmarPei.c
@@ -498,6 +498,7 @@ ProcessDrhdPostMemory (
   Initializes the Intel VTd Info in post memory phase.
 
   @retval EFI_SUCCESS           Usb bot driver is successfully initialized.
+  @retval EFI_NOT_FOUND         Can't find the ACPI DMAR Table.
   @retval EFI_OUT_OF_RESOURCES  Can't initialize the driver.
 **/
 EFI_STATUS
@@ -514,7 +515,10 @@ InitVTdInfo (
   ASSERT (VTdInfo != NULL);
 
   AcpiDmarTable = GetAcpiDmarTable ();
-  ASSERT (AcpiDmarTable != NULL);
+  if (AcpiDmarTable == NULL) {
+    ASSERT (AcpiDmarTable != NULL);
+    return EFI_NOT_FOUND;
+  }
 
   if (VTdInfo->VtdUnitInfo == NULL) {
     //
@@ -562,6 +566,7 @@ InitVTdInfo (
   Initializes the Intel VTd DMAR for block all DMA.
 
   @retval EFI_SUCCESS           Driver is successfully initialized.
+  @retval EFI_NOT_FOUND         Can't find the ACPI DMAR Table.
   @retval RETURN_NOT_READY      Fail to get VTdInfo Hob .
 **/
 EFI_STATUS
@@ -575,7 +580,10 @@ InitVTdDmarBlockAll (
   // Get the DMAR table
   //
   AcpiDmarTable = GetAcpiDmarTable ();
-  ASSERT (AcpiDmarTable != NULL);
+  if (AcpiDmarTable == NULL) {
+    ASSERT (AcpiDmarTable != NULL);
+    return EFI_NOT_FOUND;
+  }
 
   //
   // Parse the DMAR table and block all DMA


### PR DESCRIPTION
**Two commits:**

---

**IntelSiliconPkg/IntelVTdDmarPei: Prevent invalid dereference**

Prevent invalid DMAR ACPI table dereference if the table is not
found.

---

**IntelSiliconPkg/SmmAccess: Fix potential integer overflow in loop comparison**

SmmAccessDxe:

`mSmmAccess.NumberRegions` is a `UINTN` while the loop index variable
compared against it is a `UINT8`. This can lead to an overflow of the
loop index for `mSmmAccess.NumberRegions` for values larger than
`UINT8_MAX`. This change makes `Index` a `UINTN` to match in width.

PeiSmmAccessLib:

Fixes a similar `UINT8` loop index issue.