### PR TITLE
JadePkg: Add missing RedfishPlatformWantedDeviceLib

### DIFF
--- a/Platform/Ampere/JadePkg/Jade.dsc
+++ b/Platform/Ampere/JadePkg/Jade.dsc
@@ -99,6 +99,7 @@
 !if $(REDFISH_ENABLE) == TRUE
   RedfishContentCodingLib|RedfishPkg/Library/RedfishContentCodingLibNull/RedfishContentCodingLibNull.inf
   RedfishPlatformHostInterfaceLib|RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.inf
+  RedfishPlatformWantedDeviceLib|RedfishPkg/Library/RedfishPlatformWantedDeviceLibNull/RedfishPlatformWantedDeviceLibNull.inf
 !endif
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]


### PR DESCRIPTION
This fixes the compilation error due to missing dependency on RedfishPlatformWantedDeviceLib which is recently introduced by the RedfishPkg.