### PR TITLE
Platform/Sgi: Add Firmware Version Support

### DIFF
--- a/Platform/ARM/SgiPkg/Drivers/SmbiosPlatformDxe/Type0BiosInformation.c
+++ b/Platform/ARM/SgiPkg/Drivers/SmbiosPlatformDxe/Type0BiosInformation.c
@@ -16,8 +16,8 @@
 
 #define TYPE0_STRINGS                                   \
   "ARM LTD\0"                   /* Vendor */            \
-  "EDK II\0"                    /* BiosVersion */       \
-  __DATE__"\0"                  /* BiosReleaseDate */   \
+  EDK2_PLAT_FW_REL_VERSION      /* BiosVersion */       \
+  "\0"__DATE__"\0"              /* BiosReleaseDate */   \
   "\0"
 
 typedef enum {

--- a/Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
+++ b/Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
@@ -23,7 +23,9 @@
   DEFINE CPPC_EN                            = FALSE
 
 [BuildOptions]
-  *_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES
+  # EDK2_PLAT_FW_REL_VERSION macro resolve to value like RD-INFRA-2024.09.30.
+  # This value is set in build-uefi.sh
+  *_*_*_CC_FLAGS = -DDISABLE_NEW_DEPRECATED_INTERFACES -DEDK2_PLAT_FW_REL_VERSION=\"$(EDK2_PLAT_FW_REL_VERSION)\"
 
 [LibraryClasses.common]
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf


### PR DESCRIPTION
BiosVersion value is hardcoded as "EDK II" and it appears same in SMBIOS type 0 record firmware version string. This is not meaningful, it remains unchanged across releases and it does not match the version string in the release notes.

So updated BiosVersion from “EDK II” to a format that reflects the release version, such as “RD-INFRA-YYYY.MM.DD” (e.g., “RD-INFRA-2024.09.30”).