### PR TITLE
Support RealTimeClockLib header move to MdeModulePkg

### DIFF
--- a/Platform/ADLINK/ComHpcAltPkg/Library/PCF8563RealTimeClockLib/PCF8563RealTimeClockLib.inf
+++ b/Platform/ADLINK/ComHpcAltPkg/Library/PCF8563RealTimeClockLib/PCF8563RealTimeClockLib.inf
@@ -24,6 +24,7 @@
   ArmPlatformPkg/ArmPlatformPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dec
   Silicon/Ampere/AmpereSiliconPkg/AmpereSiliconPkg.dec
 

--- a/Platform/ASRockRack/AltraBoardPkg/Library/ISL1208RealTimeClockLib/ISL1208RealTimeClockLib.inf
+++ b/Platform/ASRockRack/AltraBoardPkg/Library/ISL1208RealTimeClockLib/ISL1208RealTimeClockLib.inf
@@ -24,6 +24,7 @@
   ArmPlatformPkg/ArmPlatformPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dec
   Silicon/Ampere/AmpereSiliconPkg/AmpereSiliconPkg.dec
 

--- a/Platform/Ampere/JadePkg/Library/PCF85063RealTimeClockLib/PCF85063RealTimeClockLib.inf
+++ b/Platform/Ampere/JadePkg/Library/PCF85063RealTimeClockLib/PCF85063RealTimeClockLib.inf
@@ -24,6 +24,7 @@
   ArmPlatformPkg/ArmPlatformPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dec
   Silicon/Ampere/AmpereSiliconPkg/AmpereSiliconPkg.dec
 

--- a/Platform/Loongson/LoongArchQemuPkg/Library/LsRealTimeClockLib/LsRealTimeClockLib.inf
+++ b/Platform/Loongson/LoongArchQemuPkg/Library/LsRealTimeClockLib/LsRealTimeClockLib.inf
@@ -23,6 +23,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   Platform/Loongson/LoongArchQemuPkg/Loongson.dec
 

--- a/Silicon/Maxim/Library/Ds1307RtcLib/Ds1307RtcLib.inf
+++ b/Silicon/Maxim/Library/Ds1307RtcLib/Ds1307RtcLib.inf
@@ -21,6 +21,7 @@
 [Packages]
   EmbeddedPkg/EmbeddedPkg.dec
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   Silicon/Maxim/Library/Ds1307RtcLib/Ds1307RtcLib.dec
 
 [LibraryClasses]


### PR DESCRIPTION
RealTimeClockLib header has been moved to MdeModulePkg in https://github.com/tianocore/edk2/pull/11362
So the package has been added to the relevant INF files.