### PR TITLE
SbsaQemu: fix FWTS errors

### DIFF
--- a/Platform/Qemu/SbsaQemu/SbsaQemu.dsc
+++ b/Platform/Qemu/SbsaQemu/SbsaQemu.dsc
@@ -518,7 +518,7 @@ DEFINE NETWORK_HTTP_BOOT_ENABLE       = FALSE
   #
   # SMBIOS entry point version
   #
-  gEfiMdeModulePkgTokenSpaceGuid.PcdSmbiosVersion|0x0304
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSmbiosVersion|0x0307
   gEfiMdeModulePkgTokenSpaceGuid.PcdSmbiosDocRev|0x0
 
   gArmTokenSpaceGuid.PcdSystemBiosRelease|0x0100

--- a/Silicon/Qemu/SbsaQemu/Drivers/SbsaQemuAcpiDxe/SbsaQemuAcpiDxe.c
+++ b/Silicon/Qemu/SbsaQemu/Drivers/SbsaQemuAcpiDxe/SbsaQemuAcpiDxe.c
@@ -76,7 +76,7 @@ AddIortTable (
     SBSAQEMU_ACPI_HEADER (
       EFI_ACPI_6_0_IO_REMAPPING_TABLE_SIGNATURE,
       SBSA_IO_REMAPPING_STRUCTURE,
-      EFI_ACPI_IO_REMAPPING_TABLE_REVISION_00
+      EFI_ACPI_IO_REMAPPING_TABLE_REVISION_06
       ),
     3,
     sizeof (EFI_ACPI_6_0_IO_REMAPPING_TABLE),        // NodeOffset
@@ -89,8 +89,8 @@ AddIortTable (
       {
         EFI_ACPI_IORT_TYPE_SMMUv3,
         sizeof (SBSA_EFI_ACPI_6_0_IO_REMAPPING_SMMU3_NODE),
-        2,                                                               // Revision
-        0,                                                               // Reserved
+        5,                                                               // Revision
+        0,                                                               // Identifier
         1,                                                               // NumIdMapping
         OFFSET_OF (SBSA_EFI_ACPI_6_0_IO_REMAPPING_SMMU3_NODE, SmmuIdMap) // IdReference
       },
@@ -115,24 +115,26 @@ AddIortTable (
     }
   };
 
-  // NOTE(hrw): update to IORT E.e?
   SBSA_EFI_ACPI_6_0_IO_REMAPPING_RC_NODE  Rc = {
     {
       {
         EFI_ACPI_IORT_TYPE_ROOT_COMPLEX,                            // Type
         sizeof (SBSA_EFI_ACPI_6_0_IO_REMAPPING_RC_NODE),            // Length
         0,                                                          // Revision
-        0,                                                          // Reserved
+        0,                                                          // Identifier
         1,                                                          // NumIdMappings
         OFFSET_OF (SBSA_EFI_ACPI_6_0_IO_REMAPPING_RC_NODE, RcIdMap) // IdReference
       },
-      1,                                          // CacheCoherent
+      1,                                          // CacheCoherentAttribute
       0,                                          // AllocationHints
       0,                                          // Reserved
       1,                                          // MemoryAccessFlags
       EFI_ACPI_IORT_ROOT_COMPLEX_ATS_UNSUPPORTED, // AtsAttribute
       0x0,                                        // PciSegmentNumber
-      // 0,       //MemoryAddressSizeLimit
+      0,                                          // MemoryAddressSize
+      0,                                          // PasidCapabilities
+      { 0 },                                      // Reserved1[1]
+      0,                                          // Flags
     },
     {
       0x0000,                                            // InputBase

--- a/Silicon/Qemu/SbsaQemu/Drivers/SbsaQemuAcpiDxe/SbsaQemuAcpiDxe.c
+++ b/Silicon/Qemu/SbsaQemu/Drivers/SbsaQemuAcpiDxe/SbsaQemuAcpiDxe.c
@@ -129,7 +129,7 @@ AddIortTable (
       1,                                          // CacheCoherent
       0,                                          // AllocationHints
       0,                                          // Reserved
-      0,                                          // MemoryAccessFlags
+      1,                                          // MemoryAccessFlags
       EFI_ACPI_IORT_ROOT_COMPLEX_ATS_UNSUPPORTED, // AtsAttribute
       0x0,                                        // PciSegmentNumber
       // 0,       //MemoryAddressSizeLimit

--- a/Silicon/Qemu/SbsaQemu/Drivers/SbsaQemuSmbiosDxe/SbsaQemuSmbiosDxe.c
+++ b/Silicon/Qemu/SbsaQemu/Drivers/SbsaQemuSmbiosDxe/SbsaQemuSmbiosDxe.c
@@ -112,17 +112,21 @@ SMBIOS_TABLE_TYPE17  mMemDevInfoType17 = {
       0  // Reserved                        :10;
     }
   },
-  0,                        // FirwareVersion
-  0,                        // ModuleManufacturerID (unknown)
-  0,                        // ModuleProductID (unknown)
-  0,                        // MemorySubsystemControllerManufacturerID (unknown)
-  0,                        // MemorySubsystemControllerProductID (unknown)
-  0,                        // NonVolatileSize
-  0,                        // VolatileSize; initialized at runtime, refer to MemDevInfoUpdateSmbiosType17
-  0,                        // CacheSize
-  0,                        // LogicalSize (since MemoryType is not MemoryTypeLogicalNonVolatileDevice)
-  0,                        // ExtendedSpeed
-  0                         // ExtendedConfiguredMemorySpeed
+  0, // FirwareVersion
+  0, // ModuleManufacturerID (unknown)
+  0, // ModuleProductID (unknown)
+  0, // MemorySubsystemControllerManufacturerID (unknown)
+  0, // MemorySubsystemControllerProductID (unknown)
+  0, // NonVolatileSize
+  0, // VolatileSize; initialized at runtime, refer to MemDevInfoUpdateSmbiosType17
+  0, // CacheSize
+  0, // LogicalSize (since MemoryType is not MemoryTypeLogicalNonVolatileDevice)
+  0, // ExtendedSpeed
+  0, // ExtendedConfiguredMemorySpeed
+  0, // Pmic0ManufacturerID
+  0, // Pmic0RevisionNumber
+  0, // RcdManufacturerID
+  0, // RcdRevisionNumber
 };
 CHAR8                *mMemDevInfoType17Strings[] = {
   NULL


### PR DESCRIPTION
I ran FirmWare Test Suite and it gave me two errors:

- IORT

```
FAILED [HIGH] IORTMemAttrInvalid: Test 1, IORT PCI Root Complex Node Memory
Attributes are illegal, CCA cannot be 1 if CPM is 0.
```

- SMBIOS

```
FAILED [HIGH] DMIBadTableLength: Test 3, Type 17 expects length of 0x5c, has
incorrect length of 0x64
```

This branch fixes both of them. Also updates IORT to E.f version of specification.