### PR TITLE
MinPlatformPkg: Move FirmwarePerformancePei to FvPreMemory

### DIFF
--- a/Platform/Intel/MinPlatformPkg/Include/Fdf/CorePostMemoryInclude.fdf
+++ b/Platform/Intel/MinPlatformPkg/Include/Fdf/CorePostMemoryInclude.fdf
@@ -7,8 +7,3 @@
 #
 ##
 
-!if gMinPlatformPkgTokenSpaceGuid.PcdBootToShellOnly == FALSE
-  !if gMinPlatformPkgTokenSpaceGuid.PcdPerformanceEnable == TRUE
-    INF  MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.inf
-  !endif
-!endif

--- a/Platform/Intel/MinPlatformPkg/Include/Fdf/CorePreMemoryInclude.fdf
+++ b/Platform/Intel/MinPlatformPkg/Include/Fdf/CorePreMemoryInclude.fdf
@@ -22,3 +22,8 @@ INF  MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.inf
 
 INF  MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
 
+!if gMinPlatformPkgTokenSpaceGuid.PcdBootToShellOnly == FALSE
+  !if gMinPlatformPkgTokenSpaceGuid.PcdPerformanceEnable == TRUE
+    INF  MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.inf
+  !endif
+!endif


### PR DESCRIPTION
Some platforms do not dispatch FvPostMemory on S3 resume. Moving this PEIM to FvPreMemory ensures performance measurement during S3 resume works on all implementations.