### PR TITLE
Platform/PlatformStandaloneMmPkg/: Disable shadow copying of BFV in StMM

### DIFF
--- a/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
+++ b/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
@@ -113,6 +113,12 @@
 
   gArmTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
 
+  # The BFV is not located in the Flash area but is loaded in the RAM
+  # by optee's stmm_sp.c instead, therefore no shadow copy is needed.
+  # So disable shadow copy of boot firmware volume while loading StMM drivers.
+  #
+  gStandaloneMmPkgTokenSpaceGuid.PcdShadowBfv|FALSE
+
 [PcdsPatchableInModule]
   # Allocated memory for EDK2 uppers layers
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0x0


### PR DESCRIPTION
On PlatformStandaloneMmPkg, the StandaloneMM Boot Firmware Volume (BFV) is not in the Flash area. Instead it is loaded in
to the RAM by optee's code.
Therefore, disable the shadow copying of the BFV in StandaloneMM.