### PR TITLE
Platform/Intel: Add build_bios.py option to skip rebuilding BaseTools

### DIFF
--- a/Platform/Intel/build_bios.py
+++ b/Platform/Intel/build_bios.py
@@ -34,7 +34,7 @@ except ImportError:
     import configparser
 
 
-def pre_build(build_config, build_type="DEBUG", silent=False, toolchain=None):
+def pre_build(build_config, build_type="DEBUG", silent=False, toolchain=None, skip_tools=False):
     """Sets the environment variables that shall be used for the build
 
         :param build_config: The build configuration as defined in the JSON
@@ -229,24 +229,25 @@ def pre_build(build_config, build_type="DEBUG", silent=False, toolchain=None):
         shell = False
         command = ["make", "-C", os.path.join(config["BASE_TOOLS_PATH"])]
 
-    _, _, result, return_code = execute_script(command, config, shell=shell)
-    if return_code != 0:
-        #
-        # If the BaseTools build fails, then run a clean build and retry
-        #
-        clean_command = ["nmake", "-f",
-                         os.path.join(config["BASE_TOOLS_PATH"], "Makefile"),
-                         "clean"]
-        if os.name == "posix":
-            clean_command = ["make", "-C",
-                             os.path.join(config["BASE_TOOLS_PATH"]), "clean"]
-        _, _, result, return_code = execute_script(clean_command, config,
-                                                   shell=shell)
-        if return_code != 0:
-            build_failed(config)
+    if not skip_tools:
         _, _, result, return_code = execute_script(command, config, shell=shell)
         if return_code != 0:
-            build_failed(config)
+            #
+            # If the BaseTools build fails, then run a clean build and retry
+            #
+            clean_command = ["nmake", "-f",
+                            os.path.join(config["BASE_TOOLS_PATH"], "Makefile"),
+                            "clean"]
+            if os.name == "posix":
+                clean_command = ["make", "-C",
+                                os.path.join(config["BASE_TOOLS_PATH"]), "clean"]
+            _, _, result, return_code = execute_script(clean_command, config,
+                                                    shell=shell)
+            if return_code != 0:
+                build_failed(config)
+            _, _, result, return_code = execute_script(command, config, shell=shell)
+            if return_code != 0:
+                build_failed(config)
 
     #
     # build platform silicon tools
@@ -1056,6 +1057,9 @@ def get_cmd_arguments(build_config):
     parser.add_argument('--list', '-l', action=PrintPlatforms,
                         help='lists available platforms', nargs=0)
 
+    parser.add_argument('--skiptools', '-s', dest='skip_tools',
+                        help='skips rebuilding base tools', action='store_true')
+
     parser.add_argument('--cleanall', dest='clean_all',
                         help='cleans all', action='store_true')
 
@@ -1140,7 +1144,8 @@ def main():
     config = pre_build(config,
                        build_type=arguments.target,
                        toolchain=arguments.toolchain,
-                       silent=arguments.silent)
+                       silent=arguments.silent,
+                       skip_tools=arguments.skip_tools)
 
     # build selected platform
     config = build(config)


### PR DESCRIPTION
# Description

When running build_bios.py manually it is convenient to be able to avoid rebuilding BaseTools (which also involves re-running the BaseTools tests) on every run.

Even though the time to build BaseTools (once they are already built) and re-run the BaseTools tests is relatively small compared to the time taken to fully build any of these platforms, we may be debugging an issue which prevents a given platform from building entirely, or early, and which has nothing to do with changes in BaseTools, in which case it is convenient not to have to wait for the BaseTools tests to complete each time round the debug loop.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Local builds.

## Integration Instructions

N/A