### PR TITLE
AmdPlatformPkg/DynamicTables: Fix Coverity issue

### DIFF
--- a/Platform/AMD/AmdPlatformPkg/DynamicTables/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/AMD/AmdPlatformPkg/DynamicTables/ConfigurationManagerDxe/ConfigurationManager.c
@@ -175,7 +175,6 @@ EDKII_PLATFORM_REPOSITORY_INFO  mAmdPlatformRepositoryInfo = {
 /** A structure describing the configuration manager protocol interface.
 */
 STATIC
-CONST
 EDKII_CONFIGURATION_MANAGER_PROTOCOL  mAmdPlatformConfigManagerProtocol = {
   CREATE_REVISION (1,   0),
   AmdPlatformGetObject,

--- a/Platform/AMD/AmdPlatformPkg/DynamicTables/ConfigurationManagerDxe/NameSpaceObject.c
+++ b/Platform/AMD/AmdPlatformPkg/DynamicTables/ConfigurationManagerDxe/NameSpaceObject.c
@@ -32,6 +32,10 @@ HandleCmObject (
   IN  OUT   CM_OBJ_DESCRIPTOR   *CONST  CmObjectDesc
   )
 {
+  if ((ObjectSize > MAX_UINT32) || (ObjectCount > MAX_UINT32)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
   CmObjectDesc->ObjectId = CmObjectId;
   CmObjectDesc->Size     = (UINT32)ObjectSize;
   CmObjectDesc->Data     = (VOID *)Object;


### PR DESCRIPTION
Fix for coverity reported issue on ConfigurationManagerDxe.

Fix the possible integer overflow.
Fix the typecast of const to non-const.

Cc: Abner Chang <abner.chang@amd.com>
Cc: Paul Grimes <paul.grimes@amd.com>