### PR TITLE
IpmiFeaturePkg: FixUp FuctionPointer in gPeiIpmiTransportPpiGuid after MemoryDiscovered

### DIFF
--- a/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.inf
+++ b/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.inf
@@ -53,6 +53,7 @@
   BtInterfaceLib
   SsifInterfaceLib
   IpmbInterfaceLib
+  PeiServicesLib
 
 [Guids]
   gPeiIpmiHobGuid


### PR DESCRIPTION
**Description:**
Currently we will hit PF# if using gPeiIpmiTransportPpiGuid function in Post Mem since nobody do migraite for the function pointer in gPeiIpmiTransportPpiGuid.

**Solution:** 
FixUp FuctionPointer in gPeiIpmiTransportPpiGuid afte MemoryDiscovered