### PR TITLE
Silicon/Ampere: Enable PCIe resizable BAR support

### DIFF
--- a/Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dsc.inc
+++ b/Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dsc.inc
@@ -463,6 +463,8 @@
   gArmPlatformTokenSpaceGuid.PL011UartClkInHz|1843200
   gArmPlatformTokenSpaceGuid.PL011UartInterrupt|0x62
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPcieResizableBarSupport|TRUE
+
   #
   # PL011 - Serial Debug UART
   # Ampere Altra UART2


### PR DESCRIPTION
Modern graphics cards benefit from being able to negotiate a larger BAR size than they advertise by default. In testing, the Linux amdgpu driver crashed without it enabled. Since I'm not aware of any problems with it, enable it for all Ampere Altra platforms.