### PR TITLE
JadePkg/AcpiTables: Fix mapping MMIO regions as cacheable

### DIFF
--- a/Platform/Ampere/JadePkg/Ac02AcpiTables/PCI-S0.Rca01.asi
+++ b/Platform/Ampere/JadePkg/Ac02AcpiTables/PCI-S0.Rca01.asi
@@ -139,7 +139,7 @@ Device (PCI0) {
       PosDecode,            // Decode
       MinFixed,             // IsMinFixed
       MaxFixed,             // IsMaxFixed
-      Cacheable,            // Cacheable
+      NonCacheable,         // NonCacheable
       ReadWrite,            // ReadAndWrite
       0x0000000000000000,   // AddressGranularity - GRA
       0x0000000040000000,   // AddressMinimum - MIN
@@ -153,7 +153,7 @@ Device (PCI0) {
       PosDecode,            // Decode
       MinFixed,             // IsMinFixed
       MaxFixed,             // IsMaxFixed
-      Cacheable,            // Cacheable
+      NonCacheable,         // NonCacheable
       ReadWrite,            // ReadAndWrite
       0x0000000000000000,   // AddressGranularity - GRA
       0x0000300000000000,   // AddressMinimum - MIN
@@ -470,7 +470,7 @@ Device (PCI1) {
       PosDecode,            // Decode
       MinFixed,             // IsMinFixed
       MaxFixed,             // IsMaxFixed
-      Cacheable,            // Cacheable
+      NonCacheable,         // NonCacheable
       ReadWrite,            // ReadAndWrite
       0x0000000000000000,   // AddressGranularity - GRA
       0x0000000050000000,   // AddressMinimum - MIN
@@ -484,7 +484,7 @@ Device (PCI1) {
       PosDecode,            // Decode
       MinFixed,             // IsMinFixed
       MaxFixed,             // IsMaxFixed
-      Cacheable,            // Cacheable
+      NonCacheable,         // NonCacheable
       ReadWrite,            // ReadAndWrite
       0x0000000000000000,   // AddressGranularity - GRA
       0x0000340000000000,   // AddressMinimum - MIN

--- a/Platform/Ampere/JadePkg/AcpiTables/PCI-S0.Rca01.asi
+++ b/Platform/Ampere/JadePkg/AcpiTables/PCI-S0.Rca01.asi
@@ -145,7 +145,7 @@
         PosDecode,            // Decode
         MinFixed,             // IsMinFixed
         MaxFixed,             // IsMaxFixed
-        Cacheable,            // Cacheable
+        NonCacheable,         // NonCacheable
         ReadWrite,            // ReadAndWrite
         0x0000000000000000,   // AddressGranularity - GRA
         0x0000000040000000,   // AddressMinimum - MIN
@@ -159,7 +159,7 @@
         PosDecode,            // Decode
         MinFixed,             // IsMinFixed
         MaxFixed,             // IsMaxFixed
-        Cacheable,            // Cacheable
+        NonCacheable,         // NonCacheable
         ReadWrite,            // ReadAndWrite
         0x0000000000000000,   // AddressGranularity - GRA
         0x0000300000000000,   // AddressMinimum - MIN
@@ -482,7 +482,7 @@
         PosDecode,            // Decode
         MinFixed,             // IsMinFixed
         MaxFixed,             // IsMaxFixed
-        Cacheable,            // Cacheable
+        NonCacheable,         // NonCacheable
         ReadWrite,            // ReadAndWrite
         0x0000000000000000,   // AddressGranularity - GRA
         0x0000000050000000,   // AddressMinimum - MIN
@@ -496,7 +496,7 @@
         PosDecode,            // Decode
         MinFixed,             // IsMinFixed
         MaxFixed,             // IsMaxFixed
-        Cacheable,            // Cacheable
+        NonCacheable,         // NonCacheable
         ReadWrite,            // ReadAndWrite
         0x0000000000000000,   // AddressGranularity - GRA
         0x0000340000000000,   // AddressMinimum - MIN


### PR DESCRIPTION
This corrects the MMIO regions mapping in ACPI to be marked as NonCacheable, aligning with the precise configuration in PCI-S0.asi.

Reported-by: Chuong Tran <chuong@os.amperecomputing.com>