### PR TITLE
Alderlake: Add support for the Clang compiler

### DIFF
--- a/Platform/Intel/AlderlakeOpenBoardPkg/AlderlakePRvp/OpenBoardPkgBuildOption.dsc
+++ b/Platform/Intel/AlderlakeOpenBoardPkg/AlderlakePRvp/OpenBoardPkgBuildOption.dsc
@@ -1,7 +1,7 @@
 ## @file
 # platform build option configuration file.
 #
-#   Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+#   Copyright (c) 2022 - 2025, Intel Corporation. All rights reserved.<BR>
 #   SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -147,13 +147,17 @@ MSFT:  *_*_X64_ASLCC_FLAGS    = $(DSC_PLTPKG_FEATURE_BUILD_OPTIONS)
 
 # Force PE/COFF sections to be aligned at 4KB boundaries to support page level protection
 [BuildOptions.common.EDKII.DXE_SMM_DRIVER, BuildOptions.common.EDKII.SMM_CORE]
-  MSFT:*_*_*_DLINK_FLAGS = /ALIGN:4096
-  GCC:*_GCC*_*_DLINK_FLAGS = -z common-page-size=0x1000
+  MSFT:*_*_*_DLINK_FLAGS        = /ALIGN:4096
+  GCC:*_GCC*_*_DLINK_FLAGS      = -z common-page-size=0x1000
+  CLANGPDB:*_*_*_DLINK_FLAGS    = /ALIGN:4096
+  CLANGDWARF:*_*_*_DLINK_FLAGS  = -z common-page-size=0x1000
 
 # Force PE/COFF sections to be aligned at 4KB boundaries to support MemoryAttribute table
 [BuildOptions.common.EDKII.DXE_RUNTIME_DRIVER]
-  MSFT:*_*_*_DLINK_FLAGS = /ALIGN:4096
-  GCC:*_GCC*_*_DLINK_FLAGS = -z common-page-size=0x1000
+  MSFT:*_*_*_DLINK_FLAGS        = /ALIGN:4096
+  GCC:*_GCC*_*_DLINK_FLAGS      = -z common-page-size=0x1000
+  CLANGPDB:*_*_*_DLINK_FLAGS    = /ALIGN:4096
+  CLANGDWARF:*_*_*_DLINK_FLAGS  = -z common-page-size=0x1000
 
 # Force PE/COFF sections to be aligned at 4KB boundaries to support NX protection
 [BuildOptions.common.EDKII.DXE_DRIVER, BuildOptions.common.EDKII.DXE_CORE, BuildOptions.common.EDKII.UEFI_DRIVER, BuildOptions.common.EDKII.UEFI_APPLICATION]

--- a/Platform/Intel/AlderlakeOpenBoardPkg/Policy/Library/DxeSiliconPolicyUpdateLib/DxeSiliconPolicyUpdateLate.c
+++ b/Platform/Intel/AlderlakeOpenBoardPkg/Policy/Library/DxeSiliconPolicyUpdateLib/DxeSiliconPolicyUpdateLate.c
@@ -1,6 +1,6 @@
 /** @file
 
-   Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+   Copyright (c) 2022 - 2025, Intel Corporation. All rights reserved.<BR>
    SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -74,5 +74,5 @@ SiliconPolicyUpdateLate (
   DEBUG ((DEBUG_INFO, "SystemAgent Dxe Platform Policy Initialization status: %r\n", Status));
   ASSERT_EFI_ERROR (Status);
 
-  return EFI_SUCCESS;
+  return NULL;
 }

--- a/Silicon/Intel/AlderlakeSiliconPkg/Product/Alderlake/SiPkgBuildOption.dsc
+++ b/Silicon/Intel/AlderlakeSiliconPkg/Product/Alderlake/SiPkgBuildOption.dsc
@@ -1,7 +1,7 @@
 ## @file
 # Silicon build option configuration file.
 #
-#   Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+#   Copyright (c) 2022 - 2025, Intel Corporation. All rights reserved.<BR>
 #   SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
@@ -116,7 +116,8 @@ MSFT:  *_*_X64_ASLCC_FLAGS    = $(DSC_SIPKG_FEATURE_BUILD_OPTIONS)
 
 # Force PE/COFF sections to be aligned at 4KB boundaries to support page level protection of runtime modules
 [BuildOptions.common.EDKII.DXE_RUNTIME_DRIVER]
-  MSFT:  *_*_*_DLINK_FLAGS      = /ALIGN:4096
-  GCC:   *_GCC*_*_DLINK_FLAGS   = -z common-page-size=0x1000
-
+  MSFT:       *_*_*_DLINK_FLAGS     = /ALIGN:4096
+  GCC:        *_GCC*_*_DLINK_FLAGS  = -z common-page-size=0x1000
+  CLANGPDB:   *_*_*_DLINK_FLAGS     = /ALIGN:4096
+  CLANGDWARF: *_*_*_DLINK_FLAGS     = -z common-page-size=0x1000
 


### PR DESCRIPTION
- Adds `[BuildOptions]` entries needed to compile with Clang
- Fix return type of the SiliconPolicyUpdateLate() function