### PR TITLE
IntelSiliconPkg: Add IntelVTdPeiDxeLib to DEC LibraryClasses

### DIFF
--- a/Silicon/Intel/IntelSiliconPkg/IntelSiliconPkg.dec
+++ b/Silicon/Intel/IntelSiliconPkg/IntelSiliconPkg.dec
@@ -55,6 +55,10 @@
   #
   SpiFlashCommonLib|Include/Library/SpiFlashCommonLib.h
 
+  ## @libraryclass Provides Intel VT-d services
+  #
+  IntelVTdPeiDxeLib|Include/Library/IntelVTdPeiDxeLib.h
+
 [Guids]
   ## GUID for Package token space
   # {A9F8D54E-1107-4F0A-ADD0-4587E7A4A735}


### PR DESCRIPTION
The library class is currently missing in the `LibraryClasses` section.