### PR TITLE
Platform: VExpressPkg: Add GICv5 support

### DIFF
--- a/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
@@ -169,9 +169,6 @@
   gArmPlatformTokenSpaceGuid.PcdSerialDbgUartBaudRate|115200
   gArmPlatformTokenSpaceGuid.PcdSerialDbgUartClkInHz|24000000
 
-  # SBSA Generic Watchdog
-  gArmTokenSpaceGuid.PcdGenericWatchdogEl2IntrNum|59
-
   ## PL031 RealTimeClock
   gArmPlatformTokenSpaceGuid.PcdPL031RtcBase|0x1C170000
 
@@ -179,7 +176,6 @@
   gArmPlatformTokenSpaceGuid.PcdWatchdogCount|1
   gArmTokenSpaceGuid.PcdGenericWatchdogControlBase|0x2a440000
   gArmTokenSpaceGuid.PcdGenericWatchdogRefreshBase|0x2a450000
-  gArmTokenSpaceGuid.PcdGenericWatchdogEl2IntrNum|59
 
 !ifdef EDK2_ENABLE_PL111
   ## PL111 Versatile Express Motherboard controller
@@ -196,6 +192,8 @@
   gArmTokenSpaceGuid.PcdGicDistributorBase|0x2f000000
   gArmTokenSpaceGuid.PcdGicRedistributorsBase|0x2f100000
   gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase|0x2C000000
+
+  gArmTokenSpaceGuid.PcdGicIrsConfigFrameBase|0x2f1a0000
 
   #
   # PCI Root Complex
@@ -216,6 +214,11 @@
   # ACPI Table Version
   #
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiExposedTableVersions|0x20
+
+[PcdsDynamicDefault.common]
+  # ARM Generic Watchdog Interrupt number for GIC pre-v5
+  # This will be overwritten when GICv5 is in use
+  gArmTokenSpaceGuid.PcdGenericWatchdogEl2IntrNum|59
 
 ################################################################################
 #
@@ -324,10 +327,14 @@
   ArmPkg/Drivers/ArmGicDxe/ArmGicDxe.inf
   Platform/ARM/Drivers/NorFlashDxe/NorFlashDxe.inf
   ArmPkg/Drivers/TimerDxe/TimerDxe.inf
+
 !ifdef EDK2_ENABLE_PL111
   ArmPlatformPkg/Drivers/LcdGraphicsOutputDxe/LcdGraphicsOutputDxe.inf
 !endif
-  ArmPkg/Drivers/GenericWatchdogDxe/GenericWatchdogDxe.inf
+  ArmPkg/Drivers/GenericWatchdogDxe/GenericWatchdogDxe.inf {
+    <LibraryClasses>
+      NULL|Platform/ARM/VExpressPkg/Library/ArmVExpressWatchdogLib/ArmVExpressWatchdogLib.inf
+  }
 
   # SMBIOS Support
 

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -29,7 +29,7 @@
 /** The platform configuration repository information.
 */
 STATIC
-EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
+EDKII_PLATFORM_REPOSITORY_INFO  VExpressPlatRepositoryInfo = {
   /// Configuration Manager information
   { CONFIGURATION_MANAGER_REVISION, CFG_MGR_OEM_ID },
 
@@ -68,7 +68,7 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
       EFI_ACPI_6_3_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
       0, // Unused
       CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdDsdt),
-      (EFI_ACPI_DESCRIPTION_HEADER*)dsdt_aml_code
+      (EFI_ACPI_DESCRIPTION_HEADER *)dsdt_aml_code
     },
     // DBG2 Table
     {
@@ -112,17 +112,17 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
       0, // Unused
       CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdSsdtPciExpress),
       NULL,
-      SIGNATURE_64 ('S','S','D','T','-','P','C','I')
+      SIGNATURE_64 ('S', 'S', 'D', 'T', '-', 'P', 'C', 'I')
     },
   },
 
   // Boot architecture information
   { EFI_ACPI_6_5_ARM_PSCI_COMPLIANT },              // BootArchFlags
 
-#ifdef HEADLESS_PLATFORM
+ #ifdef HEADLESS_PLATFORM
   // Fixed feature flag information
   { EFI_ACPI_6_5_HEADLESS },                        // Fixed feature flags
-#endif
+ #endif
 
   // Power management profile information
   { EFI_ACPI_6_5_PM_PROFILE_ENTERPRISE_SERVER },    // PowerManagement Profile
@@ -391,23 +391,23 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
 
   // PCI address-range mapping information
   {
-    { // PciAddressMapInfo[0] -> 32-bit BAR Window
-      PCI_SS_M32,    // SpaceCode
-      0x50000000,    // PciAddress
-      0x50000000,    // CpuAddress
-      0x08000000     // AddressSize
+    {             // PciAddressMapInfo[0] -> 32-bit BAR Window
+      PCI_SS_M32, // SpaceCode
+      0x50000000, // PciAddress
+      0x50000000, // CpuAddress
+      0x08000000  // AddressSize
     },
-    { // PciAddressMapInfo[1] -> 64-bit BAR Window
-      PCI_SS_M64,    // SpaceCode
-      0x4000000000,  // PciAddress
-      0x4000000000,  // CpuAddress
-      0x0100000000   // AddressSize
+    {               // PciAddressMapInfo[1] -> 64-bit BAR Window
+      PCI_SS_M64,   // SpaceCode
+      0x4000000000, // PciAddress
+      0x4000000000, // CpuAddress
+      0x0100000000  // AddressSize
     },
-    { // PciAddressMapInfo[2] -> IO BAR Window
-      PCI_SS_IO,     // SpaceCode
-      0x00000000,    // PciAddress
-      0x5f800000,    // CpuAddress
-      0x00800000     // AddressSize
+    {             // PciAddressMapInfo[2] -> IO BAR Window
+      PCI_SS_IO,  // SpaceCode
+      0x00000000, // PciAddress
+      0x5f800000, // CpuAddress
+      0x00800000  // AddressSize
     },
   },
 
@@ -421,37 +421,37 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
 
   // PCI device legacy interrupts mapping information
   {
-    { // PciInterruptMapInfo[0] -> Device 0, INTA
-      0,   // PciBus
-      0,   // PciDevice
-      0,   // PciInterrupt
+    {    // PciInterruptMapInfo[0] -> Device 0, INTA
+      0, // PciBus
+      0, // PciDevice
+      0, // PciInterrupt
       {
         168, // Interrupt
         0x0  // Flags
       }
     },
-    { // PciInterruptMapInfo[1] -> Device 0, INTB
-      0,   // PciBus
-      0,   // PciDevice
-      1,   // PciInterrupt
+    {    // PciInterruptMapInfo[1] -> Device 0, INTB
+      0, // PciBus
+      0, // PciDevice
+      1, // PciInterrupt
       {
         169, // Interrupt
         0x0  // Flags
       }
     },
-    { // PciInterruptMapInfo[2] -> Device 0, INTC
-      0,   // PciBus
-      0,   // PciDevice
-      2,   // PciInterrupt
+    {    // PciInterruptMapInfo[2] -> Device 0, INTC
+      0, // PciBus
+      0, // PciDevice
+      2, // PciInterrupt
       {
         170, // Interrupt
         0x0  // Flags
       }
     },
-    { // PciInterruptMapInfo[3] -> Device 0, INTD
-      0,   // PciBus
-      0,   // PciDevice
-      3,   // PciInterrupt
+    {    // PciInterruptMapInfo[3] -> Device 0, INTD
+      0, // PciBus
+      0, // PciDevice
+      3, // PciInterrupt
       {
         171, // Interrupt
         0x0  // Flags
@@ -477,7 +477,7 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
         EFI_ACPI_6_3_PPTT_PROCESSOR_IS_NOT_THREAD,
         EFI_ACPI_6_3_PPTT_NODE_IS_NOT_LEAF,
         EFI_ACPI_6_3_PPTT_IMPLEMENTATION_IDENTICAL
-      ),
+        ),
       // CM_OBJECT_TOKEN  ParentToken
       CM_NULL_TOKEN,
       // CM_OBJECT_TOKEN  AcpiIdObjectToken
@@ -500,7 +500,7 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
         EFI_ACPI_6_3_PPTT_PROCESSOR_IS_NOT_THREAD,
         EFI_ACPI_6_3_PPTT_NODE_IS_NOT_LEAF,
         EFI_ACPI_6_3_PPTT_IMPLEMENTATION_IDENTICAL
-      ),
+        ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[0]), // -> Package
       // CM_OBJECT_TOKEN  AcpiIdObjectToken
@@ -523,7 +523,7 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
         EFI_ACPI_6_3_PPTT_PROCESSOR_IS_NOT_THREAD,
         EFI_ACPI_6_3_PPTT_NODE_IS_NOT_LEAF,
         EFI_ACPI_6_3_PPTT_IMPLEMENTATION_IDENTICAL
-      ),
+        ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[0]), // -> Package
       // CM_OBJECT_TOKEN  AcpiIdObjectToken
@@ -546,7 +546,7 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
         EFI_ACPI_6_3_PPTT_PROCESSOR_IS_NOT_THREAD,
         EFI_ACPI_6_3_PPTT_NODE_IS_LEAF,
         EFI_ACPI_6_3_PPTT_IMPLEMENTATION_NOT_IDENTICAL
-      ),
+        ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[1]), // -> Cluster 0
       // CM_OBJECT_TOKEN  AcpiIdObjectToken
@@ -568,7 +568,7 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
         EFI_ACPI_6_3_PPTT_PROCESSOR_IS_NOT_THREAD,
         EFI_ACPI_6_3_PPTT_NODE_IS_LEAF,
         EFI_ACPI_6_3_PPTT_IMPLEMENTATION_NOT_IDENTICAL
-      ),
+        ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[1]), // -> Cluster 0
       // CM_OBJECT_TOKEN  AcpiIdObjectToken
@@ -590,7 +590,7 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
         EFI_ACPI_6_3_PPTT_PROCESSOR_IS_NOT_THREAD,
         EFI_ACPI_6_3_PPTT_NODE_IS_LEAF,
         EFI_ACPI_6_3_PPTT_IMPLEMENTATION_NOT_IDENTICAL
-      ),
+        ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[1]), // -> Cluster 0
       // CM_OBJECT_TOKEN  AcpiIdObjectToken
@@ -612,7 +612,7 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
         EFI_ACPI_6_3_PPTT_PROCESSOR_IS_NOT_THREAD,
         EFI_ACPI_6_3_PPTT_NODE_IS_LEAF,
         EFI_ACPI_6_3_PPTT_IMPLEMENTATION_NOT_IDENTICAL
-      ),
+        ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[1]), // -> Cluster 0
       // CM_OBJECT_TOKEN  AcpiIdObjectToken
@@ -635,7 +635,7 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
         EFI_ACPI_6_3_PPTT_PROCESSOR_IS_NOT_THREAD,
         EFI_ACPI_6_3_PPTT_NODE_IS_LEAF,
         EFI_ACPI_6_3_PPTT_IMPLEMENTATION_NOT_IDENTICAL
-      ),
+        ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[2]), // -> Cluster 1
       // CM_OBJECT_TOKEN  AcpiIdObjectToken
@@ -657,7 +657,7 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
         EFI_ACPI_6_3_PPTT_PROCESSOR_IS_NOT_THREAD,
         EFI_ACPI_6_3_PPTT_NODE_IS_LEAF,
         EFI_ACPI_6_3_PPTT_IMPLEMENTATION_NOT_IDENTICAL
-      ),
+        ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[2]), // -> Cluster 1
       // CM_OBJECT_TOKEN  AcpiIdObjectToken
@@ -679,7 +679,7 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
         EFI_ACPI_6_3_PPTT_PROCESSOR_IS_NOT_THREAD,
         EFI_ACPI_6_3_PPTT_NODE_IS_LEAF,
         EFI_ACPI_6_3_PPTT_IMPLEMENTATION_NOT_IDENTICAL
-      ),
+        ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[2]), // -> Cluster 1
       // CM_OBJECT_TOKEN  AcpiIdObjectToken
@@ -701,7 +701,7 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
         EFI_ACPI_6_3_PPTT_PROCESSOR_IS_NOT_THREAD,
         EFI_ACPI_6_3_PPTT_NODE_IS_LEAF,
         EFI_ACPI_6_3_PPTT_IMPLEMENTATION_NOT_IDENTICAL
-      ),
+        ),
       // CM_OBJECT_TOKEN  ParentToken
       REFERENCE_TOKEN (ProcHierarchyInfo[2]), // -> Cluster 1
       // CM_OBJECT_TOKEN  AcpiIdObjectToken
@@ -715,7 +715,6 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
     }
   },
 
-
   // Cache information
   {
     // L3 cache
@@ -725,11 +724,12 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
       0x400000,                        // UINT32  Size
       4096,                            // UINT32  NumberOfSets
       16,                              // UINT32  Associativity
-      CACHE_ATTRIBUTES (               // UINT8   Attributes
+      CACHE_ATTRIBUTES (
+        // UINT8   Attributes
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_ALLOCATION_READ_WRITE,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_CACHE_TYPE_UNIFIED,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_WRITE_POLICY_WRITE_BACK
-      ),
+        ),
       64                               // UINT16  LineSize
     },
     // L2 cache
@@ -739,11 +739,12 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
       0x80000,                         // UINT32  Size
       512,                             // UINT32  NumberOfSets
       16,                              // UINT32  Associativity
-      CACHE_ATTRIBUTES (               // UINT8   Attributes
+      CACHE_ATTRIBUTES (
+        // UINT8   Attributes
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_ALLOCATION_READ_WRITE,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_CACHE_TYPE_UNIFIED,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_WRITE_POLICY_WRITE_BACK
-      ),
+        ),
       64                               // UINT16  LineSize
     },
     // L1 instruction cache
@@ -753,11 +754,12 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
       0x8000,                          // UINT32  Size
       256,                             // UINT32  NumberOfSets
       2,                               // UINT32  Associativity
-      CACHE_ATTRIBUTES (               // UINT8   Attributes
+      CACHE_ATTRIBUTES (
+        // UINT8   Attributes
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_ALLOCATION_READ,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_CACHE_TYPE_INSTRUCTION,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_WRITE_POLICY_WRITE_BACK
-      ),
+        ),
       64                               // UINT16  LineSize
     },
     // L1 data cache
@@ -767,11 +769,12 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
       0x8000,                          // UINT32  Size
       256,                             // UINT32  NumberOfSets
       2,                               // UINT32  Associativity
-      CACHE_ATTRIBUTES (               // UINT8   Attributes
+      CACHE_ATTRIBUTES (
+        // UINT8   Attributes
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_ALLOCATION_READ_WRITE,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_CACHE_TYPE_DATA,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_WRITE_POLICY_WRITE_BACK
-      ),
+        ),
       64                               // UINT16  LineSize
     },
 
@@ -782,11 +785,12 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
       0x80000,                         // UINT32  Size
       512,                             // UINT32  NumberOfSets
       16,                              // UINT32  Associativity
-      CACHE_ATTRIBUTES (               // UINT8   Attributes
+      CACHE_ATTRIBUTES (
+        // UINT8   Attributes
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_ALLOCATION_READ_WRITE,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_CACHE_TYPE_UNIFIED,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_WRITE_POLICY_WRITE_BACK
-      ),
+        ),
       64                               // UINT16  LineSize
     },
     // L1 instruction cache
@@ -796,11 +800,12 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
       0x8000,                          // UINT32  Size
       256,                             // UINT32  NumberOfSets
       2,                               // UINT32  Associativity
-      CACHE_ATTRIBUTES (               // UINT8   Attributes
+      CACHE_ATTRIBUTES (
+        // UINT8   Attributes
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_ALLOCATION_READ,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_CACHE_TYPE_INSTRUCTION,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_WRITE_POLICY_WRITE_BACK
-      ),
+        ),
       64                               // UINT16  LineSize
     },
     // L1 data cache
@@ -810,11 +815,12 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
       0x8000,                          // UINT32  Size
       256,                             // UINT32  NumberOfSets
       2,                               // UINT32  Associativity
-      CACHE_ATTRIBUTES (               // UINT8   Attributes
+      CACHE_ATTRIBUTES (
+        // UINT8   Attributes
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_ALLOCATION_READ_WRITE,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_CACHE_TYPE_DATA,
         EFI_ACPI_6_3_CACHE_ATTRIBUTES_WRITE_POLICY_WRITE_BACK
-      ),
+        ),
       64                               // UINT16  LineSize
     }
   },
@@ -842,25 +848,24 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
     { REFERENCE_TOKEN (CacheInfo[6]) }  // -> cluster 1 core's L1 D-cache
   },
 
-
   // Low Power Idle state information (LPI) for all cores/clusters
   // This structure currently contains dummy values
   {
-    { // LpiInfo[0] -> Clusters CluPwrDn
-      2500,         // MinResidency
-      1150,         // WorstCaseWakeLatency
-      1,            // Flags
-      1,            // ArchFlags
-      100,          // ResCntFreq
-      0,            // EnableParentState
-      TRUE,         // IsInteger
-      0x01000000,   // IntegerEntryMethod
+    {             // LpiInfo[0] -> Clusters CluPwrDn
+      2500,       // MinResidency
+      1150,       // WorstCaseWakeLatency
+      1,          // Flags
+      1,          // ArchFlags
+      100,        // ResCntFreq
+      0,          // EnableParentState
+      TRUE,       // IsInteger
+      0x01000000, // IntegerEntryMethod
       // RegisterEntryMethod (NULL, use IntegerEntryMethod)
-      { EFI_ACPI_6_3_SYSTEM_MEMORY, 0, 0, 0, 0 },
+      { EFI_ACPI_6_3_SYSTEM_MEMORY,     0, 0, 0, 0     },
       // ResidencyCounterRegister (NULL)
-      { EFI_ACPI_6_3_SYSTEM_MEMORY, 0, 0, 0, 0 },
+      { EFI_ACPI_6_3_SYSTEM_MEMORY,     0, 0, 0, 0     },
       // UsageCounterRegister (NULL)
-      { EFI_ACPI_6_3_SYSTEM_MEMORY, 0, 0, 0, 0 },
+      { EFI_ACPI_6_3_SYSTEM_MEMORY,     0, 0, 0, 0     },
       "CluPwrDn" // StateName
     },
     // LpiInfo[1] -> Cores WFI
@@ -876,15 +881,15 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
       // RegisterEntryMethod
       {
         EFI_ACPI_6_3_FUNCTIONAL_FIXED_HARDWARE, // AddressSpaceId
-        0x20, // RegisterBitWidth
-        0x00, // RegisterBitOffset
-        0x03, // AccessSize
-        0xFFFFFFFF // Address
+        0x20,                                   // RegisterBitWidth
+        0x00,                                   // RegisterBitOffset
+        0x03,                                   // AccessSize
+        0xFFFFFFFF                              // Address
       },
       // ResidencyCounterRegister (NULL)
-      { EFI_ACPI_6_3_SYSTEM_MEMORY, 0, 0, 0, 0 },
+      { EFI_ACPI_6_3_SYSTEM_MEMORY,     0, 0, 0, 0     },
       // UsageCounterRegister (NULL)
-      { EFI_ACPI_6_3_SYSTEM_MEMORY, 0, 0, 0, 0 },
+      { EFI_ACPI_6_3_SYSTEM_MEMORY,     0, 0, 0, 0     },
       "WFI" // StateName
     },
     // LpiInfo[2] -> Cores CorePwrDn
@@ -899,16 +904,16 @@ EDKII_PLATFORM_REPOSITORY_INFO VExpressPlatRepositoryInfo = {
       0,            // IntegerEntryMethod (0, use RegisterEntryMethod)
       // RegisterEntryMethod
       {
-          EFI_ACPI_6_3_FUNCTIONAL_FIXED_HARDWARE, // AddressSpaceId
-          0x20, // RegisterBitWidth
-          0x00, // RegisterBitOffset
-          0x03, // AccessSize
-          0x00010000 // Address
+        EFI_ACPI_6_3_FUNCTIONAL_FIXED_HARDWARE, // AddressSpaceId
+        0x20,                                   // RegisterBitWidth
+        0x00,                                   // RegisterBitOffset
+        0x03,                                   // AccessSize
+        0x00010000                              // Address
       },
       // ResidencyCounterRegister (NULL)
-      { EFI_ACPI_6_3_SYSTEM_MEMORY, 0, 0, 0, 0 },
+      { EFI_ACPI_6_3_SYSTEM_MEMORY,     0, 0, 0, 0     },
       // UsageCounterRegister (NULL)
-      { EFI_ACPI_6_3_SYSTEM_MEMORY, 0, 0, 0, 0 },
+      { EFI_ACPI_6_3_SYSTEM_MEMORY,     0, 0, 0, 0     },
       "CorePwrDn" // StateName
     },
   },
@@ -939,16 +944,16 @@ EFI_STATUS
 EFIAPI
 HandleCmObject (
   IN  CONST CM_OBJECT_ID                CmObjectId,
-  IN        VOID                *       Object,
+  IN        VOID                        *Object,
   IN  CONST UINTN                       ObjectSize,
   IN  CONST UINTN                       ObjectCount,
-  IN  OUT   CM_OBJ_DESCRIPTOR   * CONST CmObjectDesc
+  IN  OUT   CM_OBJ_DESCRIPTOR   *CONST  CmObjectDesc
   )
 {
   CmObjectDesc->ObjectId = CmObjectId;
-  CmObjectDesc->Size = ObjectSize;
-  CmObjectDesc->Data = (VOID*)Object;
-  CmObjectDesc->Count = ObjectCount;
+  CmObjectDesc->Size     = ObjectSize;
+  CmObjectDesc->Data     = (VOID *)Object;
+  CmObjectDesc->Count    = ObjectCount;
   DEBUG ((
     DEBUG_INFO,
     "INFO: CmObjectId = %x, Ptr = 0x%p, Size = %d, Count = %d\n",
@@ -982,23 +987,24 @@ STATIC
 EFI_STATUS
 EFIAPI
 HandleCmObjectRefByToken (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
-  IN        VOID                                  *       Object,
+  IN        VOID                                          *Object,
   IN  CONST UINTN                                         ObjectSize,
   IN  CONST UINTN                                         ObjectCount,
   IN  CONST CM_OBJECT_TOKEN                               Token,
   IN  CONST CM_OBJECT_HANDLER_PROC                        HandlerProc,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObjectDesc
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObjectDesc
   )
 {
   EFI_STATUS  Status;
+
   CmObjectDesc->ObjectId = CmObjectId;
   if (Token == CM_NULL_TOKEN) {
-    CmObjectDesc->Size = ObjectSize;
-    CmObjectDesc->Data = (VOID*)Object;
+    CmObjectDesc->Size  = ObjectSize;
+    CmObjectDesc->Data  = (VOID *)Object;
     CmObjectDesc->Count = ObjectCount;
-    Status = EFI_SUCCESS;
+    Status              = EFI_SUCCESS;
   } else {
     Status = HandlerProc (This, CmObjectId, Token, CmObjectDesc);
   }
@@ -1006,7 +1012,7 @@ HandleCmObjectRefByToken (
   DEBUG ((
     DEBUG_INFO,
     "INFO: Token = 0x%p, CmObjectId = %x, Ptr = 0x%p, Size = %d, Count = %d\n",
-    (VOID*)Token,
+    (VOID *)Token,
     CmObjectId,
     CmObjectDesc->Data,
     CmObjectDesc->Size,
@@ -1035,14 +1041,15 @@ STATIC
 EFI_STATUS
 EFIAPI
 HandleCmObjectSearchPlatformRepo (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               Token,
   IN  CONST CM_OBJECT_HANDLER_PROC                        HandlerProc,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObjectDesc
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObjectDesc
   )
 {
   EFI_STATUS  Status;
+
   CmObjectDesc->ObjectId = CmObjectId;
   if (Token == CM_NULL_TOKEN) {
     DEBUG ((
@@ -1057,7 +1064,7 @@ HandleCmObjectSearchPlatformRepo (
   DEBUG ((
     DEBUG_INFO,
     "INFO: Token = 0x%p, CmObjectId = %x, Ptr = 0x%p, Size = %d, Count = %d\n",
-    (VOID*)Token,
+    (VOID *)Token,
     CmObjectId,
     CmObjectDesc->Data,
     CmObjectDesc->Size,
@@ -1077,19 +1084,20 @@ STATIC
 EFI_STATUS
 EFIAPI
 InitializePlatformRepository (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This
   )
 {
-  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
-  UINTN  Index;
-  UINT16 TrbeInterrupt;
-  CM_OBJECT_TOKEN EtToken;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+  UINTN                           Index;
+  UINT16                          TrbeInterrupt;
+  CM_OBJECT_TOKEN                 EtToken;
 
   PlatformRepo = This->PlatRepoInfo;
 
   PlatformRepo->SysId = MmioRead32 (ARM_VE_SYS_ID_REG);
   if ((PlatformRepo->SysId & ARM_FVP_SYS_ID_REV_MASK) ==
-       ARM_FVP_BASE_REVC_REV) {
+      ARM_FVP_BASE_REVC_REV)
+  {
     // REVC affinity is shifted, update the MPIDR
     PlatformRepo->GicCInfo[0].MPIDR = GET_MPID_MT (0, 0, 0);
     PlatformRepo->GicCInfo[1].MPIDR = GET_MPID_MT (0, 1, 0);
@@ -1103,7 +1111,7 @@ InitializePlatformRepository (
   }
 
   TrbeInterrupt = 0;
-  EtToken = CM_NULL_TOKEN;
+  EtToken       = CM_NULL_TOKEN;
 
   // The ID_AA64DFR0_EL1.TraceBuffer field identifies support for FEAT_TRBE.
   if (ArmHasTrbe ()) {
@@ -1118,7 +1126,7 @@ InitializePlatformRepository (
 
   for (Index = 0; Index < PLAT_CPU_COUNT; Index++) {
     PlatformRepo->GicCInfo[Index].TrbeInterrupt = TrbeInterrupt;
-    PlatformRepo->GicCInfo[Index].EtToken = EtToken;
+    PlatformRepo->GicCInfo[Index].EtToken       = EtToken;
   }
 
   return EFI_SUCCESS;
@@ -1140,15 +1148,15 @@ InitializePlatformRepository (
 EFI_STATUS
 EFIAPI
 GetLpiInfo (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               SearchToken,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
-  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
-  UINT32                            TotalObjCount;
-  UINT32                            ObjIndex;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+  UINT32                          TotalObjCount;
+  UINT32                          ObjIndex;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1163,9 +1171,9 @@ GetLpiInfo (
   for (ObjIndex = 0; ObjIndex < TotalObjCount; ObjIndex++) {
     if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->LpiInfo[ObjIndex]) {
       CmObject->ObjectId = CmObjectId;
-      CmObject->Size = sizeof (PlatformRepo->LpiInfo[ObjIndex]);
-      CmObject->Data = (VOID*)&PlatformRepo->LpiInfo[ObjIndex];
-      CmObject->Count = 1;
+      CmObject->Size     = sizeof (PlatformRepo->LpiInfo[ObjIndex]);
+      CmObject->Data     = (VOID *)&PlatformRepo->LpiInfo[ObjIndex];
+      CmObject->Count    = 1;
       return EFI_SUCCESS;
     }
   }
@@ -1188,13 +1196,13 @@ GetLpiInfo (
 EFI_STATUS
 EFIAPI
 GetGTBlockTimerFrameInfo (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               Token,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
-  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1209,10 +1217,10 @@ GetGTBlockTimerFrameInfo (
   }
 
   CmObject->ObjectId = CmObjectId;
-  CmObject->Size = sizeof (PlatformRepo->GTBlock0TimerInfo);
-  CmObject->Data = (VOID*)&PlatformRepo->GTBlock0TimerInfo;
-  CmObject->Count = sizeof (PlatformRepo->GTBlock0TimerInfo) /
-                      sizeof (PlatformRepo->GTBlock0TimerInfo[0]);
+  CmObject->Size     = sizeof (PlatformRepo->GTBlock0TimerInfo);
+  CmObject->Data     = (VOID *)&PlatformRepo->GTBlock0TimerInfo;
+  CmObject->Count    = sizeof (PlatformRepo->GTBlock0TimerInfo) /
+                       sizeof (PlatformRepo->GTBlock0TimerInfo[0]);
   return EFI_SUCCESS;
 }
 
@@ -1231,13 +1239,13 @@ GetGTBlockTimerFrameInfo (
 EFI_STATUS
 EFIAPI
 GetItsIdentifierArray (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               Token,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
-  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1252,9 +1260,9 @@ GetItsIdentifierArray (
   }
 
   CmObject->ObjectId = CmObjectId;
-  CmObject->Size = sizeof (PlatformRepo->ItsIdentifierArray);
-  CmObject->Data = (VOID*)&PlatformRepo->ItsIdentifierArray;
-  CmObject->Count = ARRAY_SIZE (PlatformRepo->ItsIdentifierArray);
+  CmObject->Size     = sizeof (PlatformRepo->ItsIdentifierArray);
+  CmObject->Data     = (VOID *)&PlatformRepo->ItsIdentifierArray;
+  CmObject->Count    = ARRAY_SIZE (PlatformRepo->ItsIdentifierArray);
   return EFI_SUCCESS;
 }
 
@@ -1273,13 +1281,13 @@ GetItsIdentifierArray (
 EFI_STATUS
 EFIAPI
 GetDeviceIdMappingArray (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               Token,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
-  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1290,14 +1298,15 @@ GetDeviceIdMappingArray (
   PlatformRepo = This->PlatRepoInfo;
 
   if ((Token != (CM_OBJECT_TOKEN)&PlatformRepo->DeviceIdMapping[0]) &&
-      (Token != (CM_OBJECT_TOKEN)&PlatformRepo->DeviceIdMapping[1])) {
+      (Token != (CM_OBJECT_TOKEN)&PlatformRepo->DeviceIdMapping[1]))
+  {
     return EFI_NOT_FOUND;
   }
 
   CmObject->ObjectId = CmObjectId;
-  CmObject->Size = sizeof (CM_ARM_ID_MAPPING);
-  CmObject->Data = (VOID*)Token;
-  CmObject->Count = 1;
+  CmObject->Size     = sizeof (CM_ARM_ID_MAPPING);
+  CmObject->Data     = (VOID *)Token;
+  CmObject->Count    = 1;
   return EFI_SUCCESS;
 }
 
@@ -1317,15 +1326,15 @@ GetDeviceIdMappingArray (
 EFI_STATUS
 EFIAPI
 GetPciAddressMapInfo (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               SearchToken,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
-  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
-  UINT32                            TotalObjCount;
-  UINT32                            ObjIndex;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+  UINT32                          TotalObjCount;
+  UINT32                          ObjIndex;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1340,9 +1349,9 @@ GetPciAddressMapInfo (
   for (ObjIndex = 0; ObjIndex < TotalObjCount; ObjIndex++) {
     if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->PciAddressMapInfo[ObjIndex]) {
       CmObject->ObjectId = CmObjectId;
-      CmObject->Size = sizeof (PlatformRepo->PciAddressMapInfo[ObjIndex]);
-      CmObject->Data = (VOID*)&PlatformRepo->PciAddressMapInfo[ObjIndex];
-      CmObject->Count = 1;
+      CmObject->Size     = sizeof (PlatformRepo->PciAddressMapInfo[ObjIndex]);
+      CmObject->Data     = (VOID *)&PlatformRepo->PciAddressMapInfo[ObjIndex];
+      CmObject->Count    = 1;
       return EFI_SUCCESS;
     }
   }
@@ -1366,15 +1375,15 @@ GetPciAddressMapInfo (
 EFI_STATUS
 EFIAPI
 GetPciInterruptMapInfo (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               SearchToken,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
-  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
-  UINT32                            TotalObjCount;
-  UINT32                            ObjIndex;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+  UINT32                          TotalObjCount;
+  UINT32                          ObjIndex;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1389,9 +1398,9 @@ GetPciInterruptMapInfo (
   for (ObjIndex = 0; ObjIndex < TotalObjCount; ObjIndex++) {
     if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->PciInterruptMapInfo[ObjIndex]) {
       CmObject->ObjectId = CmObjectId;
-      CmObject->Size = sizeof (PlatformRepo->PciInterruptMapInfo[ObjIndex]);
-      CmObject->Data = (VOID*)&PlatformRepo->PciInterruptMapInfo[ObjIndex];
-      CmObject->Count = 1;
+      CmObject->Size     = sizeof (PlatformRepo->PciInterruptMapInfo[ObjIndex]);
+      CmObject->Data     = (VOID *)&PlatformRepo->PciInterruptMapInfo[ObjIndex];
+      CmObject->Count    = 1;
       return EFI_SUCCESS;
     }
   }
@@ -1415,15 +1424,15 @@ GetPciInterruptMapInfo (
 EFI_STATUS
 EFIAPI
 GetGicCInfo (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               SearchToken,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
-  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
-  UINT32                            TotalObjCount;
-  UINT32                            ObjIndex;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+  UINT32                          TotalObjCount;
+  UINT32                          ObjIndex;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1438,9 +1447,9 @@ GetGicCInfo (
   for (ObjIndex = 0; ObjIndex < TotalObjCount; ObjIndex++) {
     if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->GicCInfo[ObjIndex]) {
       CmObject->ObjectId = CmObjectId;
-      CmObject->Size = sizeof (PlatformRepo->GicCInfo[ObjIndex]);
-      CmObject->Data = (VOID*)&PlatformRepo->GicCInfo[ObjIndex];
-      CmObject->Count = 1;
+      CmObject->Size     = sizeof (PlatformRepo->GicCInfo[ObjIndex]);
+      CmObject->Data     = (VOID *)&PlatformRepo->GicCInfo[ObjIndex];
+      CmObject->Count    = 1;
       return EFI_SUCCESS;
     }
   }
@@ -1465,13 +1474,13 @@ GetGicCInfo (
 EFI_STATUS
 EFIAPI
 GetCmObjRefs (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               SearchToken,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
-  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1482,56 +1491,64 @@ GetCmObjRefs (
   PlatformRepo = This->PlatRepoInfo;
 
   if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->PciAddressMapRef) {
-    CmObject->Size = sizeof (PlatformRepo->PciAddressMapRef);
-    CmObject->Data = (VOID*)&PlatformRepo->PciAddressMapRef;
+    CmObject->Size  = sizeof (PlatformRepo->PciAddressMapRef);
+    CmObject->Data  = (VOID *)&PlatformRepo->PciAddressMapRef;
     CmObject->Count = ARRAY_SIZE (PlatformRepo->PciAddressMapRef);
     return EFI_SUCCESS;
   }
+
   if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->PciInterruptMapRef) {
-    CmObject->Size = sizeof (PlatformRepo->PciInterruptMapRef);
-    CmObject->Data = (VOID*)&PlatformRepo->PciInterruptMapRef;
+    CmObject->Size  = sizeof (PlatformRepo->PciInterruptMapRef);
+    CmObject->Data  = (VOID *)&PlatformRepo->PciInterruptMapRef;
     CmObject->Count = ARRAY_SIZE (PlatformRepo->PciInterruptMapRef);
     return EFI_SUCCESS;
   }
+
   if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->PackageResources) {
-    CmObject->Size = sizeof (PlatformRepo->PackageResources);
-    CmObject->Data = (VOID*)&PlatformRepo->PackageResources;
+    CmObject->Size  = sizeof (PlatformRepo->PackageResources);
+    CmObject->Data  = (VOID *)&PlatformRepo->PackageResources;
     CmObject->Count = ARRAY_SIZE (PlatformRepo->PackageResources);
     return EFI_SUCCESS;
   }
+
   if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->Cluster0Resources) {
-    CmObject->Size = sizeof (PlatformRepo->Cluster0Resources);
-    CmObject->Data = (VOID*)&PlatformRepo->Cluster0Resources;
+    CmObject->Size  = sizeof (PlatformRepo->Cluster0Resources);
+    CmObject->Data  = (VOID *)&PlatformRepo->Cluster0Resources;
     CmObject->Count = ARRAY_SIZE (PlatformRepo->Cluster0Resources);
     return EFI_SUCCESS;
   }
+
   if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->Cluster0CoreResources) {
-    CmObject->Size = sizeof (PlatformRepo->Cluster0CoreResources);
-    CmObject->Data = (VOID*)&PlatformRepo->Cluster0CoreResources;
+    CmObject->Size  = sizeof (PlatformRepo->Cluster0CoreResources);
+    CmObject->Data  = (VOID *)&PlatformRepo->Cluster0CoreResources;
     CmObject->Count = ARRAY_SIZE (PlatformRepo->Cluster0CoreResources);
     return EFI_SUCCESS;
   }
+
   if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->Cluster1Resources) {
-    CmObject->Size = sizeof (PlatformRepo->Cluster1Resources);
-    CmObject->Data = (VOID*)&PlatformRepo->Cluster1Resources;
+    CmObject->Size  = sizeof (PlatformRepo->Cluster1Resources);
+    CmObject->Data  = (VOID *)&PlatformRepo->Cluster1Resources;
     CmObject->Count = ARRAY_SIZE (PlatformRepo->Cluster1Resources);
     return EFI_SUCCESS;
   }
+
   if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->Cluster1CoreResources) {
-    CmObject->Size = sizeof (PlatformRepo->Cluster1CoreResources);
-    CmObject->Data = (VOID*)&PlatformRepo->Cluster1CoreResources;
+    CmObject->Size  = sizeof (PlatformRepo->Cluster1CoreResources);
+    CmObject->Data  = (VOID *)&PlatformRepo->Cluster1CoreResources;
     CmObject->Count = ARRAY_SIZE (PlatformRepo->Cluster1CoreResources);
     return EFI_SUCCESS;
   }
+
   if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->ClustersLpiRef) {
-    CmObject->Size = sizeof (PlatformRepo->ClustersLpiRef);
-    CmObject->Data = (VOID*)&PlatformRepo->ClustersLpiRef;
+    CmObject->Size  = sizeof (PlatformRepo->ClustersLpiRef);
+    CmObject->Data  = (VOID *)&PlatformRepo->ClustersLpiRef;
     CmObject->Count = ARRAY_SIZE (PlatformRepo->ClustersLpiRef);
     return EFI_SUCCESS;
   }
+
   if (SearchToken == (CM_OBJECT_TOKEN)&PlatformRepo->CoresLpiRef) {
-    CmObject->Size = sizeof (PlatformRepo->CoresLpiRef);
-    CmObject->Data = (VOID*)&PlatformRepo->CoresLpiRef;
+    CmObject->Size  = sizeof (PlatformRepo->CoresLpiRef);
+    CmObject->Data  = (VOID *)&PlatformRepo->CoresLpiRef;
     CmObject->Count = ARRAY_SIZE (PlatformRepo->CoresLpiRef);
     return EFI_SUCCESS;
   }
@@ -1555,14 +1572,14 @@ GetCmObjRefs (
 EFI_STATUS
 EFIAPI
 GetStandardNameSpaceObject (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
   EFI_STATUS                      Status;
-  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
   UINTN                           AcpiTableCount;
 
   Status = EFI_SUCCESS;
@@ -1572,12 +1589,13 @@ GetStandardNameSpaceObject (
     return EFI_INVALID_PARAMETER;
   }
 
-  Status = EFI_NOT_FOUND;
+  Status         = EFI_NOT_FOUND;
   AcpiTableCount = ARRAY_SIZE (PlatformRepo->CmAcpiTableList);
-  PlatformRepo = This->PlatRepoInfo;
+  PlatformRepo   = This->PlatRepoInfo;
 
   if ((PlatformRepo->SysId & ARM_FVP_SYS_ID_REV_MASK) !=
-       ARM_FVP_BASE_REVC_REV) {
+      ARM_FVP_BASE_REVC_REV)
+  {
     // The last 3 tables in the ACPI table list are for FVP RevC
     // Reduce the count by 3 if the platform is not FVP RevC
     AcpiTableCount -= 3;
@@ -1604,7 +1622,8 @@ GetStandardNameSpaceObject (
                  );
       break;
 
-    default: {
+    default:
+    {
       Status = EFI_NOT_FOUND;
       DEBUG ((
         DEBUG_ERROR,
@@ -1635,15 +1654,15 @@ GetStandardNameSpaceObject (
 EFI_STATUS
 EFIAPI
 GetArchCommonNameSpaceObject (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
-  EFI_STATUS                        Status;
-  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
-  UINTN                             PciConfigSpaceCount;
+  EFI_STATUS                      Status;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+  UINTN                           PciConfigSpaceCount;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1651,11 +1670,12 @@ GetArchCommonNameSpaceObject (
     return EFI_INVALID_PARAMETER;
   }
 
-  Status = EFI_NOT_FOUND;
+  Status       = EFI_NOT_FOUND;
   PlatformRepo = This->PlatRepoInfo;
 
   if ((PlatformRepo->SysId & ARM_FVP_SYS_ID_REV_MASK) ==
-       ARM_FVP_BASE_REVC_REV) {
+      ARM_FVP_BASE_REVC_REV)
+  {
     PciConfigSpaceCount = 1;
   } else {
     PciConfigSpaceCount = 0;
@@ -1692,7 +1712,7 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
-#ifdef HEADLESS_PLATFORM
+ #ifdef HEADLESS_PLATFORM
     case EArchCommonObjFixedFeatureFlags:
       Status = HandleCmObject (
                  CmObjectId,
@@ -1702,7 +1722,7 @@ GetArchCommonNameSpaceObject (
                  CmObject
                  );
       break;
-#endif
+ #endif
 
     case EArchCommonObjPciConfigSpaceInfo:
       Status = HandleCmObject (
@@ -1783,7 +1803,8 @@ GetArchCommonNameSpaceObject (
                  );
       break;
 
-    default: {
+    default:
+    {
       Status = EFI_NOT_FOUND;
       DEBUG ((
         DEBUG_INFO,
@@ -1793,7 +1814,7 @@ GetArchCommonNameSpaceObject (
         ));
       break;
     }
-  } //switch
+  } // switch
 
   return Status;
 }
@@ -1814,19 +1835,19 @@ GetArchCommonNameSpaceObject (
 EFI_STATUS
 EFIAPI
 GetArmNameSpaceObject (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
-  EFI_STATUS                        Status;
-  EDKII_PLATFORM_REPOSITORY_INFO  * PlatformRepo;
-  UINTN                             Smmuv3Count;
-  UINTN                             ItsGroupCount;
-  UINTN                             ItsIdentifierArrayCount;
-  UINTN                             RootComplexCount;
-  UINTN                             DeviceIdMappingArrayCount;
+  EFI_STATUS                      Status;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+  UINTN                           Smmuv3Count;
+  UINTN                           ItsGroupCount;
+  UINTN                           ItsIdentifierArrayCount;
+  UINTN                           RootComplexCount;
+  UINTN                           DeviceIdMappingArrayCount;
 
   if ((This == NULL) || (CmObject == NULL)) {
     ASSERT (This != NULL);
@@ -1834,21 +1855,22 @@ GetArmNameSpaceObject (
     return EFI_INVALID_PARAMETER;
   }
 
-  Status = EFI_NOT_FOUND;
+  Status       = EFI_NOT_FOUND;
   PlatformRepo = This->PlatRepoInfo;
 
   if ((PlatformRepo->SysId & ARM_FVP_SYS_ID_REV_MASK) ==
-       ARM_FVP_BASE_REVC_REV) {
-    Smmuv3Count = 1;
-    ItsGroupCount = 1;
-    ItsIdentifierArrayCount = ARRAY_SIZE (PlatformRepo->ItsIdentifierArray);
-    RootComplexCount = 1;
+      ARM_FVP_BASE_REVC_REV)
+  {
+    Smmuv3Count               = 1;
+    ItsGroupCount             = 1;
+    ItsIdentifierArrayCount   = ARRAY_SIZE (PlatformRepo->ItsIdentifierArray);
+    RootComplexCount          = 1;
     DeviceIdMappingArrayCount = ARRAY_SIZE (PlatformRepo->DeviceIdMapping);
   } else {
-    Smmuv3Count = 0;
-    ItsGroupCount = 0;
-    ItsIdentifierArrayCount = 0;
-    RootComplexCount = 0;
+    Smmuv3Count               = 0;
+    ItsGroupCount             = 0;
+    ItsIdentifierArrayCount   = 0;
+    RootComplexCount          = 0;
     DeviceIdMappingArrayCount = 0;
   }
 
@@ -2008,16 +2030,18 @@ GetArmNameSpaceObject (
     case EArmObjEtInfo:
       if (Token == (CM_OBJECT_TOKEN)&PlatformRepo->EtInfo) {
         Status = HandleCmObject (
-                  CmObjectId,
-                  &PlatformRepo->EtInfo,
-                  sizeof (PlatformRepo->EtInfo),
-                  1,
-                  CmObject
-                  );
+                   CmObjectId,
+                   &PlatformRepo->EtInfo,
+                   sizeof (PlatformRepo->EtInfo),
+                   1,
+                   CmObject
+                   );
       }
+
       break;
 
-    default: {
+    default:
+    {
       Status = EFI_NOT_FOUND;
       DEBUG ((
         DEBUG_INFO,
@@ -2027,7 +2051,7 @@ GetArmNameSpaceObject (
         ));
       break;
     }
-  }//switch
+  }// switch
 
   return Status;
 }
@@ -2051,10 +2075,10 @@ GetArmNameSpaceObject (
 EFI_STATUS
 EFIAPI
 GetOemNameSpaceObject (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
   EFI_STATUS  Status;
@@ -2067,7 +2091,8 @@ GetOemNameSpaceObject (
   }
 
   switch (GET_CM_OBJECT_ID (CmObjectId)) {
-    default: {
+    default:
+    {
       Status = EFI_NOT_FOUND;
       DEBUG ((
         DEBUG_ERROR,
@@ -2100,10 +2125,10 @@ GetOemNameSpaceObject (
 EFI_STATUS
 EFIAPI
 ArmVExpressPlatformGetObject (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
-  IN  OUT   CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
   EFI_STATUS  Status;
@@ -2127,7 +2152,8 @@ ArmVExpressPlatformGetObject (
     case EObjNameSpaceOem:
       Status = GetOemNameSpaceObject (This, CmObjectId, Token, CmObject);
       break;
-    default: {
+    default:
+    {
       Status = EFI_INVALID_PARAMETER;
       DEBUG ((
         DEBUG_ERROR,
@@ -2158,10 +2184,10 @@ ArmVExpressPlatformGetObject (
 EFI_STATUS
 EFIAPI
 ArmVExpressPlatformSetObject (
-  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  * CONST This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
   IN  CONST CM_OBJECT_ID                                  CmObjectId,
   IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
-  IN        CM_OBJ_DESCRIPTOR                     * CONST CmObject
+  IN        CM_OBJ_DESCRIPTOR                     *CONST  CmObject
   )
 {
   return EFI_UNSUPPORTED;
@@ -2171,8 +2197,8 @@ ArmVExpressPlatformSetObject (
 */
 STATIC
 CONST
-EDKII_CONFIGURATION_MANAGER_PROTOCOL VExpressPlatformConfigManagerProtocol = {
-  CREATE_REVISION(1,0),
+EDKII_CONFIGURATION_MANAGER_PROTOCOL  VExpressPlatformConfigManagerProtocol = {
+  CREATE_REVISION (1,           0),
   ArmVExpressPlatformGetObject,
   ArmVExpressPlatformSetObject,
   &VExpressPlatRepositoryInfo
@@ -2192,8 +2218,8 @@ EDKII_CONFIGURATION_MANAGER_PROTOCOL VExpressPlatformConfigManagerProtocol = {
 EFI_STATUS
 EFIAPI
 ConfigurationManagerDxeInitialize (
-  IN EFI_HANDLE          ImageHandle,
-  IN EFI_SYSTEM_TABLE  * SystemTable
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
   EFI_STATUS  Status;
@@ -2215,7 +2241,7 @@ ConfigurationManagerDxeInitialize (
                   &ImageHandle,
                   &gEdkiiConfigurationManagerProtocolGuid,
                   EFI_NATIVE_INTERFACE,
-                  (VOID*)&VExpressPlatformConfigManagerProtocol
+                  (VOID *)&VExpressPlatformConfigManagerProtocol
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -228,7 +228,7 @@ EDKII_PLATFORM_REPOSITORY_INFO  VExpressPlatRepositoryInfo = {
     // The physical base address of the SBSA Watchdog refresh frame
     FixedPcdGet64 (PcdGenericWatchdogRefreshBase),
     // The watchdog interrupt
-    FixedPcdGet32 (PcdGenericWatchdogEl2IntrNum),
+    0,
     // The watchdog flags
     FVP_SBSA_WATCHDOG_FLAGS
   },
@@ -1094,6 +1094,11 @@ InitializePlatformRepository (
 
   PlatformRepo = This->PlatRepoInfo;
 
+  if (ArmHasGicV5SystemRegisters ()) {
+    DEBUG ((DEBUG_ERROR, "ConfigurationManager: GICv5 not supported.\n"));
+    return EFI_UNSUPPORTED;
+  }
+
   PlatformRepo->SysId = MmioRead32 (ARM_VE_SYS_ID_REG);
   if ((PlatformRepo->SysId & ARM_FVP_SYS_ID_REV_MASK) ==
       ARM_FVP_BASE_REVC_REV)
@@ -1128,6 +1133,9 @@ InitializePlatformRepository (
     PlatformRepo->GicCInfo[Index].TrbeInterrupt = TrbeInterrupt;
     PlatformRepo->GicCInfo[Index].EtToken       = EtToken;
   }
+
+  // Retrieve interrupts stored in PCDs
+  PlatformRepo->Watchdog.TimerGSIV = PcdGet32 (PcdGenericWatchdogEl2IntrNum);
 
   return EFI_SUCCESS;
 }

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerDxe.inf
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerDxe.inf
@@ -59,7 +59,6 @@
 
   # SBSA Generic Watchdog
   gArmTokenSpaceGuid.PcdGenericWatchdogControlBase
-  gArmTokenSpaceGuid.PcdGenericWatchdogEl2IntrNum
   gArmTokenSpaceGuid.PcdGenericWatchdogRefreshBase
 
   gArmTokenSpaceGuid.PcdGicDistributorBase
@@ -77,6 +76,7 @@
   gArmTokenSpaceGuid.PcdPciBusMax
 
 [Pcd]
+  gArmTokenSpaceGuid.PcdGenericWatchdogEl2IntrNum
 
 [Depex]
-  TRUE
+  gEfiTimerArchProtocolGuid

--- a/Platform/ARM/VExpressPkg/Library/ArmVExpressWatchdogLib/ArmVExpressWatchdogLib.c
+++ b/Platform/ARM/VExpressPkg/Library/ArmVExpressWatchdogLib/ArmVExpressWatchdogLib.c
@@ -1,0 +1,34 @@
+/** @file
+  VExpress library for ARM's WatchdogDxe
+
+  Copyright (c) 2025 Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+
+#include <Library/ArmLib.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+#define VEXPRESS_GICV5_WATCHDOG_INTID  0x6000001b
+
+RETURN_STATUS
+EFIAPI
+ArmVExpressWatchdogLibConstructor (
+  VOID
+  )
+{
+  RETURN_STATUS  PcdStatus;
+
+  if (ArmHasGicV5SystemRegisters ()) {
+    PcdStatus = PcdSet32S (PcdGenericWatchdogEl2IntrNum, VEXPRESS_GICV5_WATCHDOG_INTID);
+    ASSERT_RETURN_ERROR (PcdStatus);
+  }
+
+  return EFI_SUCCESS;
+}

--- a/Platform/ARM/VExpressPkg/Library/ArmVExpressWatchdogLib/ArmVExpressWatchdogLib.inf
+++ b/Platform/ARM/VExpressPkg/Library/ArmVExpressWatchdogLib/ArmVExpressWatchdogLib.inf
@@ -1,0 +1,33 @@
+#/** @file
+#  VExpress library for ARM's WatchdogDxe
+#
+#  Copyright (c) 2025 Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ArmVExpressWatchdogLib
+  FILE_GUID                      = 5274EF8E-0B4E-4DD5-91F7-328D42913A4F
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ArmVExpressWatchdogLib|DXE_DRIVER
+  CONSTRUCTOR                    = ArmVExpressWatchdogLibConstructor
+
+[Sources]
+  ArmVExpressWatchdogLib.c
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  PcdLib
+
+[Pcd]
+  gArmTokenSpaceGuid.PcdGenericWatchdogEl2IntrNum


### PR DESCRIPTION
GICv5 uses different interrupt numbering to previous GIC versions. ConfigurationManager now updates PlatformRepositoryInfo and the relevant PCDs if GICv5 is detected.

To ensure correct dependencies between WatchdogDxe and ConfigurationManager, this commit introduces ArmVExpressWatchdogArchLib.

This change depends on the GICv5 driver pull request at https://github.com/tianocore/edk2/pull/11240