### PR TITLE
Features: fix missing EFIAPI for PlatformPayloadFeaturePkg

### DIFF
--- a/Features/Intel/PlatformPayloadFeaturePkg/PchSmiDispatchSmm/PchSmiDispatchSmm.c
+++ b/Features/Intel/PlatformPayloadFeaturePkg/PchSmiDispatchSmm/PchSmiDispatchSmm.c
@@ -87,6 +87,7 @@ FindContextByDispatchHandle (
 
 **/
 EFI_STATUS
+EFIAPI
 SmmSwDispatcher (
   IN     EFI_HANDLE  DispatchHandle,
   IN     CONST VOID  *RegisterContext,


### PR DESCRIPTION
When register a root SMI handler, it is expected to use windows calling convention for the SMI handler. This patch adds missing EFIAPI for the SMI handler SmmSwDispatcher to avoid potential issue from Linux build.