### PR TITLE
PlatformStandaloneMmPkg/Rpmb: skip RxTx buffer mapping

### DIFF
--- a/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
+++ b/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
@@ -111,6 +111,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVariableStoreSize|0x00004000
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaSkipRxTxMapping|TRUE
 
   # The BFV is not located in the Flash area but is loaded in the RAM
   # by optee's stmm_sp.c instead, therefore no shadow copy is needed.


### PR DESCRIPTION
commit b534cabbdac4 ("ArmFfaLib: Add Rx/Tx support for Stmm secure partition") in edk2 repository, ArmFfaLib for StnadlaoneMm(Core) requires to map Rx/Tx buffer.

However, It doesn't need in RPMB platform and since StandaloneMm secure partition as TA doesn't implement the relate ABIs, it fails to load.

To address this, Skip the Rx/Tx buffer mapping in RPMB platform.\

Signed-off-by: Yeoreum Yun <yeoreum.yun@arm.com>