### PR TITLE
Silicon/Ampere: Improve SLC cache and ANC strings

### DIFF
--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/CpuConfigDxe/CpuConfigStrings.uni
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/CpuConfigDxe/CpuConfigStrings.uni
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 - 2024, Ampere Computing LLC. All rights reserved.<BR>
+// Copyright (c) 2020 - 2025, Ampere Computing LLC. All rights reserved.<BR>
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -11,12 +11,12 @@
 #string STR_CPU_FORM_SEPERATE_LINE                  #language en-US ""
 
 #string STR_CPU_SUBNUMA_MODE_PROMPT                 #language en-US "ANC mode"
-#string STR_CPU_SUBNUMA_MODE_HELP                   #language en-US "Provides 3 modes: Monolithic, Hemisphere, Quadrant. System with Monolithic mode has single NUMA partition per socket. System with Hemisphere has 2 NUMA partitions per socket. System with Quandrant has 4 NUMA partitions per socket"
+#string STR_CPU_SUBNUMA_MODE_HELP                   #language en-US "Ampere NUMA Control. Provides 3 modes: Monolithic, Hemisphere, Quadrant. System with Monolithic mode has single NUMA partition per socket; Hemisphere has 2 and Quandrant has 4."
 #string STR_CPU_SUBNUMA_MODE_MONOLITHIC             #language en-US "Monolithic"
 #string STR_CPU_SUBNUMA_MODE_HEMISPHERE             #language en-US "Hemisphere"
 #string STR_CPU_SUBNUMA_MODE_QUADRANT               #language en-US "Quadrant"
 
-#string STR_CPU_SLC_AS_L3_PROMPT                    #language en-US "SLC as L3$"
-#string STR_CPU_SLC_AS_L3_HELP                      #language en-US "This option enables / disables PPTT to indicate SLC as L3$. This is limited to only 1P Monolithic mode."
+#string STR_CPU_SLC_AS_L3_PROMPT                    #language en-US "SLC as L3 Cache"
+#string STR_CPU_SLC_AS_L3_HELP                      #language en-US "This option enables/disables PPTT to indicate SLC as L3 Cache. This is limited to only 1P Monolithic mode."
 #string STR_CPU_SLC_AS_L3_ENABLE                    #language en-US "Enabled"
 #string STR_CPU_SLC_AS_L3_DISABLE                   #language en-US "Disabled"

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/PlatformInfoDxe/PlatformInfoStrings.uni
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/PlatformInfoDxe/PlatformInfoStrings.uni
@@ -41,7 +41,7 @@
 #string STR_PLATFORM_INFO_L2CACHE                   #language en-US "L2 Cache"
 #string STR_PLATFORM_INFO_L2CACHE_VALUE             #language en-US "0KB"
 
-#string STR_PLATFORM_INFO_L3CACHE                   #language en-US "SLC as L3 Cache"
+#string STR_PLATFORM_INFO_L3CACHE                   #language en-US "System Level Cache"
 #string STR_PLATFORM_INFO_L3CACHE_VALUE             #language en-US "0KB"
 
 #string STR_PLATFORM_INFO_SOCCLK                    #language en-US "SOC Clock"


### PR DESCRIPTION
Improve some HII strings related to ANC and SLC cache.

Clarify in the help string for ANC mode that 'ANC' means Ampere NUMA Control. And simplify the rest of the string to avoid repetition.

Replace '$' with the word 'Cache'. While '$' might be a common shorthand in the industry, it confuses other people.

In the platform board information page, the help string was wrong: it doesn't indicate SLC as L3 Cache, but simply the amount of System Level Cache.