### PR TITLE
Platform: N1Sdp: Fix integer overflow in memory affinity calculation

### DIFF
--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1258,7 +1258,7 @@ InitializePlatformRepository (
 
   RemoteDdrSize = 0;
 
-  Dram2Size = ((PlatRepoInfo->PlatInfo->LocalDdrSize - 2) * SIZE_1GB);
+  Dram2Size = (((UINT64)PlatRepoInfo->PlatInfo->LocalDdrSize - 2) * SIZE_1GB);
 
   PlatRepoInfo->MemAffInfo[LOCAL_DDR_REGION2].Length = Dram2Size;
 


### PR DESCRIPTION
An integer overflow caused a negative memory size in the SRAT tables. Add a UINT64 cast to fix.