### PR TITLE
Pkg-Module: Features/VirtualKeyboardDxe PART 2

### DIFF
--- a/Features/Intel/UserInterface/VirtualKeyboardFeaturePkg/VirtualKeyboardDxe/Keyboard.c
+++ b/Features/Intel/UserInterface/VirtualKeyboardFeaturePkg/VirtualKeyboardDxe/Keyboard.c
@@ -883,7 +883,7 @@ VkApiStart (
 
   KeyData.KeyState.KeyToggleState = 0;
   KeyData.KeyState.KeyShiftState  = 0;
-  KeyData.Key.ScanCode            = SCAN_NULL;
+  KeyData.Key.UnicodeChar         = CHAR_NULL;
   NotifyHandle                    = NULL;
 
   for (KeyData.Key.ScanCode = SCAN_UP; KeyData.Key.ScanCode <= SCAN_ESC; KeyData.Key.ScanCode++) {


### PR DESCRIPTION
The Keyboard.c driver did not include ScanCodes like F1,F2,F12,etc. and UnicodeChars like Backspace, Tab in VK_NOTIFY NotifyList which is why these keys were not getting registered and not getting pushed in the KeyBuffer stack which resulted in undefined behavior of continuous backspace and not recognizing the relevant key push after the buffer overflow condition.