### PR TITLE
Reserve ecam v express

### DIFF
--- a/Platform/ARM/JunoPkg/AcpiTables/AcpiTables.inf
+++ b/Platform/ARM/JunoPkg/AcpiTables/AcpiTables.inf
@@ -46,8 +46,8 @@
   gArmTokenSpaceGuid.PcdGenericWatchdogRefreshBase
 
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
-  gArmJunoTokenSpaceGuid.PcdPciConfigurationSpaceSize
-  gArmJunoTokenSpaceGuid.PcdPciConfigurationSpaceLimit
+  gArmTokenSpaceGuid.PcdPciConfigurationSpaceSize
+  gArmTokenSpaceGuid.PcdPciConfigurationSpaceLimit
 
   #
   # PL011 UART Settings for Serial Port Console Redirection

--- a/Platform/ARM/JunoPkg/ArmJuno.dec
+++ b/Platform/ARM/JunoPkg/ArmJuno.dec
@@ -34,8 +34,8 @@
 [PcdsFixedAtBuild.common]
   gArmJunoTokenSpaceGuid.PcdPcieControlBaseAddress|0x7FF20000|UINT64|0x0000000B
   gArmJunoTokenSpaceGuid.PcdPcieRootPortBaseAddress|0x7FF30000|UINT64|0x0000000C
-  gArmJunoTokenSpaceGuid.PcdPciConfigurationSpaceSize|0x10000000|UINT64|0x00000011
-  gArmJunoTokenSpaceGuid.PcdPciConfigurationSpaceLimit|0x4FFFFFFF|UINT64|0x00000012
+  gArmTokenSpaceGuid.PcdPciConfigurationSpaceSize|0x10000000|UINT64|0x00000011
+  gArmTokenSpaceGuid.PcdPciConfigurationSpaceLimit|0x4FFFFFFF|UINT64|0x00000012
 
   gArmJunoTokenSpaceGuid.PcdSynopsysUsbOhciBaseAddress|0x7FFB0000|UINT32|0x00000004
   gArmJunoTokenSpaceGuid.PcdSynopsysUsbEhciBaseAddress|0x7FFC0000|UINT32|0x00000005

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerDxe.inf
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerDxe.inf
@@ -47,7 +47,7 @@
 [FixedPcd]
   # PCI Root complex specific PCDs
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
-  gArmJunoTokenSpaceGuid.PcdPciConfigurationSpaceSize
+  gArmTokenSpaceGuid.PcdPciConfigurationSpaceSize
 
   ## PL011 Serial Debug UART
   gArmPlatformTokenSpaceGuid.PcdSerialDbgRegisterBase

--- a/Platform/ARM/JunoPkg/Library/ArmJunoLib/ArmJunoLib.inf
+++ b/Platform/ARM/JunoPkg/Library/ArmJunoLib/ArmJunoLib.inf
@@ -46,7 +46,7 @@
 
   gArmJunoTokenSpaceGuid.PcdPcieControlBaseAddress
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
-  gArmJunoTokenSpaceGuid.PcdPciConfigurationSpaceSize
+  gArmTokenSpaceGuid.PcdPciConfigurationSpaceSize
 
   # Framebuffer Memory
   gArmPlatformTokenSpaceGuid.PcdArmLcdDdrFrameBufferBase

--- a/Platform/ARM/JunoPkg/Library/JunoPciHostBridgeLib/JunoPciHostBridgeLib.inf
+++ b/Platform/ARM/JunoPkg/Library/JunoPciHostBridgeLib/JunoPciHostBridgeLib.inf
@@ -63,7 +63,7 @@
   gArmJunoTokenSpaceGuid.PcdPcieControlBaseAddress
   gArmJunoTokenSpaceGuid.PcdPcieRootPortBaseAddress
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
-  gArmJunoTokenSpaceGuid.PcdPciConfigurationSpaceSize
+  gArmTokenSpaceGuid.PcdPciConfigurationSpaceSize
 
 [Protocols]
   gEfiCpuIo2ProtocolGuid          ## CONSUMES

--- a/Platform/ARM/VExpressPkg/ArmVExpressPkg.dec
+++ b/Platform/ARM/VExpressPkg/ArmVExpressPkg.dec
@@ -46,6 +46,9 @@
   gArmVExpressTokenSpaceGuid.PcdHdLcdVideoModeOscId|0|UINT32|0x00000005
   gArmVExpressTokenSpaceGuid.PcdArmMaliDpMaxMode|0|UINT32|0x00000008
 
+  gArmTokenSpaceGuid.PcdPciConfigurationSpaceSize|0x10000000|UINT64|0x00000011
+  gArmTokenSpaceGuid.PcdPciConfigurationSpaceLimit|0x4FFFFFFF|UINT64|0x00000012
+
   #
   # Device path of block device on which Fastboot will flash partitions
   #

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/AslTables/SsdtPci.asl
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/AslTables/SsdtPci.asl
@@ -149,6 +149,19 @@ DefinitionBlock ("SsdtPci.aml", "SSDT", 2, "ARMLTD", "FVP-REVC", 1) {
         Return (RBUF)
       } // Method(_CRS)
 
+      Device (RES0) {
+        Name (_HID, "PNP0C02" /* PNP Motherboard Resources */)  // _HID: Hardware ID
+        Name (_CRS, ResourceTemplate () {                       // _CRS: Current Resource Settings
+           QWordMemory (ResourceProducer, PosDecode, MinFixed, MaxFixed, NonCacheable, ReadWrite,
+           0x0000000000000000,                                  // Granularity
+           FixedPcdGet64 (PcdPciExpressBaseAddress),            // Range Minimum
+           FixedPcdGet64 (PcdPciConfigurationSpaceLimit),       // Range Maximum
+           0x0000000000000000,                                  // Translation Offset
+           FixedPcdGet64 (PcdPciConfigurationSpaceSize),        // Length
+           ,, , AddressRangeMemory, TypeStatic)
+        })
+      }
+
       //
       // OS Control Handoff
       //

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerDxe.inf
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerDxe.inf
@@ -73,6 +73,8 @@
   # PCI Root complex specific PCDs
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseSize
+  gArmTokenSpaceGuid.PcdPciConfigurationSpaceSize
+  gArmTokenSpaceGuid.PcdPciConfigurationSpaceLimit
 
   gArmTokenSpaceGuid.PcdPciBusMin
   gArmTokenSpaceGuid.PcdPciBusMax


### PR DESCRIPTION
Platform/Arm/VExpressPkg: Reserve the ECAM area in ACPI with RES0 device

Add a RES0 device to the SSDT to reserve the PCI ECAM area.This fixes the firmware bug reported by Linux:

`acpi PNP0A08:00: [Firmware Bug]: ECAM area [mem 0x40000000-0x4fffffff]not reserved in ACPI namespace`

With this change, the above message is replaced with:

`acpi PNP0A08:00: ECAM area [mem 0x40000000-0x4fffffff] reserved by PNP0C02:00`

This patch is based on commit 1e5be97660c6 ("Platform/ARM/JunoPkg:Reserve the ECAM area in ACPI with RES0 device")

REF:https://developer.arm.com/documentation/100964/1127/Base-Platform/Base-Platform-memory/Base-Platform-memory-map?lang=en

Also use same PCD for Juno and VExpress.
