### PR TITLE
Update for Stack Cookie Breaking Change

### DIFF
--- a/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
+++ b/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
@@ -86,8 +86,6 @@
   CacheMaintenanceLib|ArmPkg/Library/ArmCacheMaintenanceLib/ArmCacheMaintenanceLib.inf
   PeCoffExtraActionLib|StandaloneMmPkg/Library/StandaloneMmPeCoffExtraActionLib/StandaloneMmPeCoffExtraActionLib.inf
 
-  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
-
 [LibraryClasses.common.MM_CORE_STANDALONE]
   HobLib|StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf
   ArmFfaLib|ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf

--- a/Platform/BeagleBoard/BeagleBoardPkg/PrePi/PeiUniCore.inf
+++ b/Platform/BeagleBoard/BeagleBoardPkg/PrePi/PeiUniCore.inf
@@ -47,6 +47,7 @@
   PrePiLib
   SerialPortLib
   TimerLib
+  StackCheckLib
 
 [Ppis]
   gArmMpCoreInfoPpiGuid

--- a/Platform/Intel/AlderlakeOpenBoardPkg/AlderlakePRvp/OpenBoardPkg.dsc
+++ b/Platform/Intel/AlderlakeOpenBoardPkg/AlderlakePRvp/OpenBoardPkg.dsc
@@ -277,7 +277,6 @@ ResetSystemLib|$(PLATFORM_SI_PACKAGE)/Pch/Library/BaseResetSystemLib/BaseResetSy
   UefiCpuPkg/SecCore/SecCore.inf {
     <LibraryClasses>
       PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
-      NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
   }
 
 

--- a/Platform/Intel/CometlakeOpenBoardPkg/CometlakeURvp/OpenBoardPkg.dsc
+++ b/Platform/Intel/CometlakeOpenBoardPkg/CometlakeURvp/OpenBoardPkg.dsc
@@ -272,7 +272,6 @@
   UefiCpuPkg/SecCore/SecCore.inf {
     <LibraryClasses>
       PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
-      NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
   }
 
   #

--- a/Platform/Intel/KabylakeOpenBoardPkg/AspireVn7Dash572G/OpenBoardPkg.dsc
+++ b/Platform/Intel/KabylakeOpenBoardPkg/AspireVn7Dash572G/OpenBoardPkg.dsc
@@ -373,7 +373,6 @@
   UefiCpuPkg/SecCore/SecCore.inf {
     <LibraryClasses>
       PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
-      NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
   }
 
   MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.inf {

--- a/Platform/Intel/KabylakeOpenBoardPkg/GalagoPro3/OpenBoardPkg.dsc
+++ b/Platform/Intel/KabylakeOpenBoardPkg/GalagoPro3/OpenBoardPkg.dsc
@@ -288,7 +288,6 @@
   UefiCpuPkg/SecCore/SecCore.inf {
     <LibraryClasses>
       PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
-      NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
   }
 
   MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.inf {

--- a/Platform/Intel/KabylakeOpenBoardPkg/KabylakeRvp3/OpenBoardPkg.dsc
+++ b/Platform/Intel/KabylakeOpenBoardPkg/KabylakeRvp3/OpenBoardPkg.dsc
@@ -294,7 +294,6 @@
   UefiCpuPkg/SecCore/SecCore.inf {
     <LibraryClasses>
       PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
-      NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
   }
 
 !if gIntelFsp2WrapperTokenSpaceGuid.PcdFspModeSelection == 1

--- a/Platform/Intel/SimicsOpenBoardPkg/SecCore/SecMain.inf
+++ b/Platform/Intel/SimicsOpenBoardPkg/SecCore/SecMain.inf
@@ -53,6 +53,7 @@
   ExtractGuidedSectionLib
   LocalApicLib
   PciCf8Lib
+  StackCheckLib
 
 [Ppis]
   gEfiTemporaryRamSupportPpiGuid                # PPI ALWAYS_PRODUCED

--- a/Platform/Intel/TigerlakeOpenBoardPkg/TigerlakeURvp/OpenBoardPkg.dsc
+++ b/Platform/Intel/TigerlakeOpenBoardPkg/TigerlakeURvp/OpenBoardPkg.dsc
@@ -197,7 +197,6 @@
   UefiCpuPkg/SecCore/SecCore.inf {
     <LibraryClasses>
       PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
-      NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
   }
 
   #

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/UpXtreme/OpenBoardPkg.dsc
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/UpXtreme/OpenBoardPkg.dsc
@@ -272,7 +272,6 @@
   UefiCpuPkg/SecCore/SecCore.inf {
     <LibraryClasses>
       PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
-      NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
   }
 
   #

--- a/Platform/Intel/WhiskeylakeOpenBoardPkg/WhiskeylakeURvp/OpenBoardPkg.dsc
+++ b/Platform/Intel/WhiskeylakeOpenBoardPkg/WhiskeylakeURvp/OpenBoardPkg.dsc
@@ -272,7 +272,6 @@
   UefiCpuPkg/SecCore/SecCore.inf {
     <LibraryClasses>
       PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
-      NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
   }
 
   #

--- a/Platform/Intel/WhitleyOpenBoardPkg/PlatformPkg.dsc
+++ b/Platform/Intel/WhitleyOpenBoardPkg/PlatformPkg.dsc
@@ -685,10 +685,7 @@
   PeiLib|MinPlatformPkg/Library/PeiLib/PeiLib.inf
 
 [Components.IA32]
-  UefiCpuPkg/SecCore/SecCore.inf {
-    <LibraryClasses>
-      NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
-  }
+  UefiCpuPkg/SecCore/SecCore.inf
 
   !include MinPlatformPkg/Include/Dsc/CorePeiInclude.dsc
 

--- a/Platform/Loongson/LoongArchQemuPkg/Sec/SecMain.inf
+++ b/Platform/Loongson/LoongArchQemuPkg/Sec/SecMain.inf
@@ -37,6 +37,7 @@
   PeCoffLib
   PeCoffGetEntryPointLib
   PeCoffExtraActionLib
+  StackCheckLib
 
 [Ppis]
   gEfiTemporaryRamSupportPpiGuid                # PPI ALWAYS_PRODUCED

--- a/Platform/RISC-V/PlatformPkg/Universal/Sec/SecMain.inf
+++ b/Platform/RISC-V/PlatformPkg/Universal/Sec/SecMain.inf
@@ -54,6 +54,7 @@
   RiscVOpensbiLib
   RiscVOpensbiPlatformLib
   RiscVSbiLib
+  StackCheckLib
 
 [FixedPcd]
   gUefiRiscVPlatformPkgTokenSpaceGuid.PcdRiscVPeiFvBase

--- a/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
+++ b/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
@@ -71,8 +71,6 @@
   SerialPortLib|MdePkg/Library/BaseSerialPortLibNull/BaseSerialPortLibNull.inf
   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
 
-  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
-
 [LibraryClasses.common.MM_CORE_STANDALONE]
   ArmFfaLib|ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
   ArmTransferListLib|ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf

--- a/Silicon/Ampere/AmpereAltraPkg/AmpereAltraLinuxBootPkg.dsc.inc
+++ b/Silicon/Ampere/AmpereAltraPkg/AmpereAltraLinuxBootPkg.dsc.inc
@@ -129,9 +129,6 @@
   PerformanceLib|MdeModulePkg/Library/PeiPerformanceLib/PeiPerformanceLib.inf
   ArmGicArchLib|ArmPkg/Library/ArmGicArchSecLib/ArmGicArchSecLib.inf
 
-  # ARM platforms have SEC modules with standard entry points, so we can generically link StackCheckLib
-  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
-
 [LibraryClasses.common.PEI_CORE]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf

--- a/Silicon/Bosc/NanHuPkg/Sec/SecMain.inf
+++ b/Silicon/Bosc/NanHuPkg/Sec/SecMain.inf
@@ -51,6 +51,7 @@
   MemoryAllocationLib
   HobLib
   SerialPortLib
+  StackCheckLib
 
 [FixedPcd]
   gUefiRiscVPlatformPkgTokenSpaceGuid.PcdRiscVDxeFvBase                         ## CONSUMES

--- a/Silicon/Sophgo/SG2042Pkg/Sec/SecMain.inf
+++ b/Silicon/Sophgo/SG2042Pkg/Sec/SecMain.inf
@@ -51,6 +51,7 @@
   MemoryAllocationLib
   HobLib
   SerialPortLib
+  StackCheckLib
 
 [FixedPcd]
   gUefiRiscVPlatformPkgTokenSpaceGuid.PcdRiscVDxeFvBase                         ## CONSUMES


### PR DESCRIPTION
edk2 PR https://github.com/tianocore/edk2/pull/6381 updates the stack cookie mechanism per maintainer request to simplify platform usage.

This PR updates edk2-platforms to resolve the breaking change, adding StackCheckLib as a dependency to all SEC modules and removing DSC references to StackCheckLibNull as MdeLibs.dsc.inc does that globally now.

Note, this must only be merged after the aforementioned edk2 PR completes.