### PR TITLE
Drivers/ASIX: Bugfix for ASIX Ax88772c driver

### DIFF
--- a/Drivers/ASIX/Bus/Usb/UsbNetworking/Ax88772c/DriverBinding.c
+++ b/Drivers/ASIX/Bus/Usb/UsbNetworking/Ax88772c/DriverBinding.c
@@ -58,7 +58,7 @@ DriverSupported (
       //  Validate the adapter
       //
       if (VENDOR_ID == Device.IdVendor) {
-        if (PRODUCT_AX88772B_ID != Device.IdProduct) {
+        if (PRODUCT_AX88772B_ID == Device.IdProduct) {
         } else if (PRODUCT_AX88772B_ASUS_ID == Device.IdProduct) {
         } else if (PRODUCT_AX88772A_ID == Device.IdProduct) {
         } else if (PRODUCT_ID == Device.IdProduct) {


### PR DESCRIPTION
Support the USB NIC whose product id is PRODUCT_AX88772B_ID.