### PR TITLE
Silicon/Intel/FitGen: Fix path seperator error for GNU build on Windows.

### DIFF
--- a/Silicon/Intel/Tools/FitGen/GNUmakefile
+++ b/Silicon/Intel/Tools/FitGen/GNUmakefile
@@ -4,7 +4,12 @@
 # Copyright (c) 2010-2019, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
+ifeq (Windows, $(findstring Windows,$(MAKE_HOST)))
+SEP:=$(shell echo \)
+MAKEROOT ?= $(EDK_TOOLS_PATH)$(SEP)Source$(SEP)C
+else
 MAKEROOT ?= $(EDK_TOOLS_PATH)/Source/C
+endif
 
 APPNAME = FitGen
 

--- a/Silicon/Intel/Tools/GNUmakefile
+++ b/Silicon/Intel/Tools/GNUmakefile
@@ -6,7 +6,12 @@
 #
 ##
 
-MAKEROOT = $(EDK_TOOLS_PATH)/Source/C
+ifeq (Windows, $(findstring Windows,$(MAKE_HOST)))
+SEP:=$(shell echo \)
+MAKEROOT ?= $(EDK_TOOLS_PATH)$(SEP)Source$(SEP)C
+else
+MAKEROOT ?= $(EDK_TOOLS_PATH)/Source/C
+endif
 
 APPLICATIONS = \
   FitGen \


### PR DESCRIPTION
GNUmake build currently sets path separators to '/'. 
GNUmake on Windows require path separators to be '\'. 
The path Seperator for 'MAKEROOT' is now determined by the host OS.