### PR TITLE
NetworkFeaturePkg: fix build failure

### DIFF
--- a/Features/Intel/Network/NetworkFeaturePkg/Include/NetworkFeature.dsc
+++ b/Features/Intel/Network/NetworkFeaturePkg/Include/NetworkFeature.dsc
@@ -32,10 +32,10 @@
 # PCD Section - list of EDK II PCD Entries modified by the feature.
 #
 ################################################################################
-[PcdsFixedAtBuild]
+[PcdsFixedAtBuild.$(DXE_ARCH)]
   !include NetworkPkg/NetworkFixedPcds.dsc.inc
 
-[PcdsDynamicDefault]
+[PcdsDynamicDefault.$(DXE_ARCH)]
   !include NetworkPkg/NetworkDynamicPcds.dsc.inc
 
 ################################################################################


### PR DESCRIPTION
 When NETWORK_ENABLE is TRUE and NETWORK_ALLOW_HTTP_CONNECTIONS is TRUE,
 NetworkPkg/NetworkFixedPcds.dsc.inc specifies
 gEfiNetworkPkgTokenSpaceGuid.PcdAllowHttpConnections as TRUE.

But the PCD is set under [PcdsFixedAtBuild] section. The build.py will complain the following error:
Pcd (gEfiNetworkPkgTokenSpaceGuid.PcdAllowHttpConnections) defined in DSC is not declared in DEC files referenced
in INF files in FDF. Arch: ['IA32']

The commit fixes the failure by only setting the PCD in the [PcdsFixedAtBuild.$(DXE_ARCH)] section.