### PR TITLE
Silicon/Marvell: enable clang and NOOPT builds for OdysseyPkg

### DIFF
--- a/Platform/Marvell/OdysseyPkg/OdysseyPkg.dsc
+++ b/Platform/Marvell/OdysseyPkg/OdysseyPkg.dsc
@@ -60,7 +60,7 @@
 [BuildOptions]
 # GCC will generate code that runs on processors as idicated by -march
 # Single = (append) allows flags appendixes coming from [BuildOptions] defined in specific INFs.
-  GCC:*_*_AARCH64_PLATFORM_FLAGS = -DPLAT=0xBF -march=armv8.2-a -fdiagnostics-color -fno-diagnostics-show-caret
+  GCC:*_*_AARCH64_PLATFORM_FLAGS = -DPLAT=0xBF -march=armv8.2-a -fdiagnostics-color
 ################################################################################
 #
 # Pcd Section - list of all EDK II PCD Entries defined by this Platform

--- a/Platform/Marvell/OdysseyPkg/OdysseyPkg.dsc
+++ b/Platform/Marvell/OdysseyPkg/OdysseyPkg.dsc
@@ -24,7 +24,7 @@
   OUTPUT_DIRECTORY               = Build/$(PLATFORM_NAME)
 !endif
   SUPPORTED_ARCHITECTURES        = AARCH64
-  BUILD_TARGETS                  = DEBUG|RELEASE
+  BUILD_TARGETS                  = DEBUG|NOOPT|RELEASE
   SKUID_IDENTIFIER               = DEFAULT
   FLASH_DEFINITION               = Platform/Marvell/$(PLATFORM_NAME)/$(PLATFORM_NAME).fdf
 


### PR DESCRIPTION
While test building an unrelated change, I noticed I couldn't build the NOOPT target with clang on OdysseyPkg. These changes make that possible.