### PR TITLE
DynamicTablesPkg: Add SMBIOS generation

### DIFF
--- a/Platform/ADLINK/ComHpcAltPkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheData.c
+++ b/Platform/ADLINK/ComHpcAltPkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheData.c
@@ -22,8 +22,8 @@ SMBIOS_PLATFORM_DXE_TABLE_DATA (SMBIOS_TABLE_TYPE7, PlatformCache) = {
     },
     ADDITIONAL_STR_INDEX_1,                 // Socket Designation
     0x182,                                  // Write Back, Enabled, Internal, Not Socketed, Cache Level 3
-    0x8010,                                 // Maximum Cache Size: 1M
-    0x8010,                                 // Installed Size: 1M
+    {0x0010, 1},                            // Maximum Cache Size: 1M
+    {0x0010, 1},                            // Installed Size: 1M
     { 0, 0, 0, 0, 0, 1},                    // Supported SRAM Type: Synchronous
     { 0, 0, 0, 0, 0, 1},                    // Current SRAM Type: Synchronous
     0,                                      // Cache Speed

--- a/Platform/ADLINK/ComHpcAltPkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheFunction.c
+++ b/Platform/ADLINK/ComHpcAltPkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheFunction.c
@@ -20,8 +20,8 @@
 
 #define MAX_CACHE_LEVEL  2
 
-#define SLC_SIZE(x)    (UINT16)(0x8000 | (((x) * (1 << 20)) / (64 * (1 << 10))))
-#define SLC_SIZE_2(x)  (0x80000000 | (((x) * (1 << 20)) / (64 * (1 << 10))))
+#define SLC_SIZE(x)    (UINT16)((((x) * (1 << 20)) / (64 * (1 << 10))))
+#define SLC_SIZE_2(x)  ((((x) * (1 << 20)) / (64 * (1 << 10))))
 
 typedef enum {
   CacheModeWriteThrough = 0,  ///< Cache is write-through
@@ -107,15 +107,18 @@ ConfigSLCArchitectureInformation (
     //
     // Altra's SLC size is 32MB
     //
-    InputData->MaximumCacheSize  = SLC_SIZE (32);
-    InputData->MaximumCacheSize2 = SLC_SIZE_2 (32);
+    InputData->MaximumCacheSize.Size  = SLC_SIZE (32);
+    InputData->MaximumCacheSize2.Size = SLC_SIZE_2 (32);
   } else {
     //
     // Altra Max's SLC size is 16MB
     //
-    InputData->MaximumCacheSize  = SLC_SIZE (16);
-    InputData->MaximumCacheSize2 = SLC_SIZE_2 (16);
+    InputData->MaximumCacheSize.Size  = SLC_SIZE (16);
+    InputData->MaximumCacheSize2.Size = SLC_SIZE_2 (16);
   }
+
+  InputData->MaximumCacheSize.Granularity64K  = 1;
+  InputData->MaximumCacheSize2.Granularity64K = 1;
 
   InputData->InstalledSize  = InputData->MaximumCacheSize;
   InputData->InstalledSize2 = InputData->MaximumCacheSize2;

--- a/Platform/ADLINK/ComHpcAltPkg/Library/OemMiscLib/OemMiscLib.c
+++ b/Platform/ADLINK/ComHpcAltPkg/Library/OemMiscLib/OemMiscLib.c
@@ -156,10 +156,10 @@ OemGetCacheInformation (
   IN OUT SMBIOS_TABLE_TYPE7  *SmbiosCacheTable
   )
 {
-  UINT16  CacheSize16;
-  UINT32  CacheSize32;
-  UINT64  CacheSize64;
-  UINT8   Granularity32;
+  SMBIOS_CACHE_SIZE   CacheSize16;
+  SMBIOS_CACHE_SIZE2  CacheSize32;
+  UINT64              CacheSize64;
+  UINT8               Granularity32;
 
   SmbiosCacheTable->CacheConfiguration  = CacheLevel - 1;
   SmbiosCacheTable->CacheConfiguration |= (1 << 7); // Enable
@@ -180,28 +180,35 @@ OemGetCacheInformation (
   CacheSize16 = SmbiosCacheTable->MaximumCacheSize;
   CacheSize32 = SmbiosCacheTable->MaximumCacheSize2;
 
-  Granularity32 = CacheSize32 >> 31;
+  Granularity32 = SmbiosCacheTable->MaximumCacheSize2.Granularity64K;
   if (Granularity32 == 0) {
-    CacheSize64 = CacheSize32;
+    CacheSize64 = CacheSize32.Size;
   } else {
-    CacheSize64 = (CacheSize32 & (~BIT31)) * 64;
+    CacheSize64 = CacheSize32.Size * 64;
   }
 
   CacheSize64 *= GetNumberOfActiveCoresPerSocket (ProcessorIndex);
   if (CacheSize64 < MAX_INT16) {
-    CacheSize16 = CacheSize64;
-    CacheSize32 = CacheSize16;
+    CacheSize16.Size           = CacheSize64;
+    CacheSize16.Granularity64K = 0;
+    CacheSize32.Size           = CacheSize64;
+    CacheSize32.Granularity64K = 0;
   } else if ((CacheSize64 / 64) < MAX_INT16) {
-    CacheSize16 = (UINT16)(BIT15 | (CacheSize64 / 64));
-    CacheSize32 = (UINT32)(BIT31 | (CacheSize64 / 64));
+    CacheSize16.Size           = (UINT16)(CacheSize64 / 64);
+    CacheSize16.Granularity64K = 1;
+    CacheSize32.Size           = (UINT32)(CacheSize64 / 64);
+    CacheSize32.Granularity64K = 1;
   } else {
     if ((CacheSize64 / 1024) <= 2047) {
-      CacheSize32 = CacheSize64;
+      CacheSize32.Size           = CacheSize64;
+      CacheSize32.Granularity64K = 0;
     } else {
-      CacheSize32 = (UINT32)(BIT31 | (CacheSize64 / 64));
+      CacheSize32.Size           = (UINT32)(CacheSize64 / 64);
+      CacheSize32.Granularity64K = 1;
     }
 
-    CacheSize16 = 0xFFFF;
+    CacheSize16.Size           = 0x7FFF;
+    CacheSize16.Granularity64K = 1;
   }
 
   SmbiosCacheTable->MaximumCacheSize  = CacheSize16;

--- a/Platform/ARM/JunoPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.c
+++ b/Platform/ARM/JunoPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.c
@@ -282,7 +282,7 @@ STATIC CONST ARM_TYPE4 mArmDefaultType4_a72 = {
     3, //processor type CPU
     ProcessorFamilyIndicatorFamily2, //processor family, acquire from field2
     2, //manufactuer
-    {{0,},{0.}}, //processor id
+    {0, 0, 0, 0}, //processor id
     5, //version
     {0,0,0,0,0,1}, //voltage
     0, //external clock
@@ -316,7 +316,7 @@ STATIC CONST ARM_TYPE4 mArmDefaultType4_a57 = {
     3, //processor type CPU
     ProcessorFamilyIndicatorFamily2, //processor family, acquire from field2
     2, //manufactuer
-    {{0,},{0.}}, //processor id
+    {0, 0, 0, 0}, //processor id
     3, //version
     {0,0,0,0,0,1}, //voltage
     0, //external clock
@@ -350,7 +350,7 @@ STATIC CONST ARM_TYPE4 mArmDefaultType4_a53 = {
     3, //processor type CPU
     ProcessorFamilyIndicatorFamily2, //processor family, acquire from field2
     2, //manufactuer
-    {{0,},{0.}}, //processor id
+    {0, 0, 0, 0}, //processor id
     4, //version
     {0,0,0,0,0,1}, //voltage
     0, //external clock
@@ -383,8 +383,8 @@ STATIC CONST ARM_TYPE7 mArmDefaultType7_a57_l1i = {
     },
     1,
     0x380, //L1 enabled, unknown WB
-    48, //48k i cache max
-    48, //48k installed
+    {48,0}, //48k i cache max
+    {48,0}, //48k installed
     {0,1}, //SRAM type
     {0,1}, //SRAM type
     0, //unkown speed
@@ -404,8 +404,8 @@ STATIC CONST ARM_TYPE7 mArmDefaultType7_a53_l1i = {
     },
     1,
     0x380, //L1 enabled, unknown WB
-    32, //32k i cache max
-    32, //32k installed
+    {32,0}, //32k i cache max
+    {32,0}, //32k installed
     {0,1}, //SRAM type
     {0,1}, //SRAM type
     0, //unkown speed
@@ -425,8 +425,8 @@ STATIC CONST ARM_TYPE7 mArmDefaultType7_a57_l1d = {
     },
     2,
     0x180, //L1 enabled, WB
-    32, //32k d cache max
-    32, //32k installed
+    {32,0}, //32k d cache max
+    {32,0}, //32k installed
     {0,1}, //SRAM type
     {0,1}, //SRAM type
     0, //unkown speed
@@ -446,8 +446,8 @@ STATIC CONST ARM_TYPE7 mArmDefaultType7_a53_l1d = {
     },
     2,
     0x180, //L1 enabled, WB
-    32, //32k d cache max
-    32, //32k installed
+    {32,0}, //32k d cache max
+    {32,0}, //32k installed
     {0,1}, //SRAM type
     {0,1}, //SRAM type
     0, //unkown speed
@@ -467,8 +467,8 @@ STATIC CONST ARM_TYPE7 mArmDefaultType7_a57_l2 = {
     },
     3,
     0x181, //L2 enabled, WB
-    2048, //2M d cache max
-    2048, //2M installed
+    {2048,0}, //2M d cache max
+    {2048,0}, //2M installed
     {0,1}, //SRAM type
     {0,1}, //SRAM type
     0, //unkown speed
@@ -488,8 +488,8 @@ STATIC CONST ARM_TYPE7 mArmDefaultType7_a53_l2 = {
     },
     3,
     0x181, //L2 enabled, WB
-    1024, //1M D cache max
-    1024, //1M installed
+    {1024,0}, //1M D cache max
+    {1024,0}, //1M installed
     {0,1}, //SRAM type
     {0,1}, //SRAM type
     0, //unkown speed

--- a/Platform/ARM/SgiPkg/Drivers/SmbiosPlatformDxe/Type4ProcessorInformation.c
+++ b/Platform/ARM/SgiPkg/Drivers/SmbiosPlatformDxe/Type4ProcessorInformation.c
@@ -93,7 +93,7 @@ STATIC ARM_RD_SMBIOS_TYPE4 mArmRdSmbiosType4 = {
     ProcessorFamilyIndicatorFamily2,
                              // Use Processor Family 2 field
     ManufacturerName,        // Manufacturer string number
-    {{0}, {0}},              // Processor id, update dynamically
+    {0, 0, 0, 0},            // Processor id, update dynamically
     ProcessorVersionBase,    // Processor version, update dynamically
     {0, 0, 0, 0, 0, 1},      // Non legacy mode for processor voltage
     0,                       // External clock frequency unknown

--- a/Platform/ARM/SgiPkg/Drivers/SmbiosPlatformDxe/Type7CacheInformation.c
+++ b/Platform/ARM/SgiPkg/Drivers/SmbiosPlatformDxe/Type7CacheInformation.c
@@ -59,16 +59,16 @@ STATIC ARM_RD_SMBIOS_TYPE7 mArmRdSmbiosType7[] = {
         (1 << 3) | // Cache socketed
         0x0        // Cache level 1
       ),
-      0xFFFF,      // Uses Maximum cache size 2 field
-      0xFFFF,      // Uses Installed cache size 2 field
+      {0x7FFF, 1}, // Uses Maximum cache size 2 field
+      {0x7FFF, 1}, // Uses Installed cache size 2 field
       {0, 1},      // Supported SRAM type unknown
       {0, 1},      // Current SRAM type unknown
       0,           // Cache Speed Unknown
       0x02,        // Error correction type unknown
       0x03,        // Instruction cache
       0,           // Associativity, update dynamically
-      0,           // Maximum cache size 2, update dynamically
-      0            // Installed cache size 2, update dynamically
+      {0, 0},      // Maximum cache size 2, update dynamically
+      {0, 0}       // Installed cache size 2, update dynamically
     },
     // Text strings (unformatted area)
     TYPE7_STRINGS
@@ -88,16 +88,16 @@ STATIC ARM_RD_SMBIOS_TYPE7 mArmRdSmbiosType7[] = {
         (1 << 3) | // Cache socketed
         0x0        // Cache level 1
       ),
-      0xFFFF,      // Uses Maximum cache size 2 field
-      0xFFFF,      // Uses Installed cache size 2 field
+      {0x7FFF, 1}, // Uses Maximum cache size 2 field
+      {0x7FFF, 1}, // Uses Installed cache size 2 field
       {0, 1},      // Supported SRAM type unknown
       {0, 1},      // Current SRAM type unknown
       0,           // Cache Speed Unknown
       0x02,        // Error correction type unknown
       0x04,        // Data cache
       0,           // Associativity, update dynamically
-      0,           // Maximum cache size 2, update dynamically
-      0            // Installed cache size 2, update dynamically
+      {0, 0},      // Maximum cache size 2, update dynamically
+      {0, 0}       // Installed cache size 2, update dynamically
     },
     // Text strings (unformatted area)
     TYPE7_STRINGS
@@ -117,16 +117,16 @@ STATIC ARM_RD_SMBIOS_TYPE7 mArmRdSmbiosType7[] = {
         (1 << 3) | // Cache socketed
         0x1        // Cache level 2
       ),
-      0xFFFF,      // Uses Maximum cache size 2 field
-      0xFFFF,      // Uses Installed cache size 2 field
+      {0x7FFF, 1}, // Uses Maximum cache size 2 field
+      {0x7FFF, 1}, // Uses Installed cache size 2 field
       {0, 1},      // Supported SRAM type unknown
       {0, 1},      // Current SRAM type unknown
       0,           // Cache Speed Unknown
       0x02,        // Error correction type unknown
       0x05,        // Unified cache
       0,           // Associativity, update dynamically
-      0,           // Maximum cache size 2, update dynamically
-      0            // Installed cache size 2, update dynamically
+      {0, 0},      // Maximum cache size 2, update dynamically
+      {0, 0}       // Installed cache size 2, update dynamically
     },
     // Text strings (unformatted area)
     TYPE7_STRINGS
@@ -146,16 +146,16 @@ STATIC ARM_RD_SMBIOS_TYPE7 mArmRdSmbiosType7[] = {
         (1 << 3) | // Cache socketed
         0x2        // Cache level 3
       ),
-      0xFFFF,      // Uses Maximum cache size 2 field
-      0xFFFF,      // Uses Installed cache size 2 field
+      {0x7FFF, 1}, // Uses Maximum cache size 2 field
+      {0x7FFF, 1}, // Uses Installed cache size 2 field
       {0, 1},      // Supported SRAM type unknown
       {0, 1},      // Current SRAM type unknown
       0,           // Cache Speed Unknown
       0x02,        // Error correction type unknown
       0x05,        // Unified cache
       0,           // Associativity, update dynamically
-      0,           // Maximum cache size 2, update dynamically
-      0            // Installed cache size 2, update dynamically
+      {0, 0},      // Maximum cache size 2, update dynamically
+      {0, 0}       // Installed cache size 2, update dynamically
     },
     // Text strings (unformatted area)
     TYPE7_STRINGS
@@ -175,16 +175,16 @@ STATIC ARM_RD_SMBIOS_TYPE7 mArmRdSmbiosType7[] = {
         (1 << 3) | // Cache socketed
         0x3        // Cache level 4
       ),
-      0xFFFF,      // Uses Maximum cache size 2 field
-      0xFFFF,      // Uses Installed cache size 2 field
+      {0x7FFF, 1}, // Uses Maximum cache size 2 field
+      {0x7FFF, 1}, // Uses Installed cache size 2 field
       {0, 1},      // Supported SRAM type unknown
       {0, 1},      // Current SRAM type unknown
       0,           // Cache Speed Unknown
       0x02,        // Error correction type unknown
       0x05,        // Unified cache
       0,           // Associativity, update dynamically
-      0,           // Maximum cache size 2, update dynamically
-      0            // Installed cache size 2, update dynamically
+      {0, 0},      // Maximum cache size 2, update dynamically
+      {0, 0}       // Installed cache size 2, update dynamically
     },
     // Text strings (unformatted area)
     TYPE7_STRINGS
@@ -217,141 +217,141 @@ InstallType7CacheInformation (
   switch (SgiGetProductId ()) {
   case Sgi575:
     /* L1 instruction cache */
-    mArmRdSmbiosType7[0].Base.MaximumCacheSize2 = 64;     // 64KB
-    mArmRdSmbiosType7[0].Base.InstalledSize2 = 64;        // 64KB
+    mArmRdSmbiosType7[0].Base.MaximumCacheSize2.Size = 64;     // 64KB
+    mArmRdSmbiosType7[0].Base.InstalledSize2.Size = 64;        // 64KB
     mArmRdSmbiosType7[0].Base.Associativity = CacheAssociativity4Way;
     /* L1 data cache */
-    mArmRdSmbiosType7[1].Base.MaximumCacheSize2 = 64;     // 64KB
-    mArmRdSmbiosType7[1].Base.InstalledSize2 = 64;        // 64KB
+    mArmRdSmbiosType7[1].Base.MaximumCacheSize2.Size = 64;     // 64KB
+    mArmRdSmbiosType7[1].Base.InstalledSize2.Size = 64;        // 64KB
     mArmRdSmbiosType7[1].Base.Associativity = CacheAssociativity16Way;
     /* L2 cache */
-    mArmRdSmbiosType7[2].Base.MaximumCacheSize2 = 512;    // 512KB
-    mArmRdSmbiosType7[2].Base.InstalledSize2 = 512;       // 512KB
+    mArmRdSmbiosType7[2].Base.MaximumCacheSize2.Size = 512;    // 512KB
+    mArmRdSmbiosType7[2].Base.InstalledSize2.Size = 512;       // 512KB
     mArmRdSmbiosType7[2].Base.Associativity = CacheAssociativity8Way;
     /* L3 cache */
-    mArmRdSmbiosType7[3].Base.MaximumCacheSize2 = 2048;   // 2MB
-    mArmRdSmbiosType7[3].Base.InstalledSize2 = 2048;      // 2MB
+    mArmRdSmbiosType7[3].Base.MaximumCacheSize2.Size = 2048;   // 2MB
+    mArmRdSmbiosType7[3].Base.InstalledSize2.Size = 2048;      // 2MB
     mArmRdSmbiosType7[3].Base.Associativity = CacheAssociativity16Way;
     break;
   case RdN1Edge:
   case RdN1EdgeX2:
     /* L1 instruction cache */
-    mArmRdSmbiosType7[0].Base.MaximumCacheSize2 = 64;    // 64KB
-    mArmRdSmbiosType7[0].Base.InstalledSize2 = 64;       // 64KB
+    mArmRdSmbiosType7[0].Base.MaximumCacheSize2.Size = 64;    // 64KB
+    mArmRdSmbiosType7[0].Base.InstalledSize2.Size = 64;       // 64KB
     mArmRdSmbiosType7[0].Base.Associativity = CacheAssociativity4Way;
     /* L1 data cache */
-    mArmRdSmbiosType7[1].Base.MaximumCacheSize2 = 64;    // 64KB
-    mArmRdSmbiosType7[1].Base.InstalledSize2 = 64;       // 64KB
+    mArmRdSmbiosType7[1].Base.MaximumCacheSize2.Size = 64;    // 64KB
+    mArmRdSmbiosType7[1].Base.InstalledSize2.Size = 64;       // 64KB
     mArmRdSmbiosType7[1].Base.Associativity = CacheAssociativity4Way;
     /* L2 cache */
-    mArmRdSmbiosType7[2].Base.MaximumCacheSize2 = 512;   // 512KB
-    mArmRdSmbiosType7[2].Base.InstalledSize2 = 512;      // 512KB
+    mArmRdSmbiosType7[2].Base.MaximumCacheSize2.Size = 512;   // 512KB
+    mArmRdSmbiosType7[2].Base.InstalledSize2.Size = 512;      // 512KB
     mArmRdSmbiosType7[2].Base.Associativity = CacheAssociativity8Way;
     /* L3 cache */
-    mArmRdSmbiosType7[3].Base.MaximumCacheSize2 = 2048;  // 2MB
-    mArmRdSmbiosType7[3].Base.InstalledSize2 = 2048;     // 2MB
+    mArmRdSmbiosType7[3].Base.MaximumCacheSize2.Size = 2048;  // 2MB
+    mArmRdSmbiosType7[3].Base.InstalledSize2.Size = 2048;     // 2MB
     mArmRdSmbiosType7[3].Base.Associativity = CacheAssociativity16Way;
     /* System level cache */
-    mArmRdSmbiosType7[4].Base.MaximumCacheSize2 = 8192;  // 8MB SLC per chip
-    mArmRdSmbiosType7[4].Base.InstalledSize2 = 8192;     // 8MB SLC per chip
+    mArmRdSmbiosType7[4].Base.MaximumCacheSize2.Size = 8192;  // 8MB SLC per chip
+    mArmRdSmbiosType7[4].Base.InstalledSize2.Size = 8192;     // 8MB SLC per chip
     mArmRdSmbiosType7[4].Base.Associativity = CacheAssociativity16Way;
     break;
   case RdE1Edge:
     /* L1 instruction cache */
-    mArmRdSmbiosType7[0].Base.MaximumCacheSize2 = 32;    // 32KB
-    mArmRdSmbiosType7[0].Base.InstalledSize2 = 32;       // 32KB
+    mArmRdSmbiosType7[0].Base.MaximumCacheSize2.Size = 32;    // 32KB
+    mArmRdSmbiosType7[0].Base.InstalledSize2.Size = 32;       // 32KB
     mArmRdSmbiosType7[0].Base.Associativity = CacheAssociativity4Way;
     /* L1 data cache */
-    mArmRdSmbiosType7[1].Base.MaximumCacheSize2 = 32;    // 32KB
-    mArmRdSmbiosType7[1].Base.InstalledSize2 = 32;       // 32KB
+    mArmRdSmbiosType7[1].Base.MaximumCacheSize2.Size = 32;    // 32KB
+    mArmRdSmbiosType7[1].Base.InstalledSize2.Size = 32;       // 32KB
     mArmRdSmbiosType7[1].Base.Associativity = CacheAssociativity4Way;
     /* L2 cache */
-    mArmRdSmbiosType7[2].Base.MaximumCacheSize2 = 256;   // 256KB
-    mArmRdSmbiosType7[2].Base.InstalledSize2 = 256;      // 256KB
+    mArmRdSmbiosType7[2].Base.MaximumCacheSize2.Size = 256;   // 256KB
+    mArmRdSmbiosType7[2].Base.InstalledSize2.Size = 256;      // 256KB
     mArmRdSmbiosType7[2].Base.Associativity = CacheAssociativity4Way;
     /* L3 cache */
-    mArmRdSmbiosType7[3].Base.MaximumCacheSize2 = 2048;  // 2MB
-    mArmRdSmbiosType7[3].Base.InstalledSize2 = 2048;     // 2MB
+    mArmRdSmbiosType7[3].Base.MaximumCacheSize2.Size = 2048;  // 2MB
+    mArmRdSmbiosType7[3].Base.InstalledSize2.Size = 2048;     // 2MB
     mArmRdSmbiosType7[3].Base.Associativity = CacheAssociativity16Way;
     /* System level cache */
-    mArmRdSmbiosType7[4].Base.MaximumCacheSize2 = 8192;  // 8MB SLC
-    mArmRdSmbiosType7[4].Base.InstalledSize2 = 8192;     // 8MB SLC
+    mArmRdSmbiosType7[4].Base.MaximumCacheSize2.Size = 8192;  // 8MB SLC
+    mArmRdSmbiosType7[4].Base.InstalledSize2.Size = 8192;     // 8MB SLC
     mArmRdSmbiosType7[4].Base.Associativity = CacheAssociativity16Way;
     break;
   case RdV1:
   case RdV1Mc:
     /* L1 instruction cache */
-    mArmRdSmbiosType7[0].Base.MaximumCacheSize2 = 64;    // 64KB
-    mArmRdSmbiosType7[0].Base.InstalledSize2 = 64;       // 64KB
+    mArmRdSmbiosType7[0].Base.MaximumCacheSize2.Size = 64;    // 64KB
+    mArmRdSmbiosType7[0].Base.InstalledSize2.Size = 64;       // 64KB
     mArmRdSmbiosType7[0].Base.Associativity = CacheAssociativity4Way;
     /* L1 data cache */
-    mArmRdSmbiosType7[1].Base.MaximumCacheSize2 = 64;    // 64KB
-    mArmRdSmbiosType7[1].Base.InstalledSize2 = 64;       // 64KB
+    mArmRdSmbiosType7[1].Base.MaximumCacheSize2.Size = 64;    // 64KB
+    mArmRdSmbiosType7[1].Base.InstalledSize2.Size = 64;       // 64KB
     mArmRdSmbiosType7[1].Base.Associativity = CacheAssociativity4Way;
     /* L2 cache */
-    mArmRdSmbiosType7[2].Base.MaximumCacheSize2 = 1024;  // 1MB
-    mArmRdSmbiosType7[2].Base.InstalledSize2 = 1024;     // 1MB
+    mArmRdSmbiosType7[2].Base.MaximumCacheSize2.Size = 1024;  // 1MB
+    mArmRdSmbiosType7[2].Base.InstalledSize2.Size = 1024;     // 1MB
     mArmRdSmbiosType7[2].Base.Associativity = CacheAssociativity8Way;
     /* System level cache */
-    mArmRdSmbiosType7[4].Base.MaximumCacheSize2 = 16384; // 16MB SLC per chip
-    mArmRdSmbiosType7[4].Base.InstalledSize2 = 16384;    // 16MB SLC per chip
+    mArmRdSmbiosType7[4].Base.MaximumCacheSize2.Size = 16384; // 16MB SLC per chip
+    mArmRdSmbiosType7[4].Base.InstalledSize2.Size = 16384;    // 16MB SLC per chip
     mArmRdSmbiosType7[4].Base.Associativity = CacheAssociativity16Way;
     break;
   case RdN2:
   case RdN2Cfg2:
     /* L1 instruction cache */
-    mArmRdSmbiosType7[0].Base.MaximumCacheSize2 = 64;    // 64KB
-    mArmRdSmbiosType7[0].Base.InstalledSize2 = 64;       // 64KB
+    mArmRdSmbiosType7[0].Base.MaximumCacheSize2.Size = 64;    // 64KB
+    mArmRdSmbiosType7[0].Base.InstalledSize2.Size = 64;       // 64KB
     mArmRdSmbiosType7[0].Base.Associativity = CacheAssociativity4Way;
     /* L1 data cache */
-    mArmRdSmbiosType7[1].Base.MaximumCacheSize2 = 64;    // 64KB
-    mArmRdSmbiosType7[1].Base.InstalledSize2 = 64;       // 64KB
+    mArmRdSmbiosType7[1].Base.MaximumCacheSize2.Size = 64;    // 64KB
+    mArmRdSmbiosType7[1].Base.InstalledSize2.Size = 64;       // 64KB
     mArmRdSmbiosType7[1].Base.Associativity = CacheAssociativity4Way;
     /* L2 cache */
-    mArmRdSmbiosType7[2].Base.MaximumCacheSize2 = 1024;  // 1MB
-    mArmRdSmbiosType7[2].Base.InstalledSize2 = 1024;     // 1MB
+    mArmRdSmbiosType7[2].Base.MaximumCacheSize2.Size = 1024;  // 1MB
+    mArmRdSmbiosType7[2].Base.InstalledSize2.Size = 1024;     // 1MB
     mArmRdSmbiosType7[2].Base.Associativity = CacheAssociativity8Way;
     /* System level cache */
-    mArmRdSmbiosType7[4].Base.MaximumCacheSize2 = 32768; // 32MB SLC
-    mArmRdSmbiosType7[4].Base.InstalledSize2 = 32768;    // 32MB SLC
+    mArmRdSmbiosType7[4].Base.MaximumCacheSize2.Size = 32768; // 32MB SLC
+    mArmRdSmbiosType7[4].Base.InstalledSize2.Size = 32768;    // 32MB SLC
     mArmRdSmbiosType7[4].Base.Associativity = CacheAssociativity16Way;
     break;
   case RdN2Cfg1:
     /* L1 instruction cache */
-    mArmRdSmbiosType7[0].Base.MaximumCacheSize2 = 64;    // 64KB
-    mArmRdSmbiosType7[0].Base.InstalledSize2 = 64;       // 64KB
+    mArmRdSmbiosType7[0].Base.MaximumCacheSize2.Size = 64;    // 64KB
+    mArmRdSmbiosType7[0].Base.InstalledSize2.Size = 64;       // 64KB
     mArmRdSmbiosType7[0].Base.Associativity = CacheAssociativity4Way;
     /* L1 data cache */
-    mArmRdSmbiosType7[1].Base.MaximumCacheSize2 = 64;    // 64KB
-    mArmRdSmbiosType7[1].Base.InstalledSize2 = 64;       // 64KB
+    mArmRdSmbiosType7[1].Base.MaximumCacheSize2.Size = 64;    // 64KB
+    mArmRdSmbiosType7[1].Base.InstalledSize2.Size = 64;       // 64KB
     mArmRdSmbiosType7[1].Base.Associativity = CacheAssociativity4Way;
     /* L2 cache */
-    mArmRdSmbiosType7[2].Base.MaximumCacheSize2 = 1024;  // 1MB
-    mArmRdSmbiosType7[2].Base.InstalledSize2 = 1024;     // 1MB
+    mArmRdSmbiosType7[2].Base.MaximumCacheSize2.Size = 1024;  // 1MB
+    mArmRdSmbiosType7[2].Base.InstalledSize2.Size = 1024;     // 1MB
     mArmRdSmbiosType7[2].Base.Associativity = CacheAssociativity8Way;
     /* System level cache */
-    mArmRdSmbiosType7[4].Base.MaximumCacheSize2 = 8192;  // 8MB SLC
-    mArmRdSmbiosType7[4].Base.InstalledSize2 = 8192;     // 8MB SLC
+    mArmRdSmbiosType7[4].Base.MaximumCacheSize2.Size = 8192;  // 8MB SLC
+    mArmRdSmbiosType7[4].Base.InstalledSize2.Size = 8192;     // 8MB SLC
     mArmRdSmbiosType7[4].Base.Associativity = CacheAssociativity16Way;
     break;
   case RdV2:
   case RdV3:
   case RdV3Cfg2:
     /* L1 instruction cache */
-    mArmRdSmbiosType7[0].Base.MaximumCacheSize2 = 64;    // 64KB
-    mArmRdSmbiosType7[0].Base.InstalledSize2 = 64;       // 64KB
+    mArmRdSmbiosType7[0].Base.MaximumCacheSize2.Size = 64;    // 64KB
+    mArmRdSmbiosType7[0].Base.InstalledSize2.Size = 64;       // 64KB
     mArmRdSmbiosType7[0].Base.Associativity = CacheAssociativity4Way;
     /* L1 data cache */
-    mArmRdSmbiosType7[1].Base.MaximumCacheSize2 = 64;    // 64KB
-    mArmRdSmbiosType7[1].Base.InstalledSize2 = 64;       // 64KB
+    mArmRdSmbiosType7[1].Base.MaximumCacheSize2.Size = 64;    // 64KB
+    mArmRdSmbiosType7[1].Base.InstalledSize2.Size = 64;       // 64KB
     mArmRdSmbiosType7[1].Base.Associativity = CacheAssociativity4Way;
     /* L2 cache */
-    mArmRdSmbiosType7[2].Base.MaximumCacheSize2 = 2048;  // 2MB
-    mArmRdSmbiosType7[2].Base.InstalledSize2 = 2048;     // 2MB
+    mArmRdSmbiosType7[2].Base.MaximumCacheSize2.Size = 2048;  // 2MB
+    mArmRdSmbiosType7[2].Base.InstalledSize2.Size = 2048;     // 2MB
     mArmRdSmbiosType7[2].Base.Associativity = CacheAssociativity8Way;
     /* System level cache */
-    mArmRdSmbiosType7[4].Base.MaximumCacheSize2 = 32768; // 32MB SLC
-    mArmRdSmbiosType7[4].Base.InstalledSize2 = 32768;    // 32MB SLC
+    mArmRdSmbiosType7[4].Base.MaximumCacheSize2.Size = 32768; // 32MB SLC
+    mArmRdSmbiosType7[4].Base.InstalledSize2.Size = 32768;    // 32MB SLC
     mArmRdSmbiosType7[4].Base.Associativity = CacheAssociativity16Way;
     break;
   case RdV3Cfg1:
@@ -394,7 +394,7 @@ InstallType7CacheInformation (
 
   /* Install valid cache information tables */
   for (CacheIdx = 0; CacheIdx < ARRAY_SIZE (mArmRdSmbiosType7); CacheIdx++) {
-    if (mArmRdSmbiosType7[CacheIdx].Base.MaximumCacheSize2 == 0) {
+    if (mArmRdSmbiosType7[CacheIdx].Base.MaximumCacheSize2.Size == 0) {
       continue;
     }
 

--- a/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
@@ -70,6 +70,8 @@
 
   DtPlatformDtbLoaderLib|Platform/ARM/VExpressPkg/Library/ArmVExpressDtPlatformDtbLoaderLib/ArmVExpressDtPlatformDtbLoaderLib.inf
 
+  SmbiosSmcLib|DynamicTablesPkg/Library/Smbios/Arm/SmbiosSmcLib/SmbiosSmcLib.inf
+
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
   ArmFfaLib|MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
   ArmPlatformSysConfigLib|Platform/ARM/VExpressPkg/Library/ArmVExpressSysConfigRuntimeLib/ArmVExpressSysConfigRuntimeLib.inf

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -120,6 +120,8 @@ typedef EFI_STATUS (*CM_OBJECT_HANDLER_PROC) (
 */
 #define PLAT_ACPI_TABLE_COUNT       11
 
+#define PLAT_SMBIOS_TABLE_COUNT     2
+
 /** The number of platform generic timer blocks
 */
 #define PLAT_GTBLOCK_COUNT          1
@@ -203,6 +205,8 @@ typedef struct PlatformRepositoryInfo {
 
   /// List of ACPI tables
   CM_STD_OBJ_ACPI_TABLE_INFO            CmAcpiTableList[PLAT_ACPI_TABLE_COUNT];
+
+  CM_STD_OBJ_SMBIOS_TABLE_INFO          SmbiosTableList[PLAT_SMBIOS_TABLE_COUNT];
 
   /// Boot architecture information
   CM_ARM_BOOT_ARCH_INFO                 BootArchInfo;

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.uni
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.uni
@@ -1,0 +1,22 @@
+// /** @file
+//
+//
+//  Copyright (c) 2025, Arm Ltd. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#langdef   en-US "English"
+
+#string STR_SOCKET0_DESIGNATOR     #language en-US "Socket 0"
+#string STR_SOCKET0_MANUFACTURER   #language en-US "Arm Limited"
+#string STR_SOCKET0_VERSION        #language en-US "Versatile Express"
+#string STR_SOCKET0_SERIAL_NUMBER  #language en-US "01234567-89abcdef"
+#string STR_SOCKET0_ASSET_TAG      #language en-US "To be filled in by O.E.M."
+#string STR_SOCKET0_PART_NUMBER    #language en-US "00000001"
+#string STR_SOCKET0_SOCKET_TYPE    #language en-US "N/A"
+
+#string STR_CACHE_SOCKET0_L1       #language en-US "Socket 0 Level 1 cache"
+#string STR_CACHE_SOCKET0_L2       #language en-US "Socket 0 Level 2 cache"
+#string STR_CACHE_SOCKET0_L3       #language en-US "Socket 0 Level 3 cache"

--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerDxe.inf
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManagerDxe.inf
@@ -22,6 +22,7 @@
 
 [Sources]
   ConfigurationManager.c
+  ConfigurationManager.uni
   AslTables/Dsdt.asl
 
 [Packages]
@@ -35,7 +36,11 @@
 [LibraryClasses]
   ArmLib
   ArmPlatformLib
+  BaseLib
+  HiiLib
+  MemoryAllocationLib
   PrintLib
+  SmbiosSmcLib
   UefiBootServicesTableLib
   UefiDriverEntryPoint
   UefiRuntimeServicesTableLib

--- a/Platform/ASRockRack/AltraBoardPkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheData.c
+++ b/Platform/ASRockRack/AltraBoardPkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheData.c
@@ -22,8 +22,8 @@ SMBIOS_PLATFORM_DXE_TABLE_DATA (SMBIOS_TABLE_TYPE7, PlatformCache) = {
     },
     ADDITIONAL_STR_INDEX_1,                 // Socket Designation
     0x182,                                  // Write Back, Enabled, Internal, Not Socketed, Cache Level 3
-    0x8010,                                 // Maximum Cache Size: 1M
-    0x8010,                                 // Installed Size: 1M
+    {0x8010, 1},                            // Maximum Cache Size: 1M
+    {0x8010, 1},                            // Installed Size: 1M
     { 0, 0, 0, 0, 0, 1},                    // Supported SRAM Type: Synchronous
     { 0, 0, 0, 0, 0, 1},                    // Current SRAM Type: Synchronous
     0,                                      // Cache Speed

--- a/Platform/ASRockRack/AltraBoardPkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheFunction.c
+++ b/Platform/ASRockRack/AltraBoardPkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheFunction.c
@@ -20,8 +20,8 @@
 
 #define MAX_CACHE_LEVEL  2
 
-#define SLC_SIZE(x)    (UINT16)(0x8000 | (((x) * (1 << 20)) / (64 * (1 << 10))))
-#define SLC_SIZE_2(x)  (0x80000000 | (((x) * (1 << 20)) / (64 * (1 << 10))))
+#define SLC_SIZE(x)    (UINT16)((((x) * (1 << 20)) / (64 * (1 << 10))))
+#define SLC_SIZE_2(x)  ((((x) * (1 << 20)) / (64 * (1 << 10))))
 
 typedef enum {
   CacheModeWriteThrough = 0,  ///< Cache is write-through
@@ -106,15 +106,18 @@ ConfigSlcArchitectureInformation (
     //
     // Altra's SLC size is 32MB
     //
-    InputData->MaximumCacheSize  = SLC_SIZE (32);
-    InputData->MaximumCacheSize2 = SLC_SIZE_2 (32);
+    InputData->MaximumCacheSize.Size  = SLC_SIZE (32);
+    InputData->MaximumCacheSize2.Size = SLC_SIZE_2 (32);
   } else {
     //
     // Altra Max's SLC size is 16MB
     //
-    InputData->MaximumCacheSize  = SLC_SIZE (16);
-    InputData->MaximumCacheSize2 = SLC_SIZE_2 (16);
+    InputData->MaximumCacheSize.Size  = SLC_SIZE (16);
+    InputData->MaximumCacheSize2.Size = SLC_SIZE_2 (16);
   }
+
+  InputData->MaximumCacheSize.Granularity64K  = 1;
+  InputData->MaximumCacheSize2.Granularity64K = 1;
 
   InputData->InstalledSize  = InputData->MaximumCacheSize;
   InputData->InstalledSize2 = InputData->MaximumCacheSize2;

--- a/Platform/ASRockRack/AltraBoardPkg/Library/OemMiscLib/OemMiscLib.c
+++ b/Platform/ASRockRack/AltraBoardPkg/Library/OemMiscLib/OemMiscLib.c
@@ -158,10 +158,10 @@ OemGetCacheInformation (
   IN OUT SMBIOS_TABLE_TYPE7  *SmbiosCacheTable
   )
 {
-  UINT16  CacheSize16;
-  UINT32  CacheSize32;
-  UINT64  CacheSize64;
-  UINT8   Granularity32;
+  SMBIOS_CACHE_SIZE   CacheSize16;
+  SMBIOS_CACHE_SIZE2  CacheSize32;
+  UINT64              CacheSize64;
+  UINT8               Granularity32;
 
   SmbiosCacheTable->CacheConfiguration  = CacheLevel - 1;
   SmbiosCacheTable->CacheConfiguration |= (1 << 7); // Enable
@@ -182,28 +182,35 @@ OemGetCacheInformation (
   CacheSize16 = SmbiosCacheTable->MaximumCacheSize;
   CacheSize32 = SmbiosCacheTable->MaximumCacheSize2;
 
-  Granularity32 = CacheSize32 >> 31;
+  Granularity32 = SmbiosCacheTable->MaximumCacheSize2.Granularity64K;
   if (Granularity32 == 0) {
-    CacheSize64 = CacheSize32;
+    CacheSize64 = CacheSize32.Size;
   } else {
-    CacheSize64 = (CacheSize32 & (~BIT31)) * 64;
+    CacheSize64 = CacheSize32.Size * 64;
   }
 
   CacheSize64 *= GetNumberOfActiveCoresPerSocket (ProcessorIndex);
   if (CacheSize64 < MAX_INT16) {
-    CacheSize16 = CacheSize64;
-    CacheSize32 = CacheSize16;
+    CacheSize16.Size           = CacheSize64;
+    CacheSize16.Granularity64K = 0;
+    CacheSize32.Size           = CacheSize64;
+    CacheSize32.Granularity64K = 0;
   } else if ((CacheSize64 / 64) < MAX_INT16) {
-    CacheSize16 = (UINT16)(BIT15 | (CacheSize64 / 64));
-    CacheSize32 = (UINT32)(BIT31 | (CacheSize64 / 64));
+    CacheSize16.Size           = (UINT16)(CacheSize64 / 64);
+    CacheSize16.Granularity64K = 1;
+    CacheSize32.Size           = (UINT32)(CacheSize64 / 64);
+    CacheSize32.Granularity64K = 1;
   } else {
     if ((CacheSize64 / 1024) <= 2047) {
-      CacheSize32 = CacheSize64;
+      CacheSize32.Size           = CacheSize64;
+      CacheSize32.Granularity64K = 0;
     } else {
-      CacheSize32 = (UINT32)(BIT31 | (CacheSize64 / 64));
+      CacheSize32.Size           = (UINT32)(CacheSize64 / 64);
+      CacheSize32.Granularity64K = 1;
     }
 
-    CacheSize16 = 0xFFFF;
+    CacheSize16.Size           = 0x7FFF;
+    CacheSize16.Granularity64K = 1;
   }
 
   SmbiosCacheTable->MaximumCacheSize  = CacheSize16;
@@ -387,6 +394,7 @@ OemUpdateSmbiosInfo (
         AsciiString = IpmiFruInfoGet (FruBoardManufacturerName);
         DEBUG ((DEBUG_INFO, "%a: (2) Product Manufacturer: %a\n", __func__, AsciiString));
       }
+
       if (AsciiString != NULL) {
         StringLength = AsciiStrLen (AsciiString) + 1;
         AsciiStrToUnicodeStrS (AsciiString, UnicodeString, StringLength);
@@ -410,6 +418,7 @@ OemUpdateSmbiosInfo (
         AsciiString = IpmiFruInfoGet (FruBoardSerialNumber);
         DEBUG ((DEBUG_INFO, "%a: (2) Product Serial: %a\n", __func__, AsciiString));
       }
+
       if (AsciiString != NULL) {
         StringLength = AsciiStrLen (AsciiString) + 1;
         AsciiStrToUnicodeStrS (AsciiString, UnicodeString, StringLength);
@@ -494,6 +503,7 @@ OemUpdateSmbiosInfo (
       if (AsciiStrCmp (AsciiString, PLACEHOLDER_SMBIOS_STRING) == 0) {
         AsciiString = IpmiFruInfoGet (FruBoardSerialNumber);
       }
+
       if (AsciiString != NULL) {
         StringLength = AsciiStrLen (AsciiString) + 1;
         AsciiStrToUnicodeStrS (AsciiString, UnicodeString, StringLength);

--- a/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheData.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheData.c
@@ -22,8 +22,8 @@ SMBIOS_PLATFORM_DXE_TABLE_DATA (SMBIOS_TABLE_TYPE7, PlatformCache) = {
     },
     ADDITIONAL_STR_INDEX_1,                 // Socket Designation
     0x182,                                  // Write Back, Enabled, Internal, Not Socketed, Cache Level 3
-    0x8010,                                 // Maximum Cache Size: 1M
-    0x8010,                                 // Installed Size: 1M
+    {0x0010, 1},                            // Maximum Cache Size: 1M
+    {0x0010, 1},                            // Installed Size: 1M
     { 0, 0, 0, 0, 0, 1},                    // Supported SRAM Type: Synchronous
     { 0, 0, 0, 0, 0, 1},                    // Current SRAM Type: Synchronous
     0,                                      // Cache Speed

--- a/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheFunction.c
+++ b/Platform/Ampere/JadePkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheFunction.c
@@ -20,8 +20,8 @@
 
 #define MAX_CACHE_LEVEL  2
 
-#define SLC_SIZE(x)    (UINT16)(0x8000 | (((x) * (1 << 20)) / (64 * (1 << 10))))
-#define SLC_SIZE_2(x)  (0x80000000 | (((x) * (1 << 20)) / (64 * (1 << 10))))
+#define SLC_SIZE(x)    (UINT16)((((x) * (1 << 20)) / (64 * (1 << 10))))
+#define SLC_SIZE_2(x)  ((((x) * (1 << 20)) / (64 * (1 << 10))))
 
 typedef enum {
   CacheModeWriteThrough = 0,  ///< Cache is write-through
@@ -106,15 +106,18 @@ ConfigSlcArchitectureInformation (
     //
     // Altra's SLC size is 32MB
     //
-    InputData->MaximumCacheSize  = SLC_SIZE (32);
-    InputData->MaximumCacheSize2 = SLC_SIZE_2 (32);
+    InputData->MaximumCacheSize.Size  = SLC_SIZE (32);
+    InputData->MaximumCacheSize2.Size = SLC_SIZE_2 (32);
   } else {
     //
     // Altra Max's SLC size is 16MB
     //
-    InputData->MaximumCacheSize  = SLC_SIZE (16);
-    InputData->MaximumCacheSize2 = SLC_SIZE_2 (16);
+    InputData->MaximumCacheSize.Size  = SLC_SIZE (16);
+    InputData->MaximumCacheSize2.Size = SLC_SIZE_2 (16);
   }
+
+  InputData->MaximumCacheSize.Granularity64K  = 1;
+  InputData->MaximumCacheSize2.Granularity64K = 1;
 
   InputData->InstalledSize  = InputData->MaximumCacheSize;
   InputData->InstalledSize2 = InputData->MaximumCacheSize2;

--- a/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscProcessorCacheFunction.c
+++ b/Platform/Intel/Vlv2TbltDevicePkg/SmBiosMiscDxe/MiscProcessorCacheFunction.c
@@ -103,15 +103,15 @@ MISC_SMBIOS_TABLE_FUNCTION(MiscProcessorCache)
     //
     switch (CacheParamsEax.Bits.CacheLevel) {
     case 1:
-      SmbiosRecord->InstalledSize      = (UINT16)(Size >> 10);
-      SmbiosRecord->MaximumCacheSize   = SmbiosRecord->InstalledSize;
+      SmbiosRecord->InstalledSize.Size      = (UINT16)(Size >> 10);
+      SmbiosRecord->MaximumCacheSize.Size   = SmbiosRecord->InstalledSize.Size;
       SmbiosRecord->SystemCacheType    = SystemCacheType;
       SmbiosRecord->Associativity      = CacheAssociativity8Way;
       SmbiosRecord->CacheConfiguration = 0x0180;
       break;
     case 2:
-      SmbiosRecord->InstalledSize      = (UINT16)(Size >> 10);
-      SmbiosRecord->MaximumCacheSize   = SmbiosRecord->InstalledSize;
+      SmbiosRecord->InstalledSize.Size      = (UINT16)(Size >> 10);
+      SmbiosRecord->MaximumCacheSize.Size   = SmbiosRecord->InstalledSize.Size;
       SmbiosRecord->SystemCacheType    = SystemCacheType;
       SmbiosRecord->Associativity      = CacheAssociativity16Way;
       SmbiosRecord->CacheConfiguration = 0x0281;

--- a/Platform/RaspberryPi/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.c
+++ b/Platform/RaspberryPi/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.c
@@ -244,8 +244,7 @@ SMBIOS_TABLE_TYPE4 mProcessorInfoType4 = {
   ProcessorFamilyIndicatorFamily2, // ProcessorFamily;        ///< The enumeration value from PROCESSOR_FAMILY2_DATA.
   2,                               // ProcessorManufacture String;
   {                                // ProcessorId;
-    { 0x00, 0x00, 0x00, 0x00 },
-    { 0x00, 0x00, 0x00, 0x00 }
+    0x00, 0x00, 0x00, 0x00
   },
   3,                    // ProcessorVersion String;
   {                     // Voltage;
@@ -311,11 +310,11 @@ SMBIOS_TABLE_TYPE7 mCacheInfoType7_L1I = {
        //Operational Mode   :2  (Unknown)
        //Reserved           :6
 #if (RPI_MODEL == 4)
-  0x0030,                   // Maximum Size (RPi4: 48KB)
-  0x0030,                   // Install Size (RPi4: 48KB)
+  {0x0030, 0},              // Maximum Size (RPi4: 48KB)
+  {0x0030, 0},              // Install Size (RPi4: 48KB)
 #else
-  0x0010,                   // Maximum Size (RPi3: 16KB)
-  0x0010,                   // Install Size (RPi3: 16KB)
+  {0x0010, 0},              // Maximum Size (RPi3: 16KB)
+  {0x0010, 0},              // Install Size (RPi3: 16KB)
 #endif
   {                         // Supported SRAM Type
     0,  //Other             :1
@@ -359,11 +358,11 @@ SMBIOS_TABLE_TYPE7 mCacheInfoType7_L1D = {
        //Operational Mode   :2  (WB)
        //Reserved           :6
 #if (RPI_MODEL == 4)
-  0x0020,                   // Maximum Size (RPi4: 32KB)
-  0x0020,                   // Install Size (RPi4: 32KB)
+  {0x0020, 0},              // Maximum Size (RPi4: 32KB)
+  {0x0020, 0},              // Install Size (RPi4: 32KB)
 #else
-  0x0010,                   // Maximum Size (RPi3: 16KB)
-  0x0010,                   // Install Size (RPi3: 16KB)
+  {0x0010, 0},              // Maximum Size (RPi3: 16KB)
+  {0x0010, 0},              // Install Size (RPi3: 16KB)
 #endif
   {                         // Supported SRAM Type
     0,  //Other             :1
@@ -411,11 +410,11 @@ SMBIOS_TABLE_TYPE7 mCacheInfoType7_L2 = {
        //Operational Mode   :2  (WB)
        //Reserved           :6
 #if (RPI_MODEL == 4)
-  0x0400,                   // Maximum Size (RPi4: 1MB)
-  0x0400,                   // Install Size (RPi4: 1MB)
+  {0x0400, 0},              // Maximum Size (RPi4: 1MB)
+  {0x0400, 0},              // Install Size (RPi4: 1MB)
 #else
-  0x0200,                   // Maximum Size (RPi3: 512KB)
-  0x0200,                   // Install Size (RPi3: 512KB)
+  {0x0200, 0},              // Maximum Size (RPi3: 512KB)
+  {0x0200, 0},              // Install Size (RPi3: 512KB)
 #endif
   {                         // Supported SRAM Type
     0,  //Other             :1

--- a/Silicon/Marvell/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c
+++ b/Silicon/Marvell/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c
@@ -177,7 +177,7 @@ STATIC SMBIOS_TABLE_TYPE4 mArmadaDefaultType4 = {
   3, //processor type CPU
   ProcessorFamilyIndicatorFamily2, //processor family, acquire from field2
   2,             //manufactuer
-  {{0,},{0.}},   //processor id
+  {0,0,0,0},     //processor id
   3,             //version
   {0,0,0,0,0,1}, //voltage
   0,             //external clock
@@ -218,8 +218,8 @@ STATIC SMBIOS_TABLE_TYPE7 mArmadaDefaultType7_a72_l1i = {
   },
   1,
   0x380, //L1 enabled, unknown WB
-  48,    //48k I-cache max
-  48,    //48k installed
+  {48,0},//48k I-cache max
+  {48,0},//48k installed
   {0,1}, //SRAM type
   {0,1}, //SRAM type
   0,     //speed unknown
@@ -239,8 +239,8 @@ STATIC SMBIOS_TABLE_TYPE7 mArmadaDefaultType7_a72_l1d = {
   },
   2,
   0x380, //L1 enabled, unknown WB
-  32,    //32k D-cache max
-  32,    //32k installed
+  {32,0},//32k D-cache max
+  {32,0},//32k installed
   {0,1}, //SRAM type
   {0,1}, //SRAM type
   0,     //speed unknown
@@ -260,8 +260,8 @@ STATIC SMBIOS_TABLE_TYPE7 mArmadaDefaultType7_a72_l2 = {
   },
   3,
   0x181, //L2 enabled, WB
-  512,   //512k D-cache max
-  512,   //512k installed
+  {512,0},//512k D-cache max
+  {512,0},//512k installed
   {0,1}, //SRAM type
   {0,1}, //SRAM type
   0,     //speed unknown
@@ -281,8 +281,8 @@ STATIC SMBIOS_TABLE_TYPE7 mArmadaDefaultType7_l3 = {
   },
   4,
   0x182, //L3 enabled, WB
-  1024,  //1M cache max
-  1024,  //1M installed
+  {1024,0},//1M cache max
+  {1024,0},//1M installed
   {0,1}, //SRAM type
   {0,1}, //SRAM type
   0,     //speed unknown

--- a/Silicon/Phytium/FT2000-4Pkg/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c
+++ b/Silicon/Phytium/FT2000-4Pkg/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c
@@ -433,12 +433,7 @@ ARM_TYPE4 ProcessorInfo_Type4 = {
     ProcessorFamilyIndicatorFamily2,            //ProcessorFamily
     2,                                          //ProcessorManufacture
     {                                           //ProcessorId
-      {                                         //Signature
-        0
-      },
-      {                                         //FeatureFlags
-        0
-      }
+      0, 0, 0, 0
     },
     3,                                          //ProcessorVersion
     {                                           //Voltage
@@ -480,8 +475,8 @@ ARM_TYPE7_L1DATA L1Data_Type7 = {
     },
     1,                                              //SocketDesignation
     0x0180,                                         //CacheConfiguration
-    0,                                              //MaximumCacheSize
-    0,                                              //InstalledSize
+    {0, 0},                                         //MaximumCacheSize
+    {0, 0},                                         //InstalledSize
     {                                               //SupportedSRAMType
       0, 0, 0, 0, 0, 1, 0, 0
     },
@@ -508,8 +503,8 @@ ARM_TYPE7_L1INS L1Ins_Type7 = {
     },
     1,                                              //SocketDesignation
     0x0180,                                         //CacheConfiguration
-    0,                                              //MaximumCacheSize
-    0,                                              //InstalledSize
+    {0, 0},                                         //MaximumCacheSize
+    {0, 0},                                         //InstalledSize
     {                                               //SupportedSRAMType
       0, 0, 0, 0, 0, 1, 0, 0
     },
@@ -536,8 +531,8 @@ ARM_TYPE7_L2 L2_Type7 = {
     },
     1,                                              //SocketDesignation
     0x0281,                                         //CacheConfiguration
-    0,                                              //MaximumCacheSize
-    0,                                              //InstalledSize
+    {0, 0},                                         //MaximumCacheSize
+    {0, 0},                                         //InstalledSize
     {                                               //SupportedSRAMType
        0, 0, 0, 0, 0, 1, 0, 0
     },
@@ -564,8 +559,8 @@ ARM_TYPE7_L3 L3_Type7 = {
     },
     1,                                              //SocketDesignation
     0x0281,                                         //CacheConfiguration
-    0,                                              //MaximumCacheSize
-    0,                                              //InstalledSize
+    {0, 0},                                         //MaximumCacheSize
+    {0, 0},                                         //InstalledSize
     {                                               //SupportedSRAMType
        0, 0, 0, 0, 0, 1, 0, 0
     },

--- a/Silicon/Sophgo/SG2042Pkg/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c
+++ b/Silicon/Sophgo/SG2042Pkg/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c
@@ -246,8 +246,8 @@ STATIC SMBIOS_TABLE_TYPE7 mSG2042EVBType7_l1i = {
   },
   1,
   0x380,                              // L1 enabled, unknown WB
-  48,                                 // 48k I-cache max
-  48,                                 // 48k installed
+  {48, 0},                            // 48k I-cache max
+  {48, 0},                            // 48k installed
   {0,1},                              // SRAM type
   {0,1},                              // SRAM type
   0,                                  // speed unknown
@@ -255,8 +255,8 @@ STATIC SMBIOS_TABLE_TYPE7 mSG2042EVBType7_l1i = {
   CacheTypeInstruction,               // instruction cache
   CacheAssociativityOther,            // three way
   // SMBIOS 3.1.0 fields
-  48,                                 //48k I-cache max
-  48,                                 //48k installed
+  {48, 0},                            //48k I-cache max
+  {48, 0},                            //48k installed
 };
 
 STATIC SMBIOS_TABLE_TYPE7 mSG2042EVBType7_l1d = {
@@ -267,8 +267,8 @@ STATIC SMBIOS_TABLE_TYPE7 mSG2042EVBType7_l1d = {
   },
   2,
   0x380,                               // L1 enabled, unknown WB
-  32,                                  // 32k D-cache max
-  32,                                  // 32k installed
+  {32, 0},                             // 32k D-cache max
+  {32, 0},                             // 32k installed
   {0,1},                               // SRAM type
   {0,1},                               // SRAM type
   0,                                   // speed unknown
@@ -276,8 +276,8 @@ STATIC SMBIOS_TABLE_TYPE7 mSG2042EVBType7_l1d = {
   CacheTypeData,                       // data cache
   CacheAssociativity2Way,              // two way
   // SMBIOS 3.1.0 fields
-  32,                                  // 32k D-cache max
-  32,                                  // 32k installed
+  {32, 0},                             // 32k D-cache max
+  {32, 0},                             // 32k installed
 };
 
 STATIC SMBIOS_TABLE_TYPE7 mSG2042EVBType7_l2 = {
@@ -288,8 +288,8 @@ STATIC SMBIOS_TABLE_TYPE7 mSG2042EVBType7_l2 = {
   },
   3,
   0x181,                               // L2 enabled, WB
-  512,                                 // 512k D-cache max
-  512,                                 // 512k installed
+  {512, 0},                            // 512k D-cache max
+  {512, 0},                            // 512k installed
   {0,1},                               // SRAM type
   {0,1},                               // SRAM type
   0,                                   // speed unknown
@@ -297,8 +297,8 @@ STATIC SMBIOS_TABLE_TYPE7 mSG2042EVBType7_l2 = {
   CacheTypeUnified,                    // instruction cache
   CacheAssociativity16Way,             // 16 way associative
   // SMBIOS 3.1.0 fields
-  512,                                 // 512k D-cache max
-  512,                                 // 512k installed
+  {512, 0},                            // 512k D-cache max
+  {512, 0},                            // 512k installed
 };
 
 STATIC SMBIOS_TABLE_TYPE7 mSG2042EVBType7_l3 = {
@@ -309,8 +309,8 @@ STATIC SMBIOS_TABLE_TYPE7 mSG2042EVBType7_l3 = {
   },
   4,
   0x182,                               // L3 enabled, WB
-  1024,                                // 1M cache max
-  1024,                                // 1M installed
+  {1024, 0},                           // 1M cache max
+  {1024, 0},                           // 1M installed
   {0,1},                               // SRAM type
   {0,1},                               // SRAM type
   0,                                   // speed unknown
@@ -318,8 +318,8 @@ STATIC SMBIOS_TABLE_TYPE7 mSG2042EVBType7_l3 = {
   CacheTypeUnified,                    // instruction cache
   CacheAssociativity8Way,              // 8 way associative
   // SMBIOS 3.1.0 fields
-  1024,                                // 1M cache max
-  1024,                                // 1M installed
+  {1024, 0},                           // 1M cache max
+  {1024, 0},                           // 1M installed
 };
 
 STATIC CONST CHAR8 *mSG2042EVBType7Strings[] = {


### PR DESCRIPTION
Platform support for DynamicTablesPkg SMBIOS generation, currently in review at https://github.com/tianocore/edk2/pull/11409.

This pull request contains changes for VExpressPkg to use the new generators. It also contains patches for a number of other platforms to use the new SMBIOS structure definitions for cache size and AArch64 CPU ID; I addressed all users I could find.