### PR TITLE
Platform/Sophgo: Adding BaseRiscVFpuLib.inf in SG2042.dsc

### DIFF
--- a/Platform/Sophgo/SG2042_EVB_Board/SG2042.dsc
+++ b/Platform/Sophgo/SG2042_EVB_Board/SG2042.dsc
@@ -144,6 +144,7 @@
 
   # RISC-V Architectural Libraries
   RiscVSbiLib|MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.inf
+  RiscVFpuLib|UefiCpuPkg/Library/BaseRiscVFpuLib/BaseRiscVFpuLib.inf
   RiscVMmuLib|UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.inf
   CpuExceptionHandlerLib|UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BaseRiscV64CpuExceptionHandlerLib.inf
 


### PR DESCRIPTION
Hi Maintainers,

We have found that without BaseRiscVFpuLib.inf , the SG2042.fv cannot be successfully build. So we added it in SG2042.dsc.

Thanks for the time,
Zixuan Ding