### PR TITLE
Add GitHub Issue Templates and Automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,334 @@
+# TianoCore edk2-platforms GitHub Bug Report Template
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: 🐛 Bug Report
+description: File a bug report
+title: "[Bug]: <title>"
+labels: ["type:bug", "state:needs-triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        👋 Thanks for taking the time to fill out this bug report!
+
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: |
+        Please search to see if an issue already exists for the bug you encountered.
+        &nbsp;&nbsp;[Seach existing issues](https://github.com/tianocore/edk2/issues)
+      options:
+      - label: I have searched existing issues
+        required: true
+
+  - type: checkboxes
+    id: bug_type
+    attributes:
+      label: Bug Type
+      description: |
+        What type of code does this bug affect?
+      options:
+        - label: Firmware
+        - label: Tool
+        - label: Unit Test
+
+  - type: checkboxes
+    id: code_first
+    attributes:
+      label: Code first?
+      description: |
+        Is this part of a [code first](https://github.com/tianocore/tianocore.github.io/wiki/EDK-II-Code-First-Process) change?
+      options:
+        - label: "Yes"
+
+  - type: dropdown
+    id: packages_impacted
+    attributes:
+      label:  What packages are impacted?
+      description: |
+        *Select all that apply*
+      multiple: true
+      options:
+        - All
+        - 96Boards/96Boards
+        - ADLINK/ComHpcAltPkg
+        - Drivers/ASIX/Asix
+        - Drivers/DisplayLink/DisplayLinkPkg
+        - Drivers/OpTee/OpteeRpmbPkg
+        - Drivers/OptionRomPkg
+        - Features/Ext4Pkg
+        - Features/Intel/AdvancedFeaturePkg
+        - Features/Intel/Debugging
+        - Features/Intel/Network
+        - Features/Intel/OutOfBandManagement
+        - Features/Intel/PlatformPayloadFeaturePkg
+        - Features/Intel/PowerManagement
+        - Features/Intel/SystemInformation
+        - Features/Intel/TemplateFeaturePkg
+        - Features/Intel/UserInterface
+        - Features/ManageabilityPkg
+        - Platform/AMD/AgesaModulePkg
+        - Platform/AMD/AgesaPkg
+        - Platform/AMD/AmdCbsPkg
+        - Platform/AMD/AmdCpmPkg
+        - Platform/AMD/AmdMinBoardPkg
+        - Platform/AMD/AmdPlatformPkg
+        - Platform/AMD/OverdriveBoard
+        - Platform/AMD/VanGoghBoard
+        - Platform/ARM/ARM
+        - Platform/ARM/JunoPkg
+        - Platform/ARM/MorelloPlatform
+        - Platform/ARM/N1SdpPlatform
+        - Platform/ARM/SgiPkg
+        - Platform/ARM/VExpressPkg
+        - Platform/Ampere/JadePkg
+        - Platform/Ampere/Tools
+        - Platform/BeagleBoard/BeagleBoardPkg
+        - Platform/Bosc/XiangshanSeriesPkg
+        - Platform/Hisilicon/D03
+        - Platform/Hisilicon/D05
+        - Platform/Hisilicon/D06
+        - Platform/Hisilicon/HiKey
+        - Platform/Hisilicon/HiKey960
+        - Platform/Intel/AlderlakeOpenBoardPkg
+        - Platform/Intel/BoardModulePkg
+        - Platform/Intel/CometlakeOpenBoardPkg
+        - Platform/Intel/KabylakeOpenBoardPkg
+        - Platform/Intel/MinPlatformPkg
+        - Platform/Intel/PurleyOpenBoardPkg
+        - Platform/Intel/QuarkPlatformPkg
+        - Platform/Intel/SimicsOpenBoardPkg
+        - Platform/Intel/TigerlakeOpenBoardPkg
+        - Platform/Intel/Vlv2TbltDevicePkg
+        - Platform/Intel/WhiskeylakeOpenBoardPkg
+        - Platform/Intel/WhitleyOpenBoardPkg
+        - Platform/LeMaker/CelloBoard
+        - Platform/Loongson/LoongArchQemuPkg
+        - Platform/Marvell/Armada70x0Db
+        - Platform/Marvell/Armada80x0Db
+        - Platform/Marvell/Cn913xDb
+        - Platform/Marvell/OdysseyPkg
+        - Platform/NXP/ConfigurationManagerPkg
+        - Platform/NXP/LS1043aRdbPkg
+        - Platform/NXP/LS1046aFrwyPkg
+        - Platform/NXP/LX2160aRdbPkg
+        - Platform/Phytium/DurianPkg
+        - Platform/Qemu/QemuOpenBoardPkg
+        - Platform/Qemu/SbsaQemu
+        - Platform/RISC-V/PlatformPkg
+        - Platform/RaspberryPi/RaspberryPi
+        - Platform/RaspberryPi/RPi3
+        - Platform/RaspberryPi/RPi4
+        - Platform/SiFive/U5SeriesPkg
+        - Platform/Socionext/DeveloperBox
+        - Platform/Socionext/SynQuacerEvalBoard
+        - Platform/SoftIron/Overdrive1000Board
+        - Platform/SolidRun/Armada80x0McBin
+        - Platform/SolidRun/Cn913xCEx7Eval
+        - Platform/Sophgo/Documents
+        - Platform/Sophgo/SG2042_EVB_Board
+        - Platform/StandaloneMm/PlatformStandaloneMmPkg
+        - Silicon/AMD/Styx
+        - Silicon/AMD/VanGoghBoard
+        - Silicon/ARM/NeoverseN1Soc
+        - Silicon/Ampere/AmpereAltraPkg
+        - Silicon/Ampere/AmpereSiliconPkg
+        - Silicon/Atmel/AtSha204a
+        - Silicon/Bosc/NanHuPkg
+        - Silicon/Broadcom/Bcm27xx
+        - Silicon/Broadcom/Bcm283x
+        - Silicon/Broadcom/Drivers
+        - Silicon/HiSilicon/Drivers
+        - Silicon/HiSilicon/Hi1610
+        - Silicon/HiSilicon/Hi1616
+        - Silicon/HiSilicon/Hi1620
+        - Silicon/HiSilicon/Hi3660
+        - Silicon/HiSilicon/Hi6220
+        - Silicon/HiSilicon/HisiPkg
+        - Silicon/Intel/AlderlakeSiliconPkg
+        - Silicon/Intel/CoffeelakeSiliconPkg
+        - Silicon/Intel/IntelSiliconPkg
+        - Silicon/Intel/KabylakeSiliconPkg
+        - Silicon/Intel/PurleyRefreshSiliconPkg
+        - Silicon/Intel/QuarkSocPkg
+        - Silicon/Intel/SimicsIch10Pkg
+        - Silicon/Intel/SimicsX58SktPkg
+        - Silicon/Intel/TigerlakeSiliconPkg
+        - Silicon/Intel/Tools
+        - Silicon/Intel/Vlv2DeviceRefCodePkg
+        - Silicon/Intel/WhitleySiliconPkg
+        - Silicon/Marvell/Applications
+        - Silicon/Marvell/Armada7k8k
+        - Silicon/Marvell/Documentation
+        - Silicon/Marvell/Drivers
+        - Silicon/Marvell/Library
+        - Silicon/Marvell/MarvellSiliconPkg
+        - Silicon/Marvell/OcteonTx
+        - Silicon/Marvell/OdysseyPkg
+        - Silicon/Maxim
+        - Silicon/NXP/Chassis2
+        - Silicon/NXP/Chassis3V2
+        - Silicon/NXP/LS1043A
+        - Silicon/NXP/LS1046A
+        - Silicon/NXP/LX2160A
+        - Silicon/NXP/NxpQoriqLs
+        - Silicon/Openmoko
+        - Silicon/Phytium/FT2000-4Pkg
+        - Silicon/Phytium/PhytiumCommonPkg
+        - Silicon/Qemu/SbsaQemu
+        - Silicon/RISC-V/ProcessorPkg
+        - Silicon/SiFive/SiFive
+        - Silicon/Socionext/SynQuacer
+        - Silicon/Sophgo/SG2042Pkg
+        - SiliconSynopsys/DesignWare
+        - Silicon/TexasInstruments/Omap35xxPkg
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: targets_impacted
+    attributes:
+      label: Which targets are impacted by this bug?
+      description: |
+        *Select all that apply*
+      multiple: true
+      options:
+        - DEBUG
+        - NO-TARGET
+        - NOOPT
+        - RELEASE
+
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current Behavior
+      description: A concise description of the bug that you're experiencing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        <example>
+        1. In this environment (OS, toolchain, platform info, etc.)...
+        2. Acquire the source code using these commands...
+        3. Build the code using these commands...
+        4. Flash the image using these commands...
+        5. Boot using this process...
+        6. Change option(s)...
+        7. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: build_environment
+    attributes:
+      label: Build Environment
+      description: |
+        Examples:
+          - **OS**: Ubuntu 24.04 or Windows 11...
+          - **Tool Chain**: GCC5 or VS2022 or CLANGPDB...
+      value: |
+          - OS(s):
+          - Tool Chain(s):
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: version_info
+    attributes:
+      label: Version Information
+      description: >
+        What version of this repo is known to reproduce the problem?
+
+
+        The problem is assumed to be present from this version and later. If an earlier version is not known other than
+        the latest commit, indicate that and put the current *edk2/master* commit SHA.
+      placeholder: |
+        Commit: <SHA>
+        -or-
+        Tag: <Tag>
+      render: text
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        **Urgency Key**
+        - 🟢 **Low**
+          - A minor change with little to no important functional impact
+          - It is not important to fix this in a specific time frame
+        - 🟡 **Medium**
+          - An important change with a functional impact
+          - Will be prioritized above *low* issues in the normal course of development
+        - 🔥 **High**
+          - A critical change that has a significant functional impact
+          - Must be fixed immediately
+
+  - type: dropdown
+    id: urgency
+    attributes:
+      label: Urgency
+      description: How urgent is it to fix this bug?
+      multiple: false
+      options:
+        - Low
+        - Medium
+        - High
+    validations:
+      required: true
+
+  - type: dropdown
+    id: fix_owner
+    attributes:
+      label: Are you going to fix this?
+      description: Indicate if you are going to fix this or requesting someone else fix it.
+      multiple: false
+      options:
+        - I will fix it
+        - Someone else needs to fix it
+    validations:
+      required: true
+
+  - type: dropdown
+    id: needs_maintainer_feedback
+    attributes:
+      label: Do you need maintainer feedback?
+      description: Indicate if you would like a maintainer to provide feedback on this submission.
+      multiple: false
+      options:
+        - No maintainer feedback needed
+        - Maintainer feedback requested
+    validations:
+      required: true
+
+  - type: textarea
+    id: anything_else
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering.
+
+        Serial debug logs and/or debugger logs are especially helpful!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,20 @@
+## @file
+# GitHub issue configuration file.
+#
+# This file is meant to direct contributors familiar with GitHub's issue tracker
+# to the external resources used by TianoCore.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+contact_links:
+  - name: Reporting Security Issues
+    url: https://github.com/tianocore/tianocore.github.io/wiki/Reporting-Security-Issues
+    about: Read the wiki page that describes the process here
+  - name: EDK II Development Mailing List
+    url: https://edk2.groups.io/g/devel
+    about: Ask questions on the mailing list (devel@edk2.groups.io)
+  - name: EDK II Platforms Discussions
+    url: https://github.com/tianocore/edk2-platforms/discussions
+    about: You can also reach out on the Discussion section for this repository

--- a/.github/ISSUE_TEMPLATE/documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request.yml
@@ -1,0 +1,87 @@
+# TianoCore edk2-platforms GitHub Documentation Request Template
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: 📖 Documentation Request
+description: Request a documentation change
+title: "[Documentation]: <title>"
+labels: ["type:documentation-request", "state:needs-triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: >
+        👋 Thanks for taking the time to help us improve our documentation!
+
+
+        This form is used to request documentation changes that should be contributed to the **edk2** repository.
+
+
+        For example, to improve API documentation in a library class header file or add a markdown file to sit
+        alongside the code implementation of a particularly complex feature or module.
+
+
+        - To file an issue for a TianoCore specification, refer to [these instructions](https://github.com/tianocore-docs/edk2-TemplateSpecification/wiki/TianoCore-Documents-GitBook-Overview)
+        and reference the specifications In the [TianoCore Docs organization](https://github.com/tianocore-docs).
+
+        - For UEFI specifications, refer to the [UEFI Forum](https://uefi.org/specifications) website.
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+  - type: textarea
+    id: request_description
+    attributes:
+      label: Request Description
+      description: |
+        A clear and concise description of what needs to change (*insert images or attachments if relevant*)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: request_owner
+    attributes:
+      label: Are you going to make the change?
+      description: Indicate if you are going to make this change or requesting someone else make it.
+      multiple: false
+      options:
+        - I will make the change
+        - Someone else needs to make the change
+    validations:
+      required: true
+
+  - type: dropdown
+    id: needs_maintainer_feedback
+    attributes:
+      label: Do you need maintainer feedback?
+      description: Indicate if you would like a maintainer to provide feedback on this submission.
+      multiple: false
+      options:
+        - No maintainer feedback needed
+        - Maintainer feedback requested
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: code_first
+    attributes:
+      label: Code first?
+      description: |
+        Is this part of a [code first](https://github.com/tianocore/tianocore.github.io/wiki/EDK-II-Code-First-Process) change?
+      options:
+        - label: "Yes"
+
+  - type: textarea
+    id: anything_else
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the request.
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,256 @@
+# TianoCore edk2-platforms GitHub Feature Request Template
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: 🚀 Feature Request
+description: Request a feature change
+title: "[Feature]: <title>"
+labels: ["type:feature-request", "state:needs-triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        👋 Thanks for taking the time to help us improve our features!
+
+  - type: textarea
+    id: feature_overview
+    attributes:
+      label: Feature Overview
+      description: Provide a high-level summary of your feature request.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution_overview
+    attributes:
+      label: Solution Overview
+      description: Give a clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives_considered
+    attributes:
+      label: Alternatives Considered
+      description: Describe alternatives you've considered.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: packages_impacted
+    attributes:
+      label: What packages are impacted?
+      description: |
+        *Select all that apply*
+      multiple: true
+      options:
+        - All
+        - 96Boards/96Boards
+        - ADLINK/ComHpcAltPkg
+        - Drivers/ASIX/Asix
+        - Drivers/DisplayLink/DisplayLinkPkg
+        - Drivers/OpTee/OpteeRpmbPkg
+        - Drivers/OptionRomPkg
+        - Features/Ext4Pkg
+        - Features/Intel/AdvancedFeaturePkg
+        - Features/Intel/Debugging
+        - Features/Intel/Network
+        - Features/Intel/OutOfBandManagement
+        - Features/Intel/PlatformPayloadFeaturePkg
+        - Features/Intel/PowerManagement
+        - Features/Intel/SystemInformation
+        - Features/Intel/TemplateFeaturePkg
+        - Features/Intel/UserInterface
+        - Features/ManageabilityPkg
+        - Platform/AMD/AgesaModulePkg
+        - Platform/AMD/AgesaPkg
+        - Platform/AMD/AmdCbsPkg
+        - Platform/AMD/AmdCpmPkg
+        - Platform/AMD/AmdMinBoardPkg
+        - Platform/AMD/AmdPlatformPkg
+        - Platform/AMD/OverdriveBoard
+        - Platform/AMD/VanGoghBoard
+        - Platform/ARM/ARM
+        - Platform/ARM/JunoPkg
+        - Platform/ARM/MorelloPlatform
+        - Platform/ARM/N1SdpPlatform
+        - Platform/ARM/SgiPkg
+        - Platform/ARM/VExpressPkg
+        - Platform/Ampere/JadePkg
+        - Platform/Ampere/Tools
+        - Platform/BeagleBoard/BeagleBoardPkg
+        - Platform/Bosc/XiangshanSeriesPkg
+        - Platform/Hisilicon/D03
+        - Platform/Hisilicon/D05
+        - Platform/Hisilicon/D06
+        - Platform/Hisilicon/HiKey
+        - Platform/Hisilicon/HiKey960
+        - Platform/Intel/AlderlakeOpenBoardPkg
+        - Platform/Intel/BoardModulePkg
+        - Platform/Intel/CometlakeOpenBoardPkg
+        - Platform/Intel/KabylakeOpenBoardPkg
+        - Platform/Intel/MinPlatformPkg
+        - Platform/Intel/PurleyOpenBoardPkg
+        - Platform/Intel/QuarkPlatformPkg
+        - Platform/Intel/SimicsOpenBoardPkg
+        - Platform/Intel/TigerlakeOpenBoardPkg
+        - Platform/Intel/Vlv2TbltDevicePkg
+        - Platform/Intel/WhiskeylakeOpenBoardPkg
+        - Platform/Intel/WhitleyOpenBoardPkg
+        - Platform/LeMaker/CelloBoard
+        - Platform/Loongson/LoongArchQemuPkg
+        - Platform/Marvell/Armada70x0Db
+        - Platform/Marvell/Armada80x0Db
+        - Platform/Marvell/Cn913xDb
+        - Platform/Marvell/OdysseyPkg
+        - Platform/NXP/ConfigurationManagerPkg
+        - Platform/NXP/LS1043aRdbPkg
+        - Platform/NXP/LS1046aFrwyPkg
+        - Platform/NXP/LX2160aRdbPkg
+        - Platform/Phytium/DurianPkg
+        - Platform/Qemu/QemuOpenBoardPkg
+        - Platform/Qemu/SbsaQemu
+        - Platform/RISC-V/PlatformPkg
+        - Platform/RaspberryPi/RaspberryPi
+        - Platform/RaspberryPi/RPi3
+        - Platform/RaspberryPi/RPi4
+        - Platform/SiFive/U5SeriesPkg
+        - Platform/Socionext/DeveloperBox
+        - Platform/Socionext/SynQuacerEvalBoard
+        - Platform/SoftIron/Overdrive1000Board
+        - Platform/SolidRun/Armada80x0McBin
+        - Platform/SolidRun/Cn913xCEx7Eval
+        - Platform/Sophgo/Documents
+        - Platform/Sophgo/SG2042_EVB_Board
+        - Platform/StandaloneMm/PlatformStandaloneMmPkg
+        - Silicon/AMD/Styx
+        - Silicon/AMD/VanGoghBoard
+        - Silicon/ARM/NeoverseN1Soc
+        - Silicon/Ampere/AmpereAltraPkg
+        - Silicon/Ampere/AmpereSiliconPkg
+        - Silicon/Atmel/AtSha204a
+        - Silicon/Bosc/NanHuPkg
+        - Silicon/Broadcom/Bcm27xx
+        - Silicon/Broadcom/Bcm283x
+        - Silicon/Broadcom/Drivers
+        - Silicon/HiSilicon/Drivers
+        - Silicon/HiSilicon/Hi1610
+        - Silicon/HiSilicon/Hi1616
+        - Silicon/HiSilicon/Hi1620
+        - Silicon/HiSilicon/Hi3660
+        - Silicon/HiSilicon/Hi6220
+        - Silicon/HiSilicon/HisiPkg
+        - Silicon/Intel/AlderlakeSiliconPkg
+        - Silicon/Intel/CoffeelakeSiliconPkg
+        - Silicon/Intel/IntelSiliconPkg
+        - Silicon/Intel/KabylakeSiliconPkg
+        - Silicon/Intel/PurleyRefreshSiliconPkg
+        - Silicon/Intel/QuarkSocPkg
+        - Silicon/Intel/SimicsIch10Pkg
+        - Silicon/Intel/SimicsX58SktPkg
+        - Silicon/Intel/TigerlakeSiliconPkg
+        - Silicon/Intel/Tools
+        - Silicon/Intel/Vlv2DeviceRefCodePkg
+        - Silicon/Intel/WhitleySiliconPkg
+        - Silicon/Marvell/Applications
+        - Silicon/Marvell/Armada7k8k
+        - Silicon/Marvell/Documentation
+        - Silicon/Marvell/Drivers
+        - Silicon/Marvell/Library
+        - Silicon/Marvell/MarvellSiliconPkg
+        - Silicon/Marvell/OcteonTx
+        - Silicon/Marvell/OdysseyPkg
+        - Silicon/Maxim
+        - Silicon/NXP/Chassis2
+        - Silicon/NXP/Chassis3V2
+        - Silicon/NXP/LS1043A
+        - Silicon/NXP/LS1046A
+        - Silicon/NXP/LX2160A
+        - Silicon/NXP/NxpQoriqLs
+        - Silicon/Openmoko
+        - Silicon/Phytium/FT2000-4Pkg
+        - Silicon/Phytium/PhytiumCommonPkg
+        - Silicon/Qemu/SbsaQemu
+        - Silicon/RISC-V/ProcessorPkg
+        - Silicon/SiFive/SiFive
+        - Silicon/Socionext/SynQuacer
+        - Silicon/Sophgo/SG2042Pkg
+        - SiliconSynopsys/DesignWare
+        - Silicon/TexasInstruments/Omap35xxPkg
+        - Other
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        **Urgency Key**
+        - 🟢 **Low**
+          - A minor enhancement
+          - It is not important to address this request in a specific time frame
+        - 🟡 **Medium**
+          - An important enhancement
+          - Will be prioritized above *low* requests in the normal course of development
+        - 🔥 **High**
+          - A critical enhancement with significant value
+          - Should be prioritized above *low* and *medium* requests
+
+  - type: dropdown
+    id: urgency
+    attributes:
+      label: Urgency
+      description: How urgent is it to resolve this feature request?
+      multiple: false
+      options:
+        - Low
+        - Medium
+        - High
+    validations:
+      required: true
+
+  - type: dropdown
+    id: request_owner
+    attributes:
+      label: Are you going to implement the feature request?
+      description: Indicate if you are going to do the work to close this feature request.
+      multiple: false
+      options:
+        - I will implement the feature
+        - Someone else needs to implement the feature
+    validations:
+      required: true
+
+  - type: dropdown
+    id: needs_maintainer_feedback
+    attributes:
+      label: Do you need maintainer feedback?
+      description: Indicate if you would like a maintainer to provide feedback on this submission.
+      multiple: false
+      options:
+        - No maintainer feedback needed
+        - Maintainer feedback requested
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: code_first
+    attributes:
+      label: Code first?
+      description: |
+        Is this part of a [code first](https://github.com/tianocore/tianocore.github.io/wiki/EDK-II-Code-First-Process) change?
+      options:
+        - label: "Yes"
+
+  - type: textarea
+    id: anything_else
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the feature you are requesting.
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,0 +1,52 @@
+# Defines the mappings between GitHub issue responses and labels applied to the issue.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/redhat-plumbers-in-action/advanced-issue-labeler
+
+policy:
+  - section:
+
+    # Issue Template - Urgency Dropdown
+    - id: ['urgency']
+      block-list: []
+      label:
+        - name: 'priority:low'
+          keys: ['Low']
+        - name: 'priority:medium'
+          keys: ['Medium']
+        - name: 'priority:high'
+          keys: ['High']
+
+    # Issue Template - Code First
+    - id: ['code_first']
+      block-list: []
+      label:
+        - name: 'type:code-first'
+          keys: ['Yes']
+
+    # Issue Template - Fix Owner Dropdown
+    - id: ['fix_owner', 'request_owner']
+      block-list: []
+      label:
+        - name: 'state:needs-owner'
+          keys: [
+            'Someone else needs to fix it',
+            'Someone else needs to make the change',
+            'Someone else needs to implement the feature'
+            ]
+        - name: 'state:needs-triage'
+          keys: [
+            'Someone else needs to fix it',
+            'Someone else needs to make the change',
+            'Someone else needs to implement the feature'
+            ]
+
+    # Issue Template - Needs Maintainer Feedback Dropdown
+    - id: ['needs_maintainer_feedback']
+      block-list: []
+      label:
+        - name: 'state:needs-maintainer-feedback'
+          keys: ['Maintainer feedback requested']

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -1,0 +1,56 @@
+# Actions that should occur when a GitHub issue is assigned.
+#
+# Currently this will remove the `state:needs-owner` label when the issue is assigned to an owner.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+name: React to Issue Assignment
+
+on:
+  issues:
+    types: assigned
+
+jobs:
+  adjust-labels:
+    name: Adjust Issue Labels
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove Labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # All labels here will be removed if present in the issue
+          LABELS_TO_REMOVE=("state:needs-owner")
+
+          # Gather issue context information
+          ISSUE_NUMBER=$(jq --raw-output .issue.number "$GITHUB_EVENT_PATH")
+          OWNER=$(jq --raw-output .repository.owner.login "$GITHUB_EVENT_PATH")
+          REPO=$(jq --raw-output .repository.name "$GITHUB_EVENT_PATH")
+          LABELS=$(curl -s \
+                        -H "Accept: application/vnd.github+json" \
+                        -H "Authorization: Bearer $GITHUB_TOKEN" \
+                        -H "X-GitHub-Api-Version: 2022-11-28" \
+                        https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/labels | jq -r '.[].name')
+
+          # Remove labels
+          for LABEL in "${LABELS_TO_REMOVE[@]}"; do
+            if echo "$LABELS" | grep -q "$LABEL"; then
+              curl -X DELETE \
+                   -s \
+                   -H "Accept: application/vnd.github+json" \
+                   -H "Authorization: Bearer $GITHUB_TOKEN" \
+                   -H "X-GitHub-Api-Version: 2022-11-28" \
+                   https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/labels/"$LABEL" > /dev/null
+              echo "$LABEL removed from issue #$ISSUE_NUMBER"
+            else
+              echo "$LABEL not found on issue #$ISSUE_NUMBER"
+            fi
+          done

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,89 @@
+# This workflow assists with initial triage of new issues by applying labels
+# based on data provided in the issue.
+#
+# Configuration file that maps issue form input values to labels:
+#   advanced-issue-labeler.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/stefanbuck/github-issue-parser
+# https://github.com/redhat-plumbers-in-action/advanced-issue-labeler
+
+name: Issue Triage Workflow
+
+on:
+  issues:
+    types: [ opened ]
+
+jobs:
+  triage_issue:
+    name: Triage Issue
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        template: [ bug_report.yml, documentation_request.yml, feature_request.yml ]
+
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse Issue Form
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          issue-body: ${{ github.event.issue.body }}
+          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
+
+      - name: Apply Labels from Triage
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          template: ${{ matrix.template }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Assignee
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FIX_OWNER: ${{ steps.issue-parser.outputs.issueparser_fix_owner }}
+        run: |
+          if [[ $FIX_OWNER == "I will fix it" ]] || [[ $FIX_OWNER == "I will make the change" ]] || [[ $FIX_OWNER == "I will implement the feature" ]]
+          then
+            gh issue edit ${{ github.event.issue.html_url }} --add-assignee ${{ github.event.issue.user.login }}
+          fi
+
+      - name: Add Package Name to the Issue
+        # Only run once per worfklow run
+        if: ${{ matrix.template == 'bug_report.yml' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issue_number = context.issue.number;
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number
+            });
+
+            const issueLines = issue.data.body.split('\n');
+            const packageLineIndex = issueLines.findIndex(line => line.includes('What packages are impacted?'));
+            if (packageLineIndex === -1) {
+              process.exit(0);
+            }
+            const packagesImpacted = issueLines[packageLineIndex + 2].split(',');
+            if (packagesImpacted.length > 3) {
+              process.exit(0);
+            }
+            const packagesToAppend = packagesImpacted.map(pkg => `[${pkg.trim()}]`).join(' ');
+            const newTitle = `${issue.data.title} - ${packagesToAppend}`;
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              title: newTitle
+            });

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -1,0 +1,52 @@
+# This workflow performs scheduled maintenance tasks.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Scheduled Maintenance
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run every hour - https://crontab.guru/#0_*_*_*_*
+    - cron:  '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  repo_cleanup:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Prune Won't Fix Pull Requests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${GITHUB_REPOSITORY}/pulls | jq -r '.[]' | jq -rc '.html_url,.labels' | \
+          while read -r html_url ; do
+            read -r labels
+            if [[ $labels == *"state:wont-fix"* ]]; then
+              gh pr close $html_url -c "Closed due to being marked as wont fix" --delete-branch
+            fi
+          done
+
+      - name: Prune Won't Fix Issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ env.REPOSITORY_NAME }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${GITHUB_REPOSITORY}/issues | jq -r '.[]' | jq -rc '.html_url,.labels' | \
+          while read -r html_url ; do
+            read -r labels
+            if [[ $labels == *"state:wont-fix"* ]]; then
+              gh issue close $html_url -c "Closed due to being marked as wont fix" -r "not planned"
+            fi
+          done


### PR DESCRIPTION
Brings edk2-platforms GitHub issues into parity with edk2.

---

**.github: Add GitHub issue templates**

REF: https://github.com/tianocore/edk2/discussions/5926

Adds GitHub form isssue templates for bugs, documentation requests,
and feature requests.

These files define the form structure in YAML to be rendered by
GitHub in the edk2-platforms repo issues area.

Due to the large amount of diverse content on edk2-platforms an
attempt was made to classify code areas in the best way for the
current organization of the code path in the tree. Please suggest
any corrections in the PR.

---

**.github: Add issue automation workflows**

REF: https://github.com/tianocore/edk2/discussions/5926

Adds workflows to manage labels on issues based on issue content.

This uses the same flow as already used for issues in the edk2 repo.

Workflows:

- `issue-assignment` - Performs actions when an issue is assigned.
  - Currently, removes the `state:needs-owner` label.
- `issue-triage` - Assigns initial labels to the issue based on data
  entered when the issue was created.
  - The policies for applying labels are defined in
    - `advanced-issue-labeler.yml`
	- Note: Based on https://github.com/marketplace/actions/advanced-issue-labeler
- `scheduled-maintenance` - Runs every hour to perform clean up work
  need on issues.
  - Currently, closes issues that have had the `state:wont-fix` label
    applied.

---

Tested on my edk2-platforms fork.