### PR TITLE
Fix hii opcode handle leak

### DIFF
--- a/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c
@@ -445,6 +445,8 @@ SmbiosPlatformDxeRestoreHiiDefaultString (
   UINT8       Index;
   EFI_STATUS  Status;
 
+  Status = EFI_INVALID_PARAMETER;
+
   if (StrToken == NULL) {
     DEBUG ((
       DEBUG_ERROR,

--- a/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type08/PlatformPortConnectorFunction.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type08/PlatformPortConnectorFunction.c
@@ -30,6 +30,7 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformPortConnector) {
 
   InputData     = (SMBIOS_TABLE_TYPE8 *)RecordData;
   InputStrToken = (STR_TOKEN_INFO *)StrToken;
+  Status        = EFI_INVALID_PARAMETER;
 
   while (InputData->Hdr.Type != NULL_TERMINATED_TYPE) {
     SmbiosPlatformDxeCreateTable (

--- a/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type09/PlatformSystemSlotFunction.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type09/PlatformSystemSlotFunction.c
@@ -325,6 +325,7 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformSystemSlot) {
   SlotIndex     = S0_RISERX32_SLOT1_INDEX;
   InputData     = (SMBIOS_TABLE_TYPE9 *)RecordData;
   InputStrToken = (STR_TOKEN_INFO *)StrToken;
+  Status        = EFI_INVALID_PARAMETER;
 
   while (InputData->Hdr.Type != NULL_TERMINATED_TYPE) {
     UpdateSmbiosType9 (SlotIndex, InputData);

--- a/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type11/PlatformOemStringFunction.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type11/PlatformOemStringFunction.c
@@ -30,6 +30,7 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformOemString) {
 
   InputData     = (SMBIOS_TABLE_TYPE11 *)RecordData;
   InputStrToken = (STR_TOKEN_INFO *)StrToken;
+  Status        = EFI_INVALID_PARAMETER;
 
   while (InputData->Hdr.Type != NULL_TERMINATED_TYPE) {
     SmbiosPlatformDxeCreateTable (

--- a/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type16/PlatformPhysicalMemoryArrayFunction.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type16/PlatformPhysicalMemoryArrayFunction.c
@@ -27,6 +27,8 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformPhysicalMemoryArray) {
   EFI_STATUS           Status;
   SMBIOS_TABLE_TYPE16  *InputData;
 
+  Status = EFI_INVALID_PARAMETER;
+
   for (Index = 0; Index < GetNumberOfSupportedSockets (); Index++) {
     InputData = (SMBIOS_TABLE_TYPE16 *)RecordData;
 

--- a/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type17/PlatformMemoryDeviceFunction.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type17/PlatformMemoryDeviceFunction.c
@@ -372,6 +372,8 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformMemoryDevice) {
     return EFI_NOT_FOUND;
   }
 
+  Status = EFI_INVALID_PARAMETER;
+
   for (Index = 0; Index < GetNumberOfSupportedSockets (); Index++) {
     InputData         = (SMBIOS_TABLE_TYPE17 *)RecordData;
     InputStrToken     = (STR_TOKEN_INFO *)StrToken;

--- a/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type19/PlatformMemoryArrayMappedAddressFunction.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type19/PlatformMemoryArrayMappedAddressFunction.c
@@ -84,6 +84,9 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformMemoryArrayMappedAddress) {
     return EFI_NOT_FOUND;
   }
 
+  MemorySize = 0;
+  Status     = EFI_INVALID_PARAMETER;
+
   for (Index = 0; Index < GetNumberOfSupportedSockets (); Index++) {
     InputData     = (SMBIOS_TABLE_TYPE19 *)RecordData;
     InputStrToken = (STR_TOKEN_INFO *)StrToken;

--- a/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type24/PlatformHardwareSecurityFunction.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type24/PlatformHardwareSecurityFunction.c
@@ -31,6 +31,8 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformHardwareSecurity) {
   InputData     = (SMBIOS_TABLE_TYPE24 *)RecordData;
   InputStrToken = (STR_TOKEN_INFO *)StrToken;
 
+  Status = EFI_INVALID_PARAMETER;
+
   while (InputData->Hdr.Type != NULL_TERMINATED_TYPE) {
     SmbiosPlatformDxeCreateTable (
       (VOID *)&Type24Record,

--- a/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type38/PlatformIpmiDeviceFunction.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type38/PlatformIpmiDeviceFunction.c
@@ -25,6 +25,7 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformIpmiDevice) {
   EFI_STATUS           Status;
   SMBIOS_TABLE_TYPE38  *InputData;
 
+  Status    = EFI_INVALID_PARAMETER;
   InputData = (SMBIOS_TABLE_TYPE38 *)RecordData;
   while (InputData->Hdr.Type != NULL_TERMINATED_TYPE) {
     Status = SmbiosPlatformDxeAddRecord ((UINT8 *)InputData, NULL);

--- a/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type41/PlatformOnboardDevicesExtendedFunction.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type41/PlatformOnboardDevicesExtendedFunction.c
@@ -31,6 +31,8 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformOnboardDevicesExtended) {
   InputData     = (SMBIOS_TABLE_TYPE41 *)RecordData;
   InputStrToken = (STR_TOKEN_INFO *)StrToken;
 
+  Status = EFI_INVALID_PARAMETER;
+
   while (InputData->Hdr.Type != NULL_TERMINATED_TYPE) {
     SmbiosPlatformDxeCreateTable (
       (VOID *)&Type41Record,

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/RootComplexConfigDxe/RootComplexConfigDxe.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/RootComplexConfigDxe/RootComplexConfigDxe.c
@@ -777,6 +777,8 @@ PcieRCScreenSetup (
       NULL                                       // Default Opcode is NULl
       );
 
+    HiiFreeOpCodeHandle (OptionsOpCodeHandle);
+
     //
     // Create Option OpCode to display bifurcation for RootComplexTypeB-High
     //
@@ -811,6 +813,7 @@ PcieRCScreenSetup (
 
   HiiFreeOpCodeHandle (StartOpCodeHandle);
   HiiFreeOpCodeHandle (EndOpCodeHandle);
+  HiiFreeOpCodeHandle (OptionsOpCodeHandle);
 
   return EFI_SUCCESS;
 }

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/RootComplexConfigDxe/RootComplexConfigDxe.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/RootComplexConfigDxe/RootComplexConfigDxe.c
@@ -314,6 +314,7 @@ RouteConfig (
   PrivateData      = SCREEN_PRIVATE_FROM_THIS (This);
   HiiConfigRouting = PrivateData->HiiConfigRouting;
   *Progress        = Configuration;
+  VarStoreConfig   = NULL;
 
   if (HiiIsConfigHdrMatch (Configuration, &gPcieFormSetGuid, mPcieNvparamVarstoreName)) {
     VarStoreConfig = (UINT8 *)&PrivateData->NVParamVarStoreConfig;

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/SystemFirmwareUpdateDxe/SystemFirmwareUpdateDxe.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/SystemFirmwareUpdateDxe/SystemFirmwareUpdateDxe.c
@@ -239,6 +239,8 @@ SystemFirmwareUpdateSetVariable (
     return EFI_SUCCESS;
   }
 
+  SubId = 0;
+
   if (StrCmp (VariableName, FWU_VARIABLE_SCP_REQUEST) == 0) {
     ImageId = FWU_IMG_ID_SCP;
   } else if (StrCmp (VariableName, FWU_VARIABLE_ATFUEFI_REQUEST) == 0) {


### PR DESCRIPTION
Actually this was a part of findings fixed by https://github.com/tianocore/edk2/pull/6424
But when I tried to build /Ampere/JadePkg/Jade.dsc  I've got a bunch of other  [-Werror=maybe-uninitialized] warnings.