### PR TITLE
Platform/RaspberryPi/Readme: Mention Pi 400

### DIFF
--- a/Platform/RaspberryPi/RPi4/Readme.md
+++ b/Platform/RaspberryPi/RPi4/Readme.md
@@ -16,6 +16,7 @@ Raspberry Pi is a trademark of the [Raspberry Pi Foundation](https://www.raspber
 
 The RPi4 target supports Pi revisions based on the BCM2711 SoC:
 - Raspberry Pi 4B
+- Raspberry Pi 400
 
 Please see the RPi3 target for the BCM2837-based variants, such as the Raspberry
 Pi 3B.
@@ -44,7 +45,7 @@ Build instructions from the top level edk2-platforms Readme.md apply.
 1. Format a uSD card as FAT16 or FAT32
 2. Copy the generated `RPI_EFI.fd` firmware onto the partition
 3. Download and copy the following files from https://github.com/raspberrypi/firmware/tree/master/boot
-  - `bcm2711-rpi-4-b.dtb`
+  - `bcm2711-rpi-4-b.dtb` or `bcm2711-rpi-400.dtb`
   - `fixup4.dat`
   - `start4.elf`
   - `overlays/miniuart-bt.dbto` or `overlays/disable-bt.dtbo` (Optional)
@@ -84,6 +85,7 @@ By default, UEFI will use the device tree loaded by the VideoCore firmware. This
 depends on the model/variant, and relies on the presence on specific files on your boot media.
 E.g.:
  - `bcm2711-rpi-4-b.dtb` (for Pi 4B)
+ - `bcm2711-rpi-400.dtb` (for Pi 400)
 
 You can override the DTB and provide a custom one. Copy the relevant `.dtb` into the root of
 the SD or USB, and then edit your `config.txt` so that it looks like:


### PR DESCRIPTION
This worked on my Pi 400, when using it's overlay so adjust the doc accordingly for visibility. It probably also works on CM4, but I don't have the hardware to test. 

Out of scope question:
Why does this doc suggest setting `disable_commandline_tags` to `2` on line 58 (currently 57)?

Raspberry Pi doc [^1] says "Set the disable_commandline_tags command to 1 to stop start.elf from filling in ATAGS (memory from 0x100) before launching the kernel."

Thanks!

[^1]: https://www.raspberrypi.com/documentation/computers/legacy_config_txt.html#disable_commandline_tags