### PR TITLE
Platform,{ADLINK,ASRockRack,Ampere}: Fix CPU speeds in SMBIOS (OemMiscLib)

### DIFF
--- a/Platform/ADLINK/ComHpcAltPkg/Library/OemMiscLib/OemMiscLib.c
+++ b/Platform/ADLINK/ComHpcAltPkg/Library/OemMiscLib/OemMiscLib.c
@@ -32,6 +32,8 @@
 
 #define SCP_VERSION_STRING_MAX_LENGTH  32
 
+#define MHZ_SCALE_FACTOR  1000000
+
 UINTN  mProcessorIndex = 0xFF;
 
 UINT32
@@ -127,8 +129,8 @@ OemGetProcessorInformation (
   ProcessorCharacteristics->ProcessorReserved2              = 0;
 
   MiscProcessorData->Voltage      = CpuGetVoltage (ProcessorIndex);
-  MiscProcessorData->CurrentSpeed = CpuGetCurrentFreq (ProcessorIndex);
-  MiscProcessorData->MaxSpeed     = CpuGetMaxFreq (ProcessorIndex);
+  MiscProcessorData->CurrentSpeed = CpuGetCurrentFreq (ProcessorIndex) / MHZ_SCALE_FACTOR;
+  MiscProcessorData->MaxSpeed     = CpuGetMaxFreq (ProcessorIndex) / MHZ_SCALE_FACTOR;
   MiscProcessorData->CoreCount    = GetMaximumNumberOfCores ();
   MiscProcessorData->ThreadCount  = GetMaximumNumberOfCores ();
   MiscProcessorData->CoresEnabled = GetNumberOfActiveCoresPerSocket (ProcessorIndex);

--- a/Platform/ASRockRack/AltraBoardPkg/Library/OemMiscLib/OemMiscLib.c
+++ b/Platform/ASRockRack/AltraBoardPkg/Library/OemMiscLib/OemMiscLib.c
@@ -34,6 +34,8 @@
 
 #define SCP_VERSION_STRING_MAX_LENGTH  32
 
+#define MHZ_SCALE_FACTOR  1000000
+
 UINTN  mProcessorIndex = 0xFF;
 
 UINT32
@@ -129,8 +131,8 @@ OemGetProcessorInformation (
   ProcessorCharacteristics->ProcessorReserved2              = 0;
 
   MiscProcessorData->Voltage      = CpuGetVoltage (ProcessorIndex);
-  MiscProcessorData->CurrentSpeed = CpuGetCurrentFreq (ProcessorIndex);
-  MiscProcessorData->MaxSpeed     = CpuGetMaxFreq (ProcessorIndex);
+  MiscProcessorData->CurrentSpeed = CpuGetCurrentFreq (ProcessorIndex) / MHZ_SCALE_FACTOR;
+  MiscProcessorData->MaxSpeed     = CpuGetMaxFreq (ProcessorIndex) / MHZ_SCALE_FACTOR;
   MiscProcessorData->CoreCount    = GetMaximumNumberOfCores ();
   MiscProcessorData->ThreadCount  = GetMaximumNumberOfCores ();
   MiscProcessorData->CoresEnabled = GetNumberOfActiveCoresPerSocket (ProcessorIndex);

--- a/Platform/Ampere/JadePkg/Library/OemMiscLib/OemMiscLib.c
+++ b/Platform/Ampere/JadePkg/Library/OemMiscLib/OemMiscLib.c
@@ -34,6 +34,8 @@
 
 UINTN  mProcessorIndex = 0xFF;
 
+#define MHZ_SCALE_FACTOR 1000000
+
 UINT32
 GetCacheConfig (
   IN UINT32   CacheLevel,
@@ -131,8 +133,8 @@ OemGetProcessorInformation (
   ProcessorCharacteristics->ProcessorReserved2              = 0;
 
   MiscProcessorData->Voltage      = CpuGetVoltage (ProcessorIndex);
-  MiscProcessorData->CurrentSpeed = CpuGetCurrentFreq (ProcessorIndex);
-  MiscProcessorData->MaxSpeed     = CpuGetMaxFreq (ProcessorIndex);
+  MiscProcessorData->CurrentSpeed = CpuGetCurrentFreq (ProcessorIndex) / MHZ_SCALE_FACTOR;
+  MiscProcessorData->MaxSpeed     = CpuGetMaxFreq (ProcessorIndex) / MHZ_SCALE_FACTOR;
   MiscProcessorData->CoreCount    = GetMaximumNumberOfCores ();
   MiscProcessorData->ThreadCount  = GetMaximumNumberOfCores ();
   MiscProcessorData->CoresEnabled = GetNumberOfActiveCoresPerSocket (ProcessorIndex);


### PR DESCRIPTION
The CPU speeds returned by AmpereCpuLib are in Hz. Divide them by 1000000 to get the values to use in the SMBIOS tables, which are in MHz.