### PR TITLE
GLOBAL: Align MDEPKG_NDEBUG dependent code with edk2 debug macro changes

### DIFF
--- a/Drivers/DisplayLink/DisplayLinkPkg/DisplayLinkGop/Gop.c
+++ b/Drivers/DisplayLink/DisplayLinkPkg/DisplayLinkGop/Gop.c
@@ -349,7 +349,6 @@ DlGopSendScreenUpdate (
  * @param videoMode
  * @return
  */
-#ifndef MDEPKG_NDEBUG
 STATIC inline UINT16
 CalculateRefreshRate (
     IN CONST struct VideoMode *VideoMode)
@@ -367,7 +366,7 @@ CalculateRefreshRate (
   }
   return Rate10Hz;
 }
-#endif // MDEPKG_NDEBUG
+
 /* ***************************************************************************************************** */
 /* ***************************************************************************************************** */
 /* ******************        START OF FUNCTIONS WHICH IMPLEMENT GOP INTERFACE         ****************** */

--- a/Platform/ARM/JunoPkg/Library/HdLcdArmJunoLib/HdLcdArmJuno.c
+++ b/Platform/ARM/JunoPkg/Library/HdLcdArmJunoLib/HdLcdArmJuno.c
@@ -247,7 +247,6 @@ LcdPlatformGetMaxMode (VOID)
   return  mMaxMode;
 }
 
-#if !defined(MDEPKG_NDEBUG)
 /** Probe Clock device ID of the HDLCD clock and current pixel clock frequency.
   NOTE: We will probe information only in DEBUG build.
 
@@ -380,7 +379,6 @@ ProbeHdLcdClock (
 
   return EFI_SUCCESS;
 }
-#endif
 
 /** Set the requested display mode.
 
@@ -426,17 +424,17 @@ LcdPlatformSetMode (
     return Status;
   }
 
-#if !defined(MDEPKG_NDEBUG)
   /* Avoid probing clock device ID in RELEASE build */
+  DEBUG_CODE_BEGIN ();
   Status = ProbeHdLcdClock (ClockProtocol, &ClockId);
   if (EFI_ERROR (Status)) {
     return Status;
   }
 
   ASSERT (ClockId == ARM_JUNO_CSS_CLKID_HDLCD_0);
-#else
+  DEBUG_CODE_END ();
+
   ClockId = ARM_JUNO_CSS_CLKID_HDLCD_0;
-#endif
 
   // Set HDLCD clock required for the requested mode
   Status = ClockProtocol->RateSet (
@@ -449,7 +447,7 @@ LcdPlatformSetMode (
     return Status;
   }
 
-#if !defined(MDEPKG_NDEBUG)
+  DEBUG_CODE_BEGIN ();
   UINT64  CurrentHdLcdFreq;
   // Actual value set can differ from requested frequency so verify.
   Status = ClockProtocol->RateGet (
@@ -465,7 +463,7 @@ LcdPlatformSetMode (
       CurrentHdLcdFreq
       ));
   }
-#endif
+  DEBUG_CODE_END ();
 
   return Status;
 }

--- a/Platform/ARM/JunoPkg/Library/JunoPciHostBridgeLib/JunoPciHostBridgeLib.c
+++ b/Platform/ARM/JunoPkg/Library/JunoPciHostBridgeLib/JunoPciHostBridgeLib.c
@@ -131,12 +131,9 @@ PciHostBridgeFreeRootBridges (
 {
 }
 
-
-#ifndef MDEPKG_NDEBUG
 STATIC CONST CHAR16 mPciHostBridgeLibAcpiAddressSpaceTypeStr[][4] = {
   L"Mem", L"I/O", L"Bus"
 };
-#endif
 
 /**
   Inform the platform that the resource conflict happens.

--- a/Platform/ARM/Morello/Library/PlatformLib/PlatformLibMem.c
+++ b/Platform/ARM/Morello/Library/PlatformLib/PlatformLibMem.c
@@ -14,7 +14,6 @@
 // The total number of descriptors, including the final "end-of-table" descriptor.
 #define MAX_VIRTUAL_MEMORY_MAP_DESCRIPTORS  12
 
-#if !defined(MDEPKG_NDEBUG)
 STATIC CONST CHAR8 *gTblAttrDesc[] = {
   "UNCACHED_UNBUFFERED          ",
   "NONSECURE_UNCACHED_UNBUFFERED",
@@ -27,7 +26,6 @@ STATIC CONST CHAR8 *gTblAttrDesc[] = {
   "DEVICE                       ",
   "NONSECURE_DEVICE             "
 };
-#endif
 
 #define LOG_MEM(desc) DEBUG ((                                              \
                         DEBUG_ERROR,                                        \

--- a/Platform/ARM/VExpressPkg/Library/ArmVExpressPciHostBridgeLib/ArmVExpressPciHostBridgeLib.c
+++ b/Platform/ARM/VExpressPkg/Library/ArmVExpressPciHostBridgeLib/ArmVExpressPciHostBridgeLib.c
@@ -95,11 +95,9 @@ STATIC PCI_ROOT_BRIDGE mRootBridge = {
   (EFI_DEVICE_PATH_PROTOCOL *)&mEfiPciRootBridgeDevicePath
 };
 
-#ifndef MDEPKG_NDEBUG
 STATIC CONST CHAR16 mAcpiAddrSpaceTypeStr[][4] = {
   L"Mem", L"I/O", L"Bus"
 };
-#endif
 
 /**
   Return all the root bridge instances in an array.

--- a/Platform/Hisilicon/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/Platform/Hisilicon/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -234,12 +234,9 @@ PciHostBridgeFreeRootBridges (
   }
 }
 
-
-#ifndef MDEPKG_NDEBUG
 STATIC CONST CHAR16 mPciHostBridgeLibAcpiAddressSpaceTypeStr[][4] = {
   L"Mem", L"I/O", L"Bus"
 };
-#endif
 
 /**
   Inform the platform that the resource conflict happens.

--- a/Platform/RaspberryPi/Drivers/MmcDxe/MmcDebug.c
+++ b/Platform/RaspberryPi/Drivers/MmcDxe/MmcDebug.c
@@ -8,13 +8,11 @@
 
 #include "Mmc.h"
 
-#if !defined(MDEPKG_NDEBUG)
-CONST CHAR8* mStrUnit[] = { "100kbit/s", "1Mbit/s", "10Mbit/s", "100MBit/s",
-                            "Unknown", "Unknown", "Unknown", "Unknown" };
-CONST CHAR8* mStrValue[] = { "1.0", "1.2", "1.3", "1.5", "2.0", "2.5",
-                             "3.0", "3.5", "4.0", "4.5", "5.0", "5.5",
-                             "6.0", "7.0", "8.0" };
-#endif
+STATIC CONST CHAR8* mStrUnit[] = { "100kbit/s", "1Mbit/s", "10Mbit/s", "100MBit/s",
+                                   "Unknown", "Unknown", "Unknown", "Unknown" };
+STATIC CONST CHAR8* mStrValue[] = { "1.0", "1.2", "1.3", "1.5", "2.0", "2.5",
+                                    "3.0", "3.5", "4.0", "4.5", "5.0", "5.5",
+                                    "6.0", "7.0", "8.0" };
 
 VOID
 PrintCID (

--- a/Silicon/AMD/Styx/Library/AmdStyxLib/StyxMem.c
+++ b/Silicon/AMD/Styx/Library/AmdStyxLib/StyxMem.c
@@ -19,8 +19,6 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/HobLib.h>
 
-#if !defined(MDEPKG_NDEBUG)
-
 static const char *tblAttrDesc[] =
 {
   "UNCACHED_UNBUFFERED          ",
@@ -32,7 +30,6 @@ static const char *tblAttrDesc[] =
   "DEVICE                       ",
   "NONSECURE_DEVICE             "
 };
-#endif
 
 #define LOG_MEM(desc) DEBUG ((DEBUG_ERROR, desc, VirtualMemoryTable[Index].PhysicalBase, \
                             ( VirtualMemoryTable[Index].PhysicalBase+VirtualMemoryTable[Index].Length - 1), \

--- a/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/P2sb/Library/PeiDxeSmmPchPcrLib/PchPcrLib.c
+++ b/Silicon/Intel/AlderlakeSiliconPkg/IpBlock/P2sb/Library/PeiDxeSmmPchPcrLib/PchPcrLib.c
@@ -18,7 +18,6 @@
 #include <Library/PciSegmentLib.h>
 #include <Register/PchPcrRegs.h>
 
-#ifndef MDEPKG_NDEBUG
 /**
   Checks if the offset is valid for a given memory access width. Offset must align to width size.
 
@@ -51,7 +50,6 @@ PchIsPcrOffsetValid (
     }
   }
 }
-#endif
 
 /**
   Read PCR register.
@@ -69,9 +67,7 @@ PchPcrRead32 (
   IN  UINT32                            Offset
   )
 {
-#ifndef MDEPKG_NDEBUG
   ASSERT (PchIsPcrOffsetValid (Offset, 4));
-#endif
   return MmioRead32 (PCH_PCR_ADDRESS (Pid, Offset));
 }
 
@@ -91,9 +87,7 @@ PchPcrRead16 (
   IN  UINT32                            Offset
   )
 {
-#ifndef MDEPKG_NDEBUG
   ASSERT (PchIsPcrOffsetValid (Offset, 2));
-#endif
   return MmioRead16 (PCH_PCR_ADDRESS (Pid, Offset));
 }
 
@@ -134,9 +128,7 @@ PchPcrWrite32 (
   IN  UINT32                            Data
   )
 {
-#ifndef MDEPKG_NDEBUG
   ASSERT (PchIsPcrOffsetValid (Offset, 4));
-#endif
   MmioWrite32 (PCH_PCR_ADDRESS (Pid, Offset), Data);
 
   return Data;
@@ -161,9 +153,7 @@ PchPcrWrite16 (
   IN  UINT16                            Data
   )
 {
-#ifndef MDEPKG_NDEBUG
   ASSERT (PchIsPcrOffsetValid (Offset, 2));
-#endif
   MmioWrite16 (PCH_PCR_ADDRESS (Pid, Offset), Data);
 
   return Data;

--- a/Silicon/Intel/CoffeelakeSiliconPkg/Pch/Library/PeiDxeSmmPchPcrLib/PchPcrLib.c
+++ b/Silicon/Intel/CoffeelakeSiliconPkg/Pch/Library/PeiDxeSmmPchPcrLib/PchPcrLib.c
@@ -16,7 +16,6 @@
 #include <Library/PchPcrLib.h>
 #include <Register/PchRegsPcr.h>
 
-#ifndef MDEPKG_NDEBUG
 /**
   Checks if the offset is valid for a given memory access width
 
@@ -40,7 +39,6 @@ PchIsPcrOffsetValid (
     return TRUE;
   }
 }
-#endif
 
 /**
   Read PCR register.
@@ -58,9 +56,7 @@ PchPcrRead32 (
   IN  UINT32                            Offset
   )
 {
-#ifndef MDEPKG_NDEBUG
   ASSERT (PchIsPcrOffsetValid (Offset, 4));
-#endif
   return MmioRead32 (PCH_PCR_ADDRESS (Pid, Offset));
 }
 
@@ -80,9 +76,7 @@ PchPcrRead16 (
   IN  UINT32                            Offset
   )
 {
-#ifndef MDEPKG_NDEBUG
   ASSERT (PchIsPcrOffsetValid (Offset, 2));
-#endif
   return MmioRead16 (PCH_PCR_ADDRESS (Pid, Offset));
 }
 
@@ -123,9 +117,7 @@ PchPcrWrite32 (
   IN  UINT32                            Data
   )
 {
-#ifndef MDEPKG_NDEBUG
   ASSERT (PchIsPcrOffsetValid (Offset, 4));
-#endif
   MmioWrite32 (PCH_PCR_ADDRESS (Pid, Offset), Data);
 
   return Data;
@@ -149,9 +141,7 @@ PchPcrWrite16 (
   IN  UINT16                            Data
   )
 {
-#ifndef MDEPKG_NDEBUG
   ASSERT (PchIsPcrOffsetValid (Offset, 2));
-#endif
   MmioWrite16 (PCH_PCR_ADDRESS (Pid, Offset), Data);
 
   return Data;

--- a/Silicon/Intel/CoffeelakeSiliconPkg/Pch/Library/PeiPchPolicyLib/PchPrintPolicy.c
+++ b/Silicon/Intel/CoffeelakeSiliconPkg/Pch/Library/PeiPchPolicyLib/PchPrintPolicy.c
@@ -454,9 +454,7 @@ PchPrintSerialIoConfig (
   )
 {
   UINTN Index;
-#ifndef MDEPKG_NDEBUG
   static UINT8 DeviceName[PCH_MAX_SERIALIO_CONTROLLERS][5] = {"I2C0","I2C1","I2C2","I2C3","I2C4","I2C5","SPI0","SPI1","SPI2","UA00","UA01","UA02"};
-#endif
 
   DEBUG ((DEBUG_INFO, "------------------ PCH Serial IO Config ------------------\n"));
   DEBUG_CODE_BEGIN ();

--- a/Silicon/Intel/KabylakeSiliconPkg/Pch/Library/PeiDxeSmmPchInfoLib/PchInfoLib.c
+++ b/Silicon/Intel/KabylakeSiliconPkg/Pch/Library/PeiDxeSmmPchInfoLib/PchInfoLib.c
@@ -44,9 +44,7 @@ PchStepping (
   UINT8         RevId;
   UINT16        LpcDeviceId;
   UINTN         LpcBaseAddress;
-#ifndef MDEPKG_NDEBUG
   static CHAR8  *UnsupportedPchMsg = "Unsupported PCH. Supported stepping starting from";
-#endif
 
   if (mPchStepping != PchSteppingMax) {
     return mPchStepping;

--- a/Silicon/Intel/KabylakeSiliconPkg/Pch/Library/PeiPchPolicyLib/PchPrintPolicy.c
+++ b/Silicon/Intel/KabylakeSiliconPkg/Pch/Library/PeiPchPolicyLib/PchPrintPolicy.c
@@ -434,9 +434,7 @@ PchPrintSerialIoConfig (
   )
 {
   UINTN Index;
-#ifndef MDEPKG_NDEBUG
   static CHAR16  DeviceName[11][5] = {L"I2C0",L"I2C1",L"I2C2",L"I2C3",L"I2C4",L"I2C5",L"SPI0",L"SPI1",L"UA00",L"UA01",L"UA02"};
-#endif
 
   DEBUG ((DEBUG_INFO, "------------------ PCH Serial IO Config ------------------\n"));
   DEBUG_CODE_BEGIN ();

--- a/Silicon/Intel/TigerlakeSiliconPkg/IpBlock/P2sb/Library/PeiDxeSmmPchPcrLib/PchPcrLib.c
+++ b/Silicon/Intel/TigerlakeSiliconPkg/IpBlock/P2sb/Library/PeiDxeSmmPchPcrLib/PchPcrLib.c
@@ -16,7 +16,6 @@
 #include <Library/PchPcrLib.h>
 #include <Register/PchPcrRegs.h>
 
-#ifndef MDEPKG_NDEBUG
 /**
   Checks if the offset is valid for a given memory access width. Offset must align to width size.
 
@@ -49,7 +48,6 @@ PchIsPcrOffsetValid (
     }
   }
 }
-#endif
 
 /**
   Read PCR register.
@@ -67,9 +65,7 @@ PchPcrRead32 (
   IN  UINT32                            Offset
   )
 {
-#ifndef MDEPKG_NDEBUG
   ASSERT (PchIsPcrOffsetValid (Offset, 4));
-#endif
   return MmioRead32 (PCH_PCR_ADDRESS (Pid, Offset));
 }
 
@@ -89,9 +85,7 @@ PchPcrRead16 (
   IN  UINT32                            Offset
   )
 {
-#ifndef MDEPKG_NDEBUG
   ASSERT (PchIsPcrOffsetValid (Offset, 2));
-#endif
   return MmioRead16 (PCH_PCR_ADDRESS (Pid, Offset));
 }
 
@@ -132,9 +126,7 @@ PchPcrWrite32 (
   IN  UINT32                            Data
   )
 {
-#ifndef MDEPKG_NDEBUG
   ASSERT (PchIsPcrOffsetValid (Offset, 4));
-#endif
   MmioWrite32 (PCH_PCR_ADDRESS (Pid, Offset), Data);
 
   return Data;
@@ -159,9 +151,7 @@ PchPcrWrite16 (
   IN  UINT16                            Data
   )
 {
-#ifndef MDEPKG_NDEBUG
   ASSERT (PchIsPcrOffsetValid (Offset, 2));
-#endif
   MmioWrite16 (PCH_PCR_ADDRESS (Pid, Offset), Data);
 
   return Data;

--- a/Silicon/Marvell/Drivers/Gpio/MvGpioDxe/MvGpioDxe.c
+++ b/Silicon/Marvell/Drivers/Gpio/MvGpioDxe/MvGpioDxe.c
@@ -35,7 +35,6 @@ STATIC MV_GPIO_DEVICE_PATH mDevicePathTemplate = {
   }
 };
 
-#if !defined(MDEPKG_NDEBUG)
 /**
 
 Routine Description:
@@ -79,7 +78,6 @@ MvGpioValidate (
 
   return EFI_SUCCESS;
 }
-#endif
 
 /**
 

--- a/Silicon/Marvell/Drivers/Gpio/MvPca95xxDxe/MvPca95xxDxe.c
+++ b/Silicon/Marvell/Drivers/Gpio/MvPca95xxDxe/MvPca95xxDxe.c
@@ -53,7 +53,6 @@ STATIC PCA95XX_PIN_COUNT mPca95xxPinCount[PCA95XX_MAX_ID] = {
   PCA9557_PIN_COUNT,
 };
 
-#if !defined(MDEPKG_NDEBUG)
 /**
 
 Routine Description:
@@ -101,7 +100,6 @@ MvPca95xxValidate (
 
   return EFI_SUCCESS;
 }
-#endif
 
 EFI_STATUS
 EFIAPI

--- a/Silicon/NXP/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/Silicon/NXP/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -168,13 +168,9 @@ STATIC CONST EFI_PCI_ROOT_BRIDGE_DEVICE_PATH mEfiPciRootBridgeDevicePath[] = {
   }
 };
 
-#ifndef MDEPKG_NDEBUG
-STATIC
-GLOBAL_REMOVE_IF_UNREFERENCED
-CHAR16 *mPciHostBridgeLibAcpiAddressSpaceTypeStr[] = {
+STATIC CHAR16 *mPciHostBridgeLibAcpiAddressSpaceTypeStr[] = {
   L"Mem", L"I/O", L"Bus"
 };
-#endif
 
 #define PCI_ALLOCATION_ATTRIBUTES       EFI_PCI_HOST_BRIDGE_COMBINE_MEM_PMEM | \
                                         EFI_PCI_HOST_BRIDGE_MEM64_DECODE

--- a/Silicon/Sophgo/SG2042Pkg/Drivers/MmcDxe/MmcDebug.c
+++ b/Silicon/Sophgo/SG2042Pkg/Drivers/MmcDxe/MmcDebug.c
@@ -9,13 +9,11 @@
 
 #include "Mmc.h"
 
-#if !defined(MDEPKG_NDEBUG)
-CONST CHAR8* mStrUnit[] = { "100kbit/s", "1Mbit/s", "10Mbit/s", "100MBit/s",
-                            "Unknown", "Unknown", "Unknown", "Unknown" };
-CONST CHAR8* mStrValue[] = { "1.0", "1.2", "1.3", "1.5", "2.0", "2.5",
-                             "3.0", "3.5", "4.0", "4.5", "5.0", "5.5",
-                             "6.0", "7.0", "8.0" };
-#endif
+STATIC CONST CHAR8* mStrUnit[] = { "100kbit/s", "1Mbit/s", "10Mbit/s", "100MBit/s",
+                                   "Unknown", "Unknown", "Unknown", "Unknown" };
+STATIC CONST CHAR8* mStrValue[] = { "1.0", "1.2", "1.3", "1.5", "2.0", "2.5",
+                                    "3.0", "3.5", "4.0", "4.5", "5.0", "5.5",
+                                    "6.0", "7.0", "8.0" };
 
 /**
   Print the Card Identification (CID) register.


### PR DESCRIPTION
# Description

edk2 commit [ae83c6b7fd83a5906e016a32027c1bcd792a624e](https://github.com/tianocore/edk2/commit/ae83c6b7fd83a5906e016a32027c1bcd792a624e) updates the 'null' variants of the DebugLib macros (used when MDEPKG_NDEBUG is defined) so that they explicitly discard their parameters using `if (FALSE)` code blocks. These are understood as marking the contained code as referenced but unused by all supported compilers. This avoids the need for additional MDEPKG_NDEBUG dependent code in c files, to conditionally hide static methods or functions which are only used in debug macros. Now, such code can and must be removed.

This commit updates the relevant MDEPKG_NDEBUG code in c files throughout edk2-platforms (there are only some 20 instances).

We also fix a couple of cases where the wrapped variables had incorrectly not been marked STATIC.

Since the RELEASE builds of all platforms which used this kind of code break after the above-mentioned edk2 commit, it is considered preferable to have one single cross-platform commit to edk2-platforms which resolves this, rarther than spreading the fix across multiple commits.

Additionally in a second commit, remove yet more MDEPKG_NDEBUG dependent code by refactoring Platform/ARM/JunoPkg HdLcdArmJuno.c to use DEBUG_CODE_BEGIN and DEBUG_CODE_END. This is preferable as it allows these debug macros to wrap the dependency on MDEPKG_NDEBUG, as originally intended.

- [ ] Breaking change?
  - Resolves a breaking change as described.
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Local builds.

## Integration Instructions

N/A