### PR TITLE
Platform/ARM/VExpressPkg: change PcdDebugPropertyMask for StandaloneMm

### DIFF
--- a/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
+++ b/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
@@ -120,8 +120,13 @@
 #
 ################################################################################
 [PcdsFixedAtBuild]
+!if $(TARGET) == RELEASE
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x21
+!else
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x2f
+!endif
+
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x8000008F
-  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0xff
   gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue|0xAF
 
   ## PL011 - Serial Terminal.


### PR DESCRIPTION
    The current PcdDebugPropertyMask setting for StandaloneMm is 0xff,
    which includes the DEBUG_PROPERTY_ASSERT_BREAKPOINT_ENABLED (0x10) flag.
    However, the svc #dbdb instruction is not implemented by the SPMCs.
    
    So in some cases even when ASSERT() fails, execution continues
    instead of halting. For instance, when SPMC_AT_EL3 is used,
    the svc #dbdb instruction is translated into an SMC call by SPMC.
    Since there is no SMC handler for #dbdb, CpuBreakPoint() returns
    SMC_UNKNOWN, resulting in the system continuing execution rather
    than stopping.
    
    In other cases, the svc #dbdb results in an exception in the SPMC,
    e.g. Rust-SPMC.
    
    By changing PcdDebugPropertyMask, let StandaloneMm call CpuDeadloop()
    when it hits an ASSERT().
    
Signed-off-by: Yeoreum Yun <yeoreum.yun@arm.com>