### PR TITLE
ManageabilityPkg/IpmiProtocol: Fix build error due to missing PCDs

### DIFF
--- a/Features/ManageabilityPkg/Universal/IpmiProtocol/Pei/IpmiPpiPei.inf
+++ b/Features/ManageabilityPkg/Universal/IpmiProtocol/Pei/IpmiPpiPei.inf
@@ -50,6 +50,10 @@
 [FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress   # Used as default KCS I/O base adddress
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSsifSmbusSlaveAddr
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialRequesterAddress
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialResponderAddress
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialRequesterLun
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialResponderLun
 
 [Depex]
   TRUE

--- a/Features/ManageabilityPkg/Universal/IpmiProtocol/Smm/IpmiProtocolSmm.inf
+++ b/Features/ManageabilityPkg/Universal/IpmiProtocol/Smm/IpmiProtocolSmm.inf
@@ -49,6 +49,10 @@
 [FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress   # Used as default KCS I/O base adddress
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSsifSmbusSlaveAddr
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialRequesterAddress
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialResponderAddress
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialRequesterLun
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialResponderLun
 
 [Depex]
   TRUE


### PR DESCRIPTION
This adds recent PCDs for IPMI Serial for IpmiProtocol PEI and SMM to fix the compilation error.