### PR TITLE
Platform/ARM/ArmShellCmdRunAxf: Fix build with clang

### DIFF
--- a/Platform/ARM/Library/ArmShellCmdRunAxf/RunAxf.c
+++ b/Platform/ARM/Library/ArmShellCmdRunAxf/RunAxf.c
@@ -147,6 +147,7 @@ ShellDynCmdRunAxfHandler (
   ShellStatus = SHELL_SUCCESS;
   FileHandle = NULL;
   FileData = NULL;
+  FileSize = 0;
   InitializeListHead (&LoadList);
 
   // Only install if they are not there yet? First time or every time?


### PR DESCRIPTION
Clang build fails with the below warning:
  |  Platform/ARM/Library/ArmShellCmdRunAxf/RunAxf.c:216:11: error: variable
  |    'FileSize' is used uninitialized whenever 'if' condition is false
  |    [-Werror,-Wsometimes-uninitialized].
  |                if (FileHandle != NULL) {
  |                    ^~~~~~~~~~~~~~~~~~
  |  Platform/ARM/Library/ArmShellCmdRunAxf/RunAxf.c:281:38: note:
  |    uninitialized use occurs here.
  |            WriteBackDataCacheRange (FileData, FileSize);
  |                                               ^~~~~~~~
  |  Platform/ARM/Library/ArmShellCmdRunAxf/RunAxf.c:136:39: note: initialize
  |    the variable 'FileSize' to silence this warning
  |            UINTN                       FileSize;
  |                                                ^
  |                                                 = 0
  |  4 errors generated.

Fix it by initializing the variable.