### PR TITLE
IpmiFeaturePkg: Add Support for PcdStandaloneMmEnable

### DIFF
--- a/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/Include/IpmiFeature.dsc
+++ b/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/Include/IpmiFeature.dsc
@@ -6,7 +6,7 @@
 # INF files to generate AutoGen.c and AutoGen.h files
 # for the build infrastructure.
 #
-# Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2019 - 2025, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) 1985 - 2023, American Megatrends International LLC. <BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -120,14 +120,17 @@
   IpmiFeaturePkg/Library/SmmIpmiBaseLib/SmmIpmiBaseLib.inf
   IpmiFeaturePkg/BmcAcpi/BmcAcpi.inf
   IpmiFeaturePkg/BmcAcpiState/BmcAcpiState.inf
-  IpmiFeaturePkg/BmcAcpiSwChild/BmcAcpiSwChild.inf
-  IpmiFeaturePkg/BmcAcpiSwChild/BmcAcpiSwChildStandaloneMm.inf
   IpmiFeaturePkg/BmcElog/DxeBmcElog.inf
-  IpmiFeaturePkg/BmcElog/SmmBmcElog.inf
-  IpmiFeaturePkg/BmcElog/StandaloneMmBmcElog.inf
   IpmiFeaturePkg/GenericElog/Dxe/GenericElog.inf
-  IpmiFeaturePkg/GenericElog/Smm/GenericElog.inf
+!if gMinPlatformPkgTokenSpaceGuid.PcdStandaloneMmEnable == TRUE
+  IpmiFeaturePkg/BmcAcpiSwChild/BmcAcpiSwChildStandaloneMm.inf
+  IpmiFeaturePkg/BmcElog/StandaloneMmBmcElog.inf
   IpmiFeaturePkg/GenericElog/Smm/GenericElogStandaloneMm.inf
+!else
+  IpmiFeaturePkg/BmcAcpiSwChild/BmcAcpiSwChild.inf
+  IpmiFeaturePkg/BmcElog/SmmBmcElog.inf
+  IpmiFeaturePkg/GenericElog/Smm/GenericElog.inf
+!endif
   IpmiFeaturePkg/Frb/FrbDxe.inf
   IpmiFeaturePkg/IpmiRedirFru/IpmiRedirFru.inf
   IpmiFeaturePkg/GenericFru/GenericFru.inf

--- a/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/Include/PostMemory.fdf
+++ b/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/Include/PostMemory.fdf
@@ -1,7 +1,7 @@
 ## @file
 #  FDF file for post-memory modules that enable Intelligent Platform Management Interface.
 #
-# Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2019 - 2025, Intel Corporation. All rights reserved.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -11,13 +11,19 @@ INF IpmiFeaturePkg/GenericIpmi/Dxe/GenericIpmi.inf
 INF IpmiFeaturePkg/IpmiInit/DxeIpmiInit.inf
 INF RuleOverride = DRIVER_ACPITABLE IpmiFeaturePkg/BmcAcpi/BmcAcpi.inf
 INF IpmiFeaturePkg/BmcAcpiState/BmcAcpiState.inf
-INF IpmiFeaturePkg/BmcAcpiSwChild/BmcAcpiSwChild.inf
 INF IpmiFeaturePkg/BmcElog/DxeBmcElog.inf
-INF IpmiFeaturePkg/BmcElog/SmmBmcElog.inf
+INF IpmiFeaturePkg/GenericElog/Dxe/GenericElog.inf
+!if gMinPlatformPkgTokenSpaceGuid.PcdStandaloneMmEnable == TRUE
+  IpmiFeaturePkg/BmcAcpiSwChild/BmcAcpiSwChildStandaloneMm.inf
+  IpmiFeaturePkg/BmcElog/StandaloneMmBmcElog.inf
+  IpmiFeaturePkg/GenericElog/Smm/GenericElogStandaloneMm.inf
+!else
+  INF IpmiFeaturePkg/BmcAcpiSwChild/BmcAcpiSwChild.inf
+  INF IpmiFeaturePkg/BmcElog/SmmBmcElog.inf
+  INF IpmiFeaturePkg/GenericElog/Smm/GenericElog.inf
+!endif
 INF IpmiFeaturePkg/Frb/FrbDxe.inf
 INF IpmiFeaturePkg/IpmiRedirFru/IpmiRedirFru.inf
-INF IpmiFeaturePkg/GenericElog/Dxe/GenericElog.inf
-INF IpmiFeaturePkg/GenericElog/Smm/GenericElog.inf
 INF IpmiFeaturePkg/GenericFru/GenericFru.inf
 INF IpmiFeaturePkg/OsWdt/OsWdt.inf
 INF IpmiFeaturePkg/SolStatus/SolStatus.inf


### PR DESCRIPTION
- Build Standalone MM IPMI drivers only when Standalone MM is enabled.
- Include the correct SMM/Standalone MM IPMI drivers into FvAdvanced.