### PR TITLE
VExpressPkg/Library: define mAcpiAddrSpaceTypeStr regardless of build

### DIFF
--- a/Platform/ARM/VExpressPkg/Library/ArmVExpressPciHostBridgeLib/ArmVExpressPciHostBridgeLib.c
+++ b/Platform/ARM/VExpressPkg/Library/ArmVExpressPciHostBridgeLib/ArmVExpressPciHostBridgeLib.c
@@ -95,11 +95,9 @@ STATIC PCI_ROOT_BRIDGE mRootBridge = {
   (EFI_DEVICE_PATH_PROTOCOL *)&mEfiPciRootBridgeDevicePath
 };
 
-#ifndef MDEPKG_NDEBUG
 STATIC CONST CHAR16 mAcpiAddrSpaceTypeStr[][4] = {
   L"Mem", L"I/O", L"Bus"
 };
-#endif
 
 /**
   Return all the root bridge instances in an array.


### PR DESCRIPTION
Since mAcpiAddrSpaceTypeStr is defined only if build type is DEBUG, 
it makes build failure on RELEASE build while expanding macro:

/home/yeoyun01/work/uefi/edk2-platforms/Platform/ARM/VExpressPkg/Library/ArmVExpressPciHostBridgeLib/ArmVExpressPciHostBridgeLib.c:182:49: error: 'mAcpiAddrSpaceTypeStr' undeclared (first use in this function)
  182 |       ASSERT (Descriptor->ResType < ARRAY_SIZE (mAcpiAddrSpaceTypeStr));
      |                                                 ^~~~~~~~~~~~~~~~~~~~~
/home/yeoyun01/work/uefi/edk2/MdePkg/Include/Library/DebugLib.h:416:17: note: in definition of macro 'ASSERT'
  416 |         (VOID) (Expression);       \
      |                 ^~~~~~~~~~
/home/yeoyun01/work/uefi/edk2-platforms/Platform/ARM/VExpressPkg/Library/ArmVExpressPciHostBridgeLib/ArmVExpressPciHostBridgeLib.c:182:37: note: in expansion of macro 'ARRAY_SIZE'
  182 |       ASSERT (Descriptor->ResType < ARRAY_SIZE (mAcpiAddrSpaceTypeStr));
      |                                     ^~~~~~~~~~
/home/yeoyun01/work/uefi/edk2-platforms/Platform/ARM/VExpressPkg/Library/ArmVExpressPciHostBridgeLib/ArmVExpressPciHostBridgeLib.c:182:49: note: each undeclared identifier is reported only once for each function it appears in
  182 |       ASSERT (Descriptor->ResType < ARRAY_SIZE (mAcpiAddrSpaceTypeStr));
      |                                                 ^~~~~~~~~~~~~~~~~~~~~
/home/yeoyun01/work/uefi/edk2/MdePkg/Include/Library/DebugLib.h:416:17: note: in definition of macro 'ASSERT'
  416 |         (VOID) (Expression);       \
      |                 ^~~~~~~~~~
/home/yeoyun01/work/uefi/edk2-platforms/Platform/ARM/VExpressPkg/Library/ArmVExpressPciHostBridgeLib/ArmVExpressPciHostBridgeLib.c:182:37: note: in expansion of macro 'ARRAY_SIZE'
  182 |       ASSERT (Descriptor->ResType < ARRAY_SIZE (mAcpiAddrSpaceTypeStr));
      |                                     ^~~~~~~~~~
Building ... /home/yeoyun01/work/uefi/edk2/MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf [AARCH64]

Remove MDEPKG_NDEBUG conditional define for mAcpiAddrSpaceTypeStr.