### PR TITLE
VanGoghBoard/FspsWrapperPeim: Prevent null pointer dereference

### DIFF
--- a/Platform/AMD/VanGoghBoard/Override/edk2/Fsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.c
+++ b/Platform/AMD/VanGoghBoard/Override/edk2/Fsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.c
@@ -542,13 +542,20 @@ FspsWrapperInitDispatchMode (
 
   if (BootMode != BOOT_ON_S3_RESUME) {
     MeasurementExcludedFvPpi = AllocatePool (sizeof (*MeasurementExcludedFvPpi));
-    ASSERT (MeasurementExcludedFvPpi != NULL);
+    if (MeasurementExcludedFvPpi == NULL) {
+      ASSERT (MeasurementExcludedFvPpi != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
     MeasurementExcludedFvPpi->Count          = 1;
     MeasurementExcludedFvPpi->Fv[0].FvBase   = PcdGet32 (PcdFspsBaseAddressInMemory);
     MeasurementExcludedFvPpi->Fv[0].FvLength = PcdGet32 (PcdFspsRegionSize);
 
     MeasurementExcludedPpiList = AllocatePool (sizeof (*MeasurementExcludedPpiList));
-    ASSERT (MeasurementExcludedPpiList != NULL);
+    if (MeasurementExcludedPpiList == NULL) {
+      ASSERT (MeasurementExcludedPpiList != NULL);
+      FreePool (MeasurementExcludedFvPpi);
+      return EFI_OUT_OF_RESOURCES;
+    }
     MeasurementExcludedPpiList->Flags = EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST;
     MeasurementExcludedPpiList->Guid  = &gEfiPeiFirmwareVolumeInfoMeasurementExcludedPpiGuid;
     MeasurementExcludedPpiList->Ppi   = MeasurementExcludedFvPpi;


### PR DESCRIPTION
Return from FspsWrapperInitDispatchMode() if a buffer allocation fails instead of attempting to dereference the pointer.

---

Note: This is bringing a change going into the original edk2 file [here](https://github.com/tianocore/edk2/pull/6250) into this forked copy of the module.