### PR TITLE
Various Arm/AArch64 platforms: make PcdVFPEnabled AArch32-only

### DIFF
--- a/Platform/ARM/JunoPkg/ArmJuno.dsc
+++ b/Platform/ARM/JunoPkg/ArmJuno.dsc
@@ -139,8 +139,6 @@
   gArmPlatformTokenSpaceGuid.PcdCoreCount|6
   gArmPlatformTokenSpaceGuid.PcdClusterCount|2
 
-  gArmTokenSpaceGuid.PcdVFPEnabled|1
-
   #
   # ARM PrimeCell
   #
@@ -222,6 +220,9 @@
   # Juno Support Trng. Override PcdEnforceSecureRngAlgorithms.
   #
   gEfiMdePkgTokenSpaceGuid.PcdEnforceSecureRngAlgorithms|TRUE
+
+[PcdsFixedAtBuild.ARM]
+  gArmTokenSpaceGuid.PcdVFPEnabled|1
 
 [PcdsPatchableInModule]
   # Console Resolution (Full HD)

--- a/Platform/ARM/Morello/MorelloPlatform.dsc.inc
+++ b/Platform/ARM/Morello/MorelloPlatform.dsc.inc
@@ -73,8 +73,6 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdTurnOffUsbLegacySupport|TRUE
 
 [PcdsFixedAtBuild.common]
-  gArmTokenSpaceGuid.PcdVFPEnabled|1
-
   gArmPlatformTokenSpaceGuid.PcdCPUCoresStackBase|0x80000000
   gArmPlatformTokenSpaceGuid.PcdCPUCorePrimaryStackSize|0x40000
 

--- a/Platform/ARM/N1Sdp/N1SdpPlatform.dsc
+++ b/Platform/ARM/N1Sdp/N1SdpPlatform.dsc
@@ -98,8 +98,6 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdTurnOffUsbLegacySupport|TRUE
 
 [PcdsFixedAtBuild.common]
-  gArmTokenSpaceGuid.PcdVFPEnabled|1
-
   # RAM Disk
   gArmN1SdpTokenSpaceGuid.PcdRamDiskBase|0x88000000
   gArmN1SdpTokenSpaceGuid.PcdRamDiskSize|0x18000000

--- a/Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
+++ b/Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
@@ -114,7 +114,6 @@
 !endif
 
 [PcdsFixedAtBuild.common]
-  gArmTokenSpaceGuid.PcdVFPEnabled|1
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize|0x2000
 
   # DRAM Block2 Base and Size

--- a/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
@@ -131,8 +131,6 @@
   gArmTokenSpaceGuid.PcdMmBufferSize|0x10000
 !endif
 
-  gArmTokenSpaceGuid.PcdVFPEnabled|1
-
   # Non-Trusted SRAM
   gArmPlatformTokenSpaceGuid.PcdCPUCoresStackBase|0x2E000000
   gArmPlatformTokenSpaceGuid.PcdCPUCorePrimaryStackSize|0x4000

--- a/Platform/Marvell/OdysseyPkg/OdysseyPkg.dsc
+++ b/Platform/Marvell/OdysseyPkg/OdysseyPkg.dsc
@@ -86,8 +86,6 @@
   # The size of volatile buffer. This buffer is used to store VOLATILE attribute variables.
   gEfiMdeModulePkgTokenSpaceGuid.PcdVariableStoreSize|0x00040000
 
-  gArmTokenSpaceGuid.PcdVFPEnabled|1
-
   # Set ARM PCD: Odyssey: up to 80 Neoverse V2 cores (code named Demeter)
   # Used to setup secondary cores stacks and ACPI PPTT.
   gArmPlatformTokenSpaceGuid.PcdCoreCount|80

--- a/Platform/Phytium/DurianPkg/DurianPkg.dsc
+++ b/Platform/Phytium/DurianPkg/DurianPkg.dsc
@@ -52,7 +52,6 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVendor|L"Durian Platform"
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString|L"V1.0"
 
-  gArmTokenSpaceGuid.PcdVFPEnabled|1
   gArmTokenSpaceGuid.PcdArmPrimaryCoreMask|0x101
   gArmTokenSpaceGuid.PcdArmPrimaryCore|0x0
   gArmPlatformTokenSpaceGuid.PcdCoreCount|4

--- a/Platform/Qemu/SbsaQemu/SbsaQemu.dsc
+++ b/Platform/Qemu/SbsaQemu/SbsaQemu.dsc
@@ -387,8 +387,6 @@ DEFINE NETWORK_HTTP_BOOT_ENABLE       = FALSE
   #
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetNxForStack|TRUE
 
-  gArmTokenSpaceGuid.PcdVFPEnabled|1
-
   # System Memory Base -- fixed
   !if $(ENABLE_RME)
     #

--- a/Platform/RaspberryPi/RPi3/RPi3.dsc
+++ b/Platform/RaspberryPi/RPi3/RPi3.dsc
@@ -378,7 +378,6 @@
 
 [PcdsFixedAtBuild.common]
   gArmPlatformTokenSpaceGuid.PcdCoreCount|4
-  gArmTokenSpaceGuid.PcdVFPEnabled|1
 
   gArmPlatformTokenSpaceGuid.PcdCPUCorePrimaryStackSize|0x4000
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize|0x2000

--- a/Platform/RaspberryPi/RPi4/RPi4.dsc
+++ b/Platform/RaspberryPi/RPi4/RPi4.dsc
@@ -383,7 +383,6 @@
 
 [PcdsFixedAtBuild.common]
   gArmPlatformTokenSpaceGuid.PcdCoreCount|4
-  gArmTokenSpaceGuid.PcdVFPEnabled|1
 
   gArmPlatformTokenSpaceGuid.PcdCPUCorePrimaryStackSize|0x4000
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize|0x2000

--- a/Silicon/Ampere/AmpereAltraPkg/AmpereAltraLinuxBootPkg.dsc.inc
+++ b/Silicon/Ampere/AmpereAltraPkg/AmpereAltraLinuxBootPkg.dsc.inc
@@ -315,8 +315,6 @@
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiLoaderCode|20
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiLoaderData|0
 
-  gArmTokenSpaceGuid.PcdVFPEnabled|1
-
   gArmTokenSpaceGuid.PcdArmPrimaryCore|0x0
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize|0x2000

--- a/Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dsc.inc
+++ b/Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dsc.inc
@@ -390,8 +390,6 @@
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiLoaderCode|0
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiLoaderData|0
 
-  gArmTokenSpaceGuid.PcdVFPEnabled|1
-
   gArmTokenSpaceGuid.PcdArmPrimaryCore|0x0
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize|0x2000


### PR DESCRIPTION
Since UEFI requires AArch64 to support FP/NEON, the Pcd to decide whether to enable (or disable trapping of) those instructions has changed to be ARM-only in edk2, and the enabling to be unconditional for AArch64.

So drop the explicit setting to 1 for all AArch64 platforms, and move the setting to a .ARM section for the one dual-architecture platform in the tree (Juno)

(This change is needed after [#10931](https://github.com/tianocore/edk2/pull/10931) is merged.)