### PR TITLE
MinPlatformPkg: Update CpuExceptionHandlerLib instance for PEI

### DIFF
--- a/Platform/Intel/MinPlatformPkg/Include/Dsc/CorePeiLib.dsc
+++ b/Platform/Intel/MinPlatformPkg/Include/Dsc/CorePeiLib.dsc
@@ -2,6 +2,7 @@
 #  Platform description.
 #
 # Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -48,6 +49,7 @@
   VariableReadLib|MinPlatformPkg/Library/BaseVariableReadLibNull/BaseVariableReadLibNull.inf
 
 [LibraryClasses.common.PEI_CORE, LibraryClasses.common.PEIM]
+  CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiCpuExceptionHandlerLib.inf
   TimerLib|PcAtChipsetPkg/Library/AcpiTimerLib/PeiAcpiTimerLib.inf
 
 [LibraryClasses.common.PEIM]


### PR DESCRIPTION
Set the appropriate CpuExceptionHandlerLib library instance for PEIM and PEI_CORE in MinPlatformPkg.