### PR TITLE
Levi/fix build fail

### DIFF
--- a/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
+++ b/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
@@ -147,7 +147,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize|0x00010000
 !endif
 
-  gArmTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
 
   #
   # The BFV is not located in the Flash area but is loaded in the RAM

--- a/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
+++ b/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
@@ -68,6 +68,7 @@
   StandaloneMmCoreEntryPoint|ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
   StandaloneMmDriverEntryPoint|MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
   VariableMmDependency|StandaloneMmPkg/Library/VariableMmDependency/VariableMmDependency.inf
+  PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
 
   # ARM PL011 UART Driver
   PL011UartClockLib|ArmPlatformPkg/Library/PL011UartClockLib/PL011UartClockLib.inf

--- a/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
+++ b/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
@@ -54,6 +54,7 @@
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.inf
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
+  PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
 
   #
   # Entry point

--- a/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
+++ b/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
@@ -110,7 +110,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize|0x00004000
   gEfiMdeModulePkgTokenSpaceGuid.PcdVariableStoreSize|0x00004000
 
-  gArmTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
 
   # The BFV is not located in the Flash area but is loaded in the RAM
   # by optee's stmm_sp.c instead, therefore no shadow copy is needed.


### PR DESCRIPTION
This patch fix the build failure of StandaloneMm in 
StandaloneMmRpmb and ARM/VExpressPkg platform for

    - PerformanceLib
        Since commit commit 4e4edd0f0772 ("StandaloneMmPkg/Core: Performance logging for MM driver load and start")
        in edk2, PerformaceLib is required to build StandaloneMmCore.

    - Token Sapce for PcdFfaLibConduitSmc
        Since commit be03ceb1176d ("ArmPkg: ArmFfaLib: Move ArmFfaLib implementation to MdeModulePkg") in edk2,
        ArmFfaLib is moved to MdeModulePkg from ArmPkg in edk2 repository.

        and commit https://github.com/tianocore/edk2-platforms/commit/b9b9716a3ffa70485713766320b30fb034a80a46
       ("StandaloneMm: PlatformStandaloneMmPkg: Update Library Paths for SMC/SVC/FFA")
       applies this change without change token space for PcdFfaLibConduitSmc

