### PR TITLE
Various platforms: Migrate to MdePkg BaseFdtLib

### DIFF
--- a/Platform/ARM/Drivers/FdtPlatformDxe/FdtPlatform.c
+++ b/Platform/ARM/Drivers/FdtPlatformDxe/FdtPlatform.c
@@ -9,7 +9,9 @@
 #include "FdtPlatform.h"
 
 #include <Library/PcdLib.h>
+#include <Library/BaseMemoryLib.h>
 #include <Library/DevicePathLib.h>
+#include <Library/FdtLib.h>
 #include <Library/BdsLib.h>
 
 #include <Protocol/DevicePath.h>
@@ -92,8 +94,8 @@ InstallFdt (
   // Ensure that the FDT header is valid and that the Size of the Device Tree
   // is smaller than the size of the read file
   //
-  if (fdt_check_header ((VOID*)(UINTN)FdtBlobBase) != 0 ||
-      (UINTN)fdt_totalsize ((VOID*)(UINTN)FdtBlobBase) > FdtBlobSize) {
+  if (FdtCheckHeader ((VOID*)(UINTN)FdtBlobBase) != 0 ||
+      (UINTN)FdtTotalSize ((VOID*)(UINTN)FdtBlobBase) > FdtBlobSize) {
     DEBUG ((DEBUG_ERROR, "InstallFdt() - loaded FDT binary image seems corrupt\n"));
     Status = EFI_LOAD_ERROR;
     goto Error;

--- a/Platform/ARM/Drivers/FdtPlatformDxe/FdtPlatform.h
+++ b/Platform/ARM/Drivers/FdtPlatformDxe/FdtPlatform.h
@@ -26,8 +26,6 @@
 
 #include <Guid/Fdt.h>
 
-#include <libfdt.h>
-
 extern EFI_HANDLE mFdtPlatformDxeHiiHandle;
 
 /**

--- a/Platform/ARM/JunoPkg/ArmJuno.dsc
+++ b/Platform/ARM/JunoPkg/ArmJuno.dsc
@@ -405,7 +405,7 @@
   Platform/ARM/Drivers/FdtPlatformDxe/FdtPlatformDxe.inf {
     <LibraryClasses>
       BdsLib|Platform/ARM/Library/BdsLib/BdsLib.inf
-      FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf  # Map to deprecated library for this module only
+      FdtLib|MdePkg/Library/BaseFdtLib/BaseFdtLib.inf
   }
 
   # SCMI Driver

--- a/Platform/ARM/N1Sdp/N1SdpPlatform.dsc
+++ b/Platform/ARM/N1Sdp/N1SdpPlatform.dsc
@@ -238,7 +238,7 @@
   # PEI Phase modules
   Silicon/ARM/NeoverseN1Soc/Library/N1SdpNtFwConfigPei/NtFwConfigPei.inf {
     <LibraryClasses>
-      FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf  # Map to deprecated library for this module only
+      FdtLib|MdePkg/Library/BaseFdtLib/BaseFdtLib.inf
   }
 
   # Human Interface Support

--- a/Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
+++ b/Platform/ARM/SgiPkg/SgiPlatform.dsc.inc
@@ -234,7 +234,7 @@
   }
   Platform/ARM/SgiPkg/Library/SgiPlatformPei/SgiPlatformPei.inf {
     <LibraryClasses>
-      FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf  # Map to deprecated library for this module only
+      FdtLib|MdePkg/Library/BaseFdtLib/BaseFdtLib.inf
   }
 
   #

--- a/Platform/RaspberryPi/RPi3/RPi3.dsc
+++ b/Platform/RaspberryPi/RPi3/RPi3.dsc
@@ -635,10 +635,7 @@
   UefiCpuPkg/CpuIo2Dxe/CpuIo2Dxe.inf
   Silicon/Broadcom/Bcm283x/Drivers/InterruptDxe/InterruptDxe.inf
   Platform/RaspberryPi/Drivers/RpiFirmwareDxe/RpiFirmwareDxe.inf
-  Platform/RaspberryPi/Drivers/FdtDxe/FdtDxe.inf {
-    <LibraryClasses>
-      FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf  # Map to deprecated library for this module only
-  }
+  Platform/RaspberryPi/Drivers/FdtDxe/FdtDxe.inf
   Platform/RaspberryPi/Drivers/ConfigDxe/ConfigDxe.inf
   ArmPkg/Drivers/TimerDxe/TimerDxe.inf
   MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf

--- a/Platform/RaspberryPi/RPi4/RPi4.dsc
+++ b/Platform/RaspberryPi/RPi4/RPi4.dsc
@@ -660,10 +660,7 @@
 
   ArmPkg/Drivers/ArmGicDxe/ArmGicV2Dxe.inf
   Platform/RaspberryPi/Drivers/RpiFirmwareDxe/RpiFirmwareDxe.inf
-  Platform/RaspberryPi/Drivers/FdtDxe/FdtDxe.inf {
-    <LibraryClasses>
-      FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf  # Map to deprecated library for this module only
-  }
+  Platform/RaspberryPi/Drivers/FdtDxe/FdtDxe.inf
   Platform/RaspberryPi/Drivers/ConfigDxe/ConfigDxe.inf
   ArmPkg/Drivers/TimerDxe/TimerDxe.inf
   MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf

--- a/Silicon/ARM/NeoverseN1Soc/Library/N1SdpNtFwConfigPei/NtFwConfigPei.c
+++ b/Silicon/ARM/NeoverseN1Soc/Library/N1SdpNtFwConfigPei/NtFwConfigPei.c
@@ -6,10 +6,10 @@
 **/
 
 #include <Library/DebugLib.h>
+#include <Library/FdtLib.h>
 #include <Library/HobLib.h>
 #include <Library/PeiServicesLib.h>
 
-#include <libfdt.h>
 #include <NeoverseN1Soc.h>
 
 STATIC EFI_PEI_PPI_DESCRIPTOR  mPpi;
@@ -60,7 +60,7 @@ NtFwConfigPeEntryPoint (
   }
 
   FdtBase = ParamPpi->NtFwConfig;
-  if (fdt_check_header (FdtBase) != 0) {
+  if (FdtCheckHeader (FdtBase) != 0) {
     DEBUG ((DEBUG_ERROR, "Invalid DTB file %p passed\n", FdtBase));
     return EFI_INVALID_PARAMETER;
   }
@@ -78,43 +78,43 @@ NtFwConfigPeEntryPoint (
     return EFI_OUT_OF_RESOURCES;
   }
 
-  Offset = fdt_subnode_offset (FdtBase, 0, "platform-info");
+  Offset = FdtSubnodeOffset (FdtBase, 0, "platform-info");
   if (Offset == -FDT_ERR_NOTFOUND) {
     DEBUG ((DEBUG_ERROR, "Invalid DTB : platform-info node not found\n"));
     return EFI_NOT_FOUND;
   }
 
-  Property = fdt_getprop (FdtBase, Offset, "local-ddr-size", NULL);
+  Property = FdtGetProp (FdtBase, Offset, "local-ddr-size", NULL);
   if (Property == NULL) {
     DEBUG ((DEBUG_ERROR, "local-ddr-size property not found\n"));
     return EFI_NOT_FOUND;
   }
 
-  PlatInfo->LocalDdrSize = fdt32_to_cpu (*Property);
+  PlatInfo->LocalDdrSize = Fdt32ToCpu (*Property);
 
-  Property = fdt_getprop (FdtBase, Offset, "remote-ddr-size", NULL);
+  Property = FdtGetProp (FdtBase, Offset, "remote-ddr-size", NULL);
   if (Property == NULL) {
     DEBUG ((DEBUG_ERROR, "remote-ddr-size property not found\n"));
     return EFI_NOT_FOUND;
   }
 
-  PlatInfo->RemoteDdrSize = fdt32_to_cpu (*Property);
+  PlatInfo->RemoteDdrSize = Fdt32ToCpu (*Property);
 
-  Property = fdt_getprop (FdtBase, Offset, "secondary-chip-count", NULL);
+  Property = FdtGetProp (FdtBase, Offset, "secondary-chip-count", NULL);
   if (Property == NULL) {
     DEBUG ((DEBUG_ERROR, "secondary-chip-count property not found\n"));
     return EFI_NOT_FOUND;
   }
 
-  PlatInfo->SecondaryChipCount = fdt32_to_cpu (*Property);
+  PlatInfo->SecondaryChipCount = Fdt32ToCpu (*Property);
 
-  Property = fdt_getprop (FdtBase, Offset, "multichip-mode", NULL);
+  Property = FdtGetProp (FdtBase, Offset, "multichip-mode", NULL);
   if (Property == NULL) {
     DEBUG ((DEBUG_ERROR, "multichip-mode property not found\n"));
     return EFI_NOT_FOUND;
   }
 
-  PlatInfo->MultichipMode = fdt32_to_cpu (*Property);
+  PlatInfo->MultichipMode = Fdt32ToCpu (*Property);
 
   mPpi.Flags = EFI_PEI_PPI_DESCRIPTOR_PPI
                | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST;

--- a/Silicon/Marvell/OdysseyPkg/OdysseyPkg.dsc.inc
+++ b/Silicon/Marvell/OdysseyPkg/OdysseyPkg.dsc.inc
@@ -326,14 +326,8 @@
   #
   # FDT support
   #
-  Silicon/Marvell/Drivers/Fdt/FdtPlatformDxe/FdtPlatformDxe.inf {
-    <LibraryClasses>
-      FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf  # Map to deprecated library for this module only
-  }
-  Silicon/Marvell/Drivers/Fdt/FdtClientDxe/FdtClientDxe.inf {
-    <LibraryClasses>
-      FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf  # Map to deprecated library for this module only
-  }
+  Silicon/Marvell/Drivers/Fdt/FdtPlatformDxe/FdtPlatformDxe.inf
+  Silicon/Marvell/Drivers/Fdt/FdtClientDxe/FdtClientDxe.inf
 
   # No EMMC/SD Interface
 
@@ -351,11 +345,10 @@
       NULL|ShellPkg/Library/UefiShellInstall1CommandsLib/UefiShellInstall1CommandsLib.inf
       NULL|ShellPkg/Library/UefiShellNetwork1CommandsLib/UefiShellNetwork1CommandsLib.inf
       NULL|ShellPkg/Library/UefiShellNetwork2CommandsLib/UefiShellNetwork2CommandsLib.inf
-      NULL|Silicon/Marvell/Applications/DumpFdt/DumpFdt.inf
+#      NULL|Silicon/Marvell/Applications/DumpFdt/DumpFdt.inf
       HandleParsingLib|ShellPkg/Library/UefiHandleParsingLib/UefiHandleParsingLib.inf
       PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
       BcfgCommandLib|ShellPkg/Library/UefiShellBcfgCommandLib/UefiShellBcfgCommandLib.inf
-      FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf  # Map to deprecated library for this module only
   }
 
   ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf


### PR DESCRIPTION
EmbeddedPkg FdtLib is getting deleted, so upgrade affected platforms that actually build.

Note: sgi575 appears broken due to unrelated ArmFfaLib changes, but I fixed the things that seem related to FdtLib.