### PR TITLE
MinPlatformPkg: Isolate FSP dependency for PlatformInitPreMem

### DIFF
--- a/Platform/Intel/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupport.c
+++ b/Platform/Intel/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupport.c
@@ -1,0 +1,10 @@
+#include <PiPei.h>
+
+UINT8
+EFIAPI
+FspGetModeSelection (
+  VOID
+  )
+{
+  return PcdGet8 (PcdFspModeSelection);
+}

--- a/Platform/Intel/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupportNull.c
+++ b/Platform/Intel/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupportNull.c
@@ -1,0 +1,10 @@
+#include <PiPei.h>
+
+UINT8
+EFIAPI
+FspGetModeSelection (
+  VOID
+  )
+{
+  return 0;
+}

--- a/Platform/Intel/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
+++ b/Platform/Intel/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
@@ -47,6 +47,12 @@ GetPlatformMemorySize (
   IN OUT  UINT64                                 *MemorySize
   );
 
+UINT8
+EFIAPI
+FspGetModeSelection (
+  VOID
+);
+
 /**
 
   This function checks the memory range in PEI.
@@ -505,7 +511,7 @@ PlatformInitPreMem (
 
   BuildMemoryTypeInformation ();
 
-  if ((!PcdGetBool (PcdFspWrapperBootMode)) || (PcdGet8 (PcdFspModeSelection) == 0)) {
+  if ((!PcdGetBool (PcdFspWrapperBootMode)) || (FspGetModeSelection() == 0)) {
     //
     // Install memory relating PPIs for EDKII native build and FSP dispatch mode
     //

--- a/Platform/Intel/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMemNonFsp.inf
+++ b/Platform/Intel/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMemNonFsp.inf
@@ -9,8 +9,8 @@
 
 [Defines]
   INF_VERSION                    = 0x00010017
-  BASE_NAME                      = PlatformInitPreMem
-  FILE_GUID                      = EEEE611D-F78F-4FB9-B868-55907F169280
+  BASE_NAME                      = PlatformInitPreMemNonFsp
+  FILE_GUID                      = BEB6F1A6-F6BC-4C34-AB32-F0390A428479
   VERSION_STRING                 = 1.0
   MODULE_TYPE                    = PEIM
   ENTRY_POINT                    = PlatformInitPreMemEntryPoint
@@ -33,14 +33,11 @@
   MinPlatformPkg/MinPlatformPkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
-  IntelSiliconPkg/IntelSiliconPkg.dec
-  IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
 
 [Pcd]
   gMinPlatformPkgTokenSpaceGuid.PcdFspWrapperBootMode          ## CONSUMES
   gMinPlatformPkgTokenSpaceGuid.PcdStopAfterDebugInit          ## CONSUMES
   gMinPlatformPkgTokenSpaceGuid.PcdStopAfterMemInit            ## CONSUMES
-  gIntelFsp2WrapperTokenSpaceGuid.PcdFspModeSelection          ## CONSUMES
 
 [FixedPcd]
   gMinPlatformPkgTokenSpaceGuid.PcdPlatformEfiAcpiReclaimMemorySize  ## CONSUMES
@@ -51,7 +48,7 @@
 
 [Sources]
   PlatformInitPreMem.c
-  FspSupport.c
+  FspSupportNull.c
 
 [Ppis]
   gEfiPeiMemoryDiscoveredPpiGuid


### PR DESCRIPTION
Provide a PlatformInitPreMemNonFsp that non Intel platforms can consume it to use PlatformInitPreMem without adding Intel specific packages as dependency.