### PR TITLE
Platform/Arm/VExpressPkg: Disable shadow copying of BFV in StMM

### DIFF
--- a/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
+++ b/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
@@ -150,6 +150,13 @@
 
   gArmTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
 
+  #
+  # The BFV is not located in the Flash area but is loaded in the RAM
+  # by TF-A instead, therefore no shadow copy is needed. So disable
+  # shadow copy of boot firmware volume while loading StMM drivers.
+  #
+  gStandaloneMmPkgTokenSpaceGuid.PcdShadowBfv|FALSE
+
 ###################################################################################################
 #
 # Components Section - list of the modules and components that will be processed by compilation


### PR DESCRIPTION
On FVP, the StandaloneMM Boot Firmware Volume (BFV) is not in the Flash area. Instead it is loaded in to the RAM by TF-A.

Therefore, disable the shadow copying of the BFV in StandaloneMM.