### PR TITLE
Platform/ARM/N1SDP: Add PMCG nodes for SMMU

### DIFF
--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -794,7 +794,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
   },
 
   {
-    // SMMUv3 Node
+    // SMMUv3 Node - PCIe
     {
       // Reference token for this Iort node
       REFERENCE_TOKEN (SmmuV3Info[Smmuv3info_pcie]),
@@ -823,7 +823,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       // Index into the array of ID mapping
       1
     },
-    // SMMUv3 Node
+    // SMMUv3 Node - CCIX
     {
       // Reference token for this Iort node
       REFERENCE_TOKEN (SmmuV3Info[Smmuv3info_ccix]),
@@ -852,7 +852,7 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       // Index into the array of ID mapping
       1
     },
-    //Remote Chip SMMU V3 setting
+    //Remote Chip SMMU V3 setting - Remote PCIe
     {
       REFERENCE_TOKEN (SmmuV3Info[Smmuv3info_remote_pcie]),
       2,
@@ -867,6 +867,165 @@ EDKII_PLATFORM_REPOSITORY_INFO N1sdpRepositoryInfo = {
       748,
       0,
       1
+    }
+  },
+
+  // PMCG Info
+  {
+    // Primary SMMU PMCG PCIe - TCU
+    {
+      // An unique token used to identify this object
+      REFERENCE_TOKEN (PmcgSmmuInfo[0]),
+      // Number of ID mappings
+      0,
+      // Reference token for the ID mapping array
+      CM_NULL_TOKEN,
+      // Base Address for performance monitor counter group
+      (SMMU_PCIE_BASE_ADDRESS_TCU1 + TCU_PMCG_PAGE0_OFFSET),
+      // GSIV for the Overflow interrupt
+      SMMU_PCIE_IRQ_TCU1,
+      // Page 1 Base address
+      (SMMU_PCIE_BASE_ADDRESS_TCU1 + TCU_PMCG_PAGE1_OFFSET),
+      // Reference token for the IORT node associated with this node
+      REFERENCE_TOKEN (SmmuV3Info[Smmuv3info_pcie])
+    },
+    // Primary SMMU PMCG PCIe - TBU1
+    {
+      // An unique token used to identify this object
+      REFERENCE_TOKEN (PmcgSmmuInfo[1]),
+      // Number of ID mappings
+      0,
+      // Reference token for the ID mapping array
+      CM_NULL_TOKEN,
+      // Base Address for performance monitor counter group
+      (SMMU_PCIE_BASE_ADDRESS_TBU1 + TBU_PMCG_PAGE0_OFFSET),
+      // GSIV for the Overflow interrupt
+      SMMU_PCIE_IRQ_TBU1,
+      // Page 1 Base address
+      (SMMU_PCIE_BASE_ADDRESS_TBU1 + TBU_PMCG_PAGE1_OFFSET),
+      // Reference token for the IORT node associated with this node
+      REFERENCE_TOKEN (SmmuV3Info[Smmuv3info_pcie])
+    },
+    // Primary SMMU PMCG PCIe - TBU0
+    {
+      // An unique token used to identify this object
+      REFERENCE_TOKEN (PmcgSmmuInfo[2]),
+      // Number of ID mappings
+      0,
+      // Reference token for the ID mapping array
+      CM_NULL_TOKEN,
+      // Base Address for performance monitor counter group
+      (SMMU_PCIE_BASE_ADDRESS_TBU0 + TBU_PMCG_PAGE0_OFFSET),
+      // GSIV for the Overflow interrupt
+      SMMU_PCIE_IRQ_TBU0,
+      // Page 1 Base address
+      (SMMU_PCIE_BASE_ADDRESS_TBU0 + TBU_PMCG_PAGE1_OFFSET),
+      // Reference token for the IORT node associated with this node
+      REFERENCE_TOKEN (SmmuV3Info[Smmuv3info_pcie])
+    },
+
+    // Primary SMMU PMCG CCIX - TCU
+    {
+      // An unique token used to identify this object
+      REFERENCE_TOKEN (PmcgSmmuInfo[3]),
+      // Number of ID mappings
+      0,
+      // Reference token for the ID mapping array
+      CM_NULL_TOKEN,
+      // Base Address for performance monitor counter group
+      (SMMU_CCIX_BASE_ADDRESS_TCU0 + TCU_PMCG_PAGE0_OFFSET),
+      // GSIV for the Overflow interrupt
+      SMMU_CCIX_IRQ_TCU0,
+      // Page 1 Base address
+      (SMMU_CCIX_BASE_ADDRESS_TCU0 + TCU_PMCG_PAGE1_OFFSET),
+      // Reference token for the IORT node associated with this node
+      REFERENCE_TOKEN (SmmuV3Info[Smmuv3info_ccix]),
+    },
+    // Primary SMMU PMCG CCIX - TBU1
+    {
+      // An unique token used to identify this object
+      REFERENCE_TOKEN (PmcgSmmuInfo[4]),
+      // Number of ID mappings
+      0,
+      // Reference token for the ID mapping array
+      CM_NULL_TOKEN,
+      // Base Address for performance monitor counter group
+      (SMMU_CCIX_BASE_ADDRESS_TBU1 + TBU_PMCG_PAGE0_OFFSET),
+      // GSIV for the Overflow interrupt
+      SMMU_CCIX_IRQ_TBU1,
+      // Page 1 Base address
+      (SMMU_CCIX_BASE_ADDRESS_TBU1 + TBU_PMCG_PAGE1_OFFSET),
+      // Reference token for the IORT node associated with this node
+      REFERENCE_TOKEN (SmmuV3Info[Smmuv3info_ccix]),
+    },
+    // Primary SMMU PMCG CCIX - TBU0
+    {
+      // An unique token used to identify this object
+      REFERENCE_TOKEN (PmcgSmmuInfo[5]),
+      // Number of ID mappings
+      0,
+      // Reference token for the ID mapping array
+      CM_NULL_TOKEN,
+      // Base Address for performance monitor counter group
+      (SMMU_CCIX_BASE_ADDRESS_TBU0 + TBU_PMCG_PAGE0_OFFSET),
+      // GSIV for the Overflow interrupt
+      SMMU_CCIX_IRQ_TBU0,
+      // Page 1 Base address
+      (SMMU_CCIX_BASE_ADDRESS_TBU0 + TBU_PMCG_PAGE1_OFFSET),
+      // Reference token for the IORT node associated with this node
+      REFERENCE_TOKEN (SmmuV3Info[Smmuv3info_ccix]),
+    },
+
+    // Remote SMMU PMCG PCIe - TCU
+    {
+      // An unique token used to identify this object
+      REFERENCE_TOKEN (PmcgSmmuInfo[6]),
+      // Number of ID mappings
+      0,
+      // Reference token for the ID mapping array
+      CM_NULL_TOKEN,
+      // Base Address for performance monitor counter group
+      (SMMU_PCIE_REMOTE_BASE_ADDRESS_TCU1 + TCU_PMCG_PAGE0_OFFSET),
+      // GSIV for the Overflow interrupt
+      SMMU_PCIE_REMOTE_IRQ_TCU1,
+      // Page 1 Base address
+      (SMMU_PCIE_REMOTE_BASE_ADDRESS_TCU1 + TCU_PMCG_PAGE1_OFFSET),
+      // Reference token for the IORT node associated with this node
+      REFERENCE_TOKEN (SmmuV3Info[Smmuv3info_remote_pcie]),
+    },
+    // Remote SMMU PMCG PCIe - TBU1
+    {
+      // An unique token used to identify this object
+      REFERENCE_TOKEN (PmcgSmmuInfo[7]),
+      // Number of ID mappings
+      0,
+      // Reference token for the ID mapping array
+      CM_NULL_TOKEN,
+      // Base Address for performance monitor counter group
+      (SMMU_PCIE_REMOTE_BASE_ADDRESS_TBU1 + TBU_PMCG_PAGE0_OFFSET),
+      // GSIV for the Overflow interrupt
+      SMMU_PCIE_REMOTE_IRQ_TBU1,
+      // Page 1 Base address
+      (SMMU_PCIE_REMOTE_BASE_ADDRESS_TBU1 + TBU_PMCG_PAGE1_OFFSET),
+      // Reference token for the IORT node associated with this node
+      REFERENCE_TOKEN (SmmuV3Info[Smmuv3info_remote_pcie]),
+    },
+    // Remote SMMU PMCG PCIe - TBU0
+    {
+      // An unique token used to identify this object
+      REFERENCE_TOKEN (PmcgSmmuInfo[8]),
+      // Number of ID mappings
+      0,
+      // Reference token for the ID mapping array
+      CM_NULL_TOKEN,
+      // Base Address for performance monitor counter group
+      (SMMU_PCIE_REMOTE_BASE_ADDRESS_TBU0 + TBU_PMCG_PAGE0_OFFSET),
+      // GSIV for the Overflow interrupt
+      SMMU_PCIE_REMOTE_IRQ_TBU0,
+      // Page 1 Base address
+      (SMMU_PCIE_REMOTE_BASE_ADDRESS_TBU0 + TBU_PMCG_PAGE1_OFFSET),
+      // Reference token for the IORT node associated with this node
+      REFERENCE_TOKEN (SmmuV3Info[Smmuv3info_remote_pcie]),
     }
   },
 
@@ -1862,6 +2021,7 @@ GetArmNameSpaceObject (
   UINT32                            ItsGroupInfoCount;
   UINT32                            ItsIdentifierArrayCount;
   UINT32                            SmmuV3InfoCount;
+  UINT32                            PmcgSmmuInfoCount;
   UINT32                            DeviceIdMappingCount;
   UINT32                            RootComplexInfoCount;
 
@@ -1882,6 +2042,7 @@ GetArmNameSpaceObject (
     ItsGroupInfoCount = Its_max;
     ItsIdentifierArrayCount = Its_max;
     SmmuV3InfoCount = Smmuv3info_max;
+    PmcgSmmuInfoCount = Smmuv3info_max * 3;
     DeviceIdMappingCount = Devicemapping_max;
     RootComplexInfoCount = Root_pcie_max;
   } else {
@@ -1891,6 +2052,7 @@ GetArmNameSpaceObject (
     ItsGroupInfoCount = Its_master_chip_max;
     ItsIdentifierArrayCount = Its_master_chip_max;
     SmmuV3InfoCount = Smmuv3info_master_chip_max;
+    PmcgSmmuInfoCount = Smmuv3info_master_chip_max * 3;
     DeviceIdMappingCount = Devicemapping_master_chip_max;
     RootComplexInfoCount = Root_pcie_master_chip_max;
   }
@@ -1998,6 +2160,16 @@ GetArmNameSpaceObject (
                  PlatformRepo->SmmuV3Info,
                  sizeof (PlatformRepo->SmmuV3Info),
                  SmmuV3InfoCount,
+                 CmObject
+                 );
+      break;
+
+    case EArmObjPmcg:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 PlatformRepo->PmcgSmmuInfo,
+                 sizeof (PlatformRepo->PmcgSmmuInfo),
+                 PmcgSmmuInfoCount,
                  CmObject
                  );
       break;

--- a/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/N1Sdp/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -178,6 +178,98 @@ typedef EFI_STATUS (*CM_OBJECT_HANDLER_PROC) (
 #define REMOTE_DDR_REGION2  3
 #define DDR_REGION_COUNT    4
 
+/** TCU Performance Monitor Counter Group (PMCG) registers,
+    page 0, offset.
+*/
+#define TCU_PMCG_PAGE0_OFFSET       0x02000
+
+/** TCU Performance Monitor Counter Group (PMCG) registers,
+    page 1, offset.
+*/
+#define TCU_PMCG_PAGE1_OFFSET       0x22000
+
+/** TBU Performance Monitor Counter Group (PMCG) registers,
+    page 0, offset.
+*/
+#define TBU_PMCG_PAGE0_OFFSET       0x02000
+
+/** TBU Performance Monitor Counter Group (PMCG) registers,
+    page 1, offset.
+*/
+#define TBU_PMCG_PAGE1_OFFSET       0x12000
+
+/** Primary Chip MMU-600 PCIe-TBU1 Base Address.
+*/
+#define SMMU_PCIE_BASE_ADDRESS_TBU1 0x4F460000
+
+/** Primary Chip MMU-600 PCIe-TBU0 Base Address.
+*/
+#define SMMU_PCIE_BASE_ADDRESS_TBU0 0x4F440000
+
+/** Primary Chip MMU-600 PCIe-TCU1 Base Address.
+*/
+#define SMMU_PCIE_BASE_ADDRESS_TCU1 0x4F400000
+
+/** Primary Chip MMU-600 CCIX-TBU1 Base Address.
+*/
+#define SMMU_CCIX_BASE_ADDRESS_TBU1 0x4F060000
+
+/** Primary Chip MMU-600 CCIX-TBU1 Base Address.
+*/
+#define SMMU_CCIX_BASE_ADDRESS_TBU0 0x4F040000
+
+/** Primary Chip MMU-600 CCIX-TCU0 Base Address.
+*/
+#define SMMU_CCIX_BASE_ADDRESS_TCU0 0x4F000000
+
+/** Remote Chip MMU-600 PCIe-TBU1 Base Address.
+*/
+#define SMMU_PCIE_REMOTE_BASE_ADDRESS_TBU1 0x4004F460000
+
+/** Remote Chip MMU-600 PCIe-TBU0 Base Address.
+*/
+#define SMMU_PCIE_REMOTE_BASE_ADDRESS_TBU0 0x4004F440000
+
+/** Remote Chip MMU-600 PCIe-TCU1 Base Address.
+*/
+#define SMMU_PCIE_REMOTE_BASE_ADDRESS_TCU1 0x4004F400000
+
+/** Primary Chip MMU-600 PCIe-TCU1 IRQ.
+*/
+#define SMMU_PCIE_IRQ_TCU1    263
+
+/** Primary Chip MMU-600 PCIe-TBU0 IRQ.
+*/
+#define SMMU_PCIE_IRQ_TBU0    286
+
+/** Primary Chip MMU-600 PCIe-TBU1 IRQ.
+*/
+#define SMMU_PCIE_IRQ_TBU1    287
+
+/** Primary Chip MMU-600 CCIX-TCU0 IRQ.
+*/
+#define SMMU_CCIX_IRQ_TCU0    256
+
+/** Primary Chip MMU-600 CCIX-TBU0 IRQ.
+*/
+#define SMMU_CCIX_IRQ_TBU0    284
+
+/** Primary Chip MMU-600 CCIX-TBU1 IRQ.
+*/
+#define SMMU_CCIX_IRQ_TBU1    285
+
+/** Remote Chip MMU-600 PCIe-TCU1 IRQ.
+*/
+#define SMMU_PCIE_REMOTE_IRQ_TCU1   (SMMU_PCIE_IRQ_TCU1 + 480)
+
+/** Remote Chip MMU-600 PCIe-TBU0 IRQ.
+*/
+#define SMMU_PCIE_REMOTE_IRQ_TBU0    (SMMU_PCIE_IRQ_TBU0 + 480)
+
+/** Remote Chip MMU-600 PCIe-TBU1 IRQ.
+*/
+#define SMMU_PCIE_REMOTE_IRQ_TBU1    (SMMU_PCIE_IRQ_TBU1 + 480)
+
 typedef enum {
    Its_smmu_ccix = 0,
    Its_smmu_pcie,
@@ -289,6 +381,9 @@ typedef struct PlatformRepositoryInfo {
 
   /// SMMUv3 node
   CM_ARM_SMMUV3_NODE                    SmmuV3Info[Smmuv3info_max];
+
+  /// SMMU PMCG node
+  CM_ARM_PMCG_NODE                      PmcgSmmuInfo[Smmuv3info_max * 3];
 
   /// PCI Root complex node
   CM_ARM_ROOT_COMPLEX_NODE              RootComplexInfo[Root_pcie_max];


### PR DESCRIPTION
The N1SDP board has two MMU-600 devices used for PCIe and CCIX. Similar, configuration exists for the second (remote) chip. The N1SDP firmware is describing the SMMUv3 nodes in the IORT table.

This patch adds support for describing the PMCG nodes for these SMMUs.