### PR TITLE
Platform/ARM/SgiPkg: Correct the comment as per instruction

### DIFF
--- a/Platform/ARM/SgiPkg/Library/PlatformLib/AArch64/Helper.S
+++ b/Platform/ARM/SgiPkg/Library/PlatformLib/AArch64/Helper.S
@@ -18,7 +18,7 @@ GCC_ASM_IMPORT(NtFwConfigDtBlob)
 //
 // First platform specific function to be called in the PEI phase
 //
-// The trusted firmware passed the hw config DT blob in x1 register.
+// The trusted firmware passed the NT FW config DT blob in x0 register.
 // Keep a copy of it in a global variable.
 //VOID
 //ArmPlatformPeiBootAction (


### PR DESCRIPTION
Commit 327ff4a (Platform/ARM/Sgi: Use NT_FW_CONFIG instead of HW_CONFIG) started using NT_FW_CONFIG instead of HW_CONFIG but did not update the comment. Update the comment inline with what is actually being done.