### PR TITLE
Silicon/Ampere: Set EFI_ACPI_6_3_LOW_POWER_S0_IDLE_CAPABLE in FADT

### DIFF
--- a/Silicon/Ampere/AmpereAltraPkg/AcpiCommonTables/Fadt.aslc
+++ b/Silicon/Ampere/AmpereAltraPkg/AcpiCommonTables/Fadt.aslc
@@ -14,7 +14,8 @@
 // This macro defines the FADT flag options.
 //
 #define FADT_FLAGS  (EFI_ACPI_6_3_HW_REDUCED_ACPI | \
-                     EFI_ACPI_6_3_PWR_BUTTON)
+                     EFI_ACPI_6_3_PWR_BUTTON | \
+                     EFI_ACPI_6_3_LOW_POWER_S0_IDLE_CAPABLE)
 
 
 EFI_ACPI_6_3_FIXED_ACPI_DESCRIPTION_TABLE Fadt = {


### PR DESCRIPTION
Set the EFI_ACPI_6_3_LOW_POWER_S0_IDLE_CAPABLE flag in the FADT.

The ACPI specification says the LOW_POWER_S0_IDLE_CAPABLE flag means that the platform is able to achieve power savings in S0 similar to or better than those typically in S3. It effectively means that the system will not achieve any power savings by transitioning to S3. Since Altra doesn't support the S3 state, set this flag.

This resolves the FWTS S0idleNoFADT error.