### PR TITLE
Pg/serial port length

### DIFF
--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -226,7 +226,9 @@ EDKII_PLATFORM_REPOSITORY_INFO ArmJunoPlatformRepositoryInfo = {
     FixedPcdGet32 (PL011UartInterrupt),               // Interrupt
     FixedPcdGet64 (PcdUartDefaultBaudRate),           // BaudRate
     FixedPcdGet32 (PL011UartClkInHz),                 // Clock
-    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_PL011_UART  // Port subtype
+    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_PL011_UART, // Port subtype
+    0x1000,                                           // Address length
+    EFI_ACPI_6_3_DWORD,                               // Access size
   },
   // Debug Serial Port
   {
@@ -234,7 +236,9 @@ EDKII_PLATFORM_REPOSITORY_INFO ArmJunoPlatformRepositoryInfo = {
     38,                                               // Interrupt
     FixedPcdGet64 (PcdSerialDbgUartBaudRate),         // BaudRate
     FixedPcdGet32 (PcdSerialDbgUartClkInHz),          // Clock
-    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_PL011_UART  // Port subtype
+    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_PL011_UART, // Port subtype
+    0x1000,                                           // Address length
+    EFI_ACPI_6_3_DWORD,                               // Access size
   },
 
   // PCI Configuration Space Info

--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -144,7 +144,9 @@ EDKII_COMMON_PLATFORM_REPOSITORY_INFO CommonPlatformInfo = {
     FixedPcdGet32 (PL011UartInterrupt),                     // Interrupt
     FixedPcdGet64 (PcdUartDefaultBaudRate),                 // BaudRate
     FixedPcdGet32 (PL011UartClkInHz),                       // Clock
-    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_PL011_UART        // Port subtype
+    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_PL011_UART,       // Port subtype
+    0x1000,                                                 // Address length
+    EFI_ACPI_6_3_DWORD,                                     // Access size
   },
 
   // Debug Serial Port
@@ -153,7 +155,9 @@ EDKII_COMMON_PLATFORM_REPOSITORY_INFO CommonPlatformInfo = {
     0,                                                      // Interrupt -unused
     FixedPcdGet64 (PcdSerialDbgUartBaudRate),               // BaudRate
     FixedPcdGet32 (PcdSerialDbgUartClkInHz),                // Clock
-    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_PL011_UART        // Port subtype
+    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_PL011_UART,       // Port subtype
+    0x1000,                                                 // Address length
+    EFI_ACPI_6_3_DWORD,                                     // Access size
   },
 
   // Processor Hierarchy Nodes

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -313,7 +313,9 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
     FixedPcdGet32 (PL011UartInterrupt),                     // Interrupt
     FixedPcdGet64 (PcdUartDefaultBaudRate),                 // BaudRate
     FixedPcdGet32 (PL011UartClkInHz),                       // Clock
-    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_PL011_UART        // Port subtype
+    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_PL011_UART,       // Port subtype
+    0x1000,                                                 // Address length
+    EFI_ACPI_6_3_DWORD,                                     // Access size
   },
 
   // Debug Serial Port
@@ -322,7 +324,9 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
     0,                                                      // Interrupt -unused
     FixedPcdGet64 (PcdSerialDbgUartBaudRate),               // BaudRate
     FixedPcdGet32 (PcdSerialDbgUartClkInHz),                // Clock
-    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_PL011_UART        // Port subtype
+    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_PL011_UART,       // Port subtype
+    0x1000,                                                 // Address length
+    EFI_ACPI_6_3_DWORD,                                     // Access size
   },
 
   // Processor Hierarchy Nodes

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -231,7 +231,9 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
     FixedPcdGet32 (PL011UartInterrupt),                       // Interrupt
     FixedPcdGet64 (PcdUartDefaultBaudRate),                   // BaudRate
     FixedPcdGet32 (PL011UartClkInHz),                         // Clock
-    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_SBSA_GENERIC_UART   // Port subtype
+    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_SBSA_GENERIC_UART,  // Port subtype
+    0x1000,                                                   // Address length
+    EFI_ACPI_6_3_DWORD,                                       // Access size
   },
   // Debug Serial Port
   {
@@ -239,7 +241,9 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
     38,                                                       // Interrupt
     FixedPcdGet64 (PcdSerialDbgUartBaudRate),                 // BaudRate
     FixedPcdGet32 (PcdSerialDbgUartClkInHz),                  // Clock
-    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_SBSA_GENERIC_UART   // Port subtype
+    EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_SBSA_GENERIC_UART,  // Port subtype
+    0x1000,                                                   // Address length
+    EFI_ACPI_6_3_DWORD,                                       // Access size
   },
 
   // GIC ITS


### PR DESCRIPTION
Add information about serial port length/ access size. This information is used by the ConfigurationManager entities to generate ACPI tables.