### PR TITLE
Marvell/OdysseyPkg: Convert to using PeilessSec

### DIFF
--- a/Platform/Marvell/OdysseyPkg/OdysseyPkg.dsc
+++ b/Platform/Marvell/OdysseyPkg/OdysseyPkg.dsc
@@ -156,7 +156,11 @@
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
       NULL|MdeModulePkg/Library/DxeCrc32GuidedSectionExtractLib/DxeCrc32GuidedSectionExtractLib.inf
   }
-  MdeModulePkg/Universal/PCD/Dxe/Pcd.inf
+
+  MdeModulePkg/Universal/PCD/Dxe/Pcd.inf {
+    <LibraryClasses>
+      PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+  }
 
   #
   # DXE Status codes

--- a/Platform/Marvell/OdysseyPkg/OdysseyPkg.dsc
+++ b/Platform/Marvell/OdysseyPkg/OdysseyPkg.dsc
@@ -28,6 +28,8 @@
   SKUID_IDENTIFIER               = DEFAULT
   FLASH_DEFINITION               = Platform/Marvell/$(PLATFORM_NAME)/$(PLATFORM_NAME).fdf
 
+!include MdePkg/MdeLibs.dsc.inc
+
 # dsc.inc file can be used in case there are different variants/boards of Odyssey family.
 # Per-board additional components shall be defined in exclusive dsc.inc files.
 !include Silicon/Marvell/$(PLATFORM_NAME)/$(PLATFORM_NAME).dsc.inc
@@ -41,7 +43,6 @@
 
   # USB Requirements
   UefiUsbLib|MdePkg/Library/UefiUsbLib/UefiUsbLib.inf # used by UsbKbDxe
-  RegisterFilterLib|MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
 
 [LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION, LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.DXE_DRIVER]
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
@@ -135,8 +136,9 @@
   #
 
   # UEFI is placed in RAM by bootloader
-  ArmPlatformPkg/PrePi/PeiUniCore.inf {
+  ArmPlatformPkg/PeilessSec/PeilessSec.inf {
     <LibraryClasses>
+      NULL|MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaCustomDecompressLib.inf
       # SoC specific implementation of ArmPlatformLib
       ArmPlatformLib|Silicon/Marvell/OdysseyPkg/Library/OdysseyLib/OdysseyLib.inf
   }

--- a/Platform/Marvell/OdysseyPkg/OdysseyPkg.fdf
+++ b/Platform/Marvell/OdysseyPkg/OdysseyPkg.fdf
@@ -68,12 +68,6 @@ READ_LOCK_CAP      = TRUE
 READ_LOCK_STATUS   = TRUE
 FvNameGuid         = d248e9b7-9ce3-43a7-868e-70c17c4b3819
 
-  APRIORI DXE {
-    INF MdeModulePkg/Universal/PCD/Dxe/Pcd.inf                      # gEfiPcdProtocolGuid
-    INF ArmPkg/Drivers/ArmGicDxe/ArmGicV3Dxe.inf                    # gHardwareInterruptProtocolGuid
-    INF ArmPkg/Drivers/CpuDxe/CpuDxe.inf                            # gEfiCpuArchProtocolGuid
-  }
-
   #
   # Core DXE modules
   #

--- a/Platform/Marvell/OdysseyPkg/OdysseyPkg.fdf
+++ b/Platform/Marvell/OdysseyPkg/OdysseyPkg.fdf
@@ -183,7 +183,7 @@ READ_LOCK_STATUS   = TRUE
   #
   # SEC Phase modules
   #
-  INF ArmPlatformPkg/PrePi/PeiUniCore.inf
+  INF ArmPlatformPkg/PeilessSec/PeilessSec.inf
 
   #
   # PEI Phase modules

--- a/Silicon/Marvell/OdysseyPkg/Library/OdysseyLib/OdysseyLib.c
+++ b/Silicon/Marvell/OdysseyPkg/Library/OdysseyLib/OdysseyLib.c
@@ -44,8 +44,6 @@ ArmPlatformInitialize (
   IN  UINTN                     MpId
   )
 {
-  ASSERT(ArmPlatformIsPrimaryCore (MpId));
-
   return RETURN_SUCCESS;
 }
 

--- a/Silicon/Marvell/OdysseyPkg/OdysseyPkg.dsc.inc
+++ b/Silicon/Marvell/OdysseyPkg/OdysseyPkg.dsc.inc
@@ -29,13 +29,11 @@
   DebugPrintErrorLevelLib|MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
 
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
-  SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   UefiDecompressLib|MdePkg/Library/BaseUefiDecompressLib/BaseUefiDecompressLib.inf
-  CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
 
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
 
@@ -72,8 +70,6 @@
   CacheMaintenanceLib|ArmPkg/Library/ArmCacheMaintenanceLib/ArmCacheMaintenanceLib.inf
   DefaultExceptionHandlerLib|ArmPkg/Library/DefaultExceptionHandlerLib/DefaultExceptionHandlerLib.inf
   CpuExceptionHandlerLib|ArmPkg/Library/ArmExceptionLib/ArmExceptionLib.inf
-  ArmPlatformStackLib|ArmPlatformPkg/Library/ArmPlatformStackLib/ArmPlatformStackLib.inf
-  ArmSmcLib|ArmPkg/Library/ArmSmcLib/ArmSmcLib.inf
   ArmGenericTimerCounterLib|ArmPkg/Library/ArmGenericTimerPhyCounterLib/ArmGenericTimerPhyCounterLib.inf
   PL011UartLib|ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.inf
 


### PR DESCRIPTION
Update OdysseyPkg files to use PeilessSec module which has superseded PrePi