### PR TITLE
Platform/RaspberryPi4: Fix EFI runtime region for varstore access

### DIFF
--- a/Platform/RaspberryPi/Library/PlatformLib/PlatformLib.inf
+++ b/Platform/RaspberryPi/Library/PlatformLib/PlatformLib.inf
@@ -55,10 +55,8 @@
   gEmbeddedTokenSpaceGuid.PcdDmaDeviceOffset
   gArmTokenSpaceGuid.PcdSystemMemoryBase
   gArmTokenSpaceGuid.PcdSystemMemorySize
+  gRaspberryPiTokenSpaceGuid.PcdNvStorageVariableBase
   gRaspberryPiTokenSpaceGuid.PcdNvStorageEventLogSize
-  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
-  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize
-  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate     # RPi3 only

--- a/Platform/RaspberryPi/Library/PlatformLib/RaspberryPiMem.c
+++ b/Platform/RaspberryPi/Library/PlatformLib/RaspberryPiMem.c
@@ -30,14 +30,7 @@ UINT32 mBoardRevision;
 STATIC BOOLEAN                  VirtualMemoryInfoInitialized = FALSE;
 STATIC RPI_MEMORY_REGION_INFO   VirtualMemoryInfo[MAX_VIRTUAL_MEMORY_MAP_DESCRIPTORS];
 
-#define VariablesSize (FixedPcdGet32(PcdFlashNvStorageVariableSize) +   \
-                       FixedPcdGet32(PcdFlashNvStorageFtwWorkingSize) + \
-                       FixedPcdGet32(PcdFlashNvStorageFtwSpareSize) +  \
-                       FixedPcdGet32(PcdNvStorageEventLogSize))
-
-#define VariablesBase (FixedPcdGet64(PcdFdBaseAddress) + \
-                       FixedPcdGet32(PcdFdSize) - \
-                       VariablesSize)
+#define VariablesBase (FixedPcdGet32(PcdNvStorageVariableBase))
 
 /**
   Return the Virtual Memory Map of your platform
@@ -116,7 +109,7 @@ ArmPlatformGetVirtualMemoryMap (
   // Firmware Volume
   VirtualMemoryTable[Index].PhysicalBase    = FixedPcdGet64 (PcdFdBaseAddress);
   VirtualMemoryTable[Index].VirtualBase     = VirtualMemoryTable[Index].PhysicalBase;
-  VirtualMemoryTable[Index].Length          = FixedPcdGet32 (PcdFdSize) - VariablesSize;
+  VirtualMemoryTable[Index].Length          = VariablesBase - VirtualMemoryTable[Index].PhysicalBase;
   VirtualMemoryTable[Index].Attributes      = ARM_MEMORY_REGION_ATTRIBUTE_WRITE_BACK;
   VirtualMemoryInfo[Index].Type             = RPI_MEM_RESERVED_REGION;
   VirtualMemoryInfo[Index++].Name           = L"FD";
@@ -124,7 +117,7 @@ ArmPlatformGetVirtualMemoryMap (
   // Variable Volume
   VirtualMemoryTable[Index].PhysicalBase    = VariablesBase;
   VirtualMemoryTable[Index].VirtualBase     = VirtualMemoryTable[Index].PhysicalBase;
-  VirtualMemoryTable[Index].Length          = VariablesSize;
+  VirtualMemoryTable[Index].Length          = FixedPcdGet32 (PcdFdtBaseAddress) - VariablesBase;
   VirtualMemoryTable[Index].Attributes      = ARM_MEMORY_REGION_ATTRIBUTE_WRITE_BACK;
   VirtualMemoryInfo[Index].Type             = RPI_MEM_RUNTIME_REGION;
   VirtualMemoryInfo[Index++].Name           = L"FD Variables";


### PR DESCRIPTION
Commit 991b802e8f70 ("Platform/RPi4: Allocate more space for UEFI image") reorganized the Flash Device (FD) layout to accommodate the growing size of the firmware, and reserved some additional space to be used for ACPI PCC channel data in the future.

This additional allocation was added at the end of the FD, after the varstore image, while the mapping code in PlatformLib expects the varstore related regions to live at the very end.

The upshot is that the varstore region in the FD is no longer mapped for runtime access, resulting in runtime service crashes when attempting to access the varstore from under the OS.

Fix this in PlatformLib, by extending the varstore memory region to include everything that comes after it.