### PR TITLE
Platform/{ADLINK,ASRockRack}: Set SMBIOS chassis type to unknown

### DIFF
--- a/Platform/ADLINK/ComHpcAltPkg/Library/OemMiscLib/OemMiscLib.c
+++ b/Platform/ADLINK/ComHpcAltPkg/Library/OemMiscLib/OemMiscLib.c
@@ -235,7 +235,7 @@ OemGetChassisType (
   VOID
   )
 {
-  return MiscChassisTypeRackMountChassis;
+  return MiscChassisTypeUnknown;
 }
 
 /** Returns whether the specified processor is present or not.

--- a/Platform/ASRockRack/AltraBoardPkg/Library/OemMiscLib/OemMiscLib.c
+++ b/Platform/ASRockRack/AltraBoardPkg/Library/OemMiscLib/OemMiscLib.c
@@ -237,7 +237,7 @@ OemGetChassisType (
   VOID
   )
 {
-  return MiscChassisTypeRackMountChassis;
+  return MiscChassisTypeUnknown;
 }
 
 /** Returns whether the specified processor is present or not.


### PR DESCRIPTION
Since the ADLINK Ampere Development Kit and ASRock Rack ALTRAD8 boards aren't full systems, we don't know what type of chassis they'll be installed in. So set the chassis type to unknown.