### PR TITLE
XiangshanSeriesPkg: Add BaseRiscVFpuLib.inf in NanhuDev.dsc

### DIFF
--- a/Platform/Bosc/XiangshanSeriesPkg/NanhuDev/NanhuDev.dsc
+++ b/Platform/Bosc/XiangshanSeriesPkg/NanhuDev/NanhuDev.dsc
@@ -145,6 +145,7 @@
 
   # RISC-V Architectural Libraries
   RiscVSbiLib|MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.inf
+  RiscVFpuLib|UefiCpuPkg/Library/BaseRiscVFpuLib/BaseRiscVFpuLib.inf
   RiscVMmuLib|UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.inf
   CpuExceptionHandlerLib|UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BaseRiscV64CpuExceptionHandlerLib.inf
 


### PR DESCRIPTION
Add the necessary dependency libraries to build NANHUDEV.fd


Cc: Yang Wang <wangyang@bosc.ac.cn>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Sunil V L <sunilvl@ventanamicro.com>
Cc: Daniel Schaefer <git@danielschaefer.me>