### PR TITLE
Platform/ARM/VExpressPkg: Enable FPDT on ARM FVP

### DIFF
--- a/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
@@ -248,6 +248,15 @@
 [Components.common]
 
   #
+  # Firmware Performance Data Table (FPDT)
+  #
+  MdeModulePkg/Universal/ReportStatusCodeRouter/RuntimeDxe/ReportStatusCodeRouterRuntimeDxe.inf
+  MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableDxe/FirmwarePerformanceDxe.inf {
+    <LibraryClasses>
+      LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf
+  }
+
+  #
   # PEI Phase modules
   #
 !if $(EDK2_SKIP_PEICORE) == TRUE

--- a/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.fdf
+++ b/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.fdf
@@ -215,6 +215,12 @@ FvNameGuid         = 87940482-fc81-41c3-87e6-399cf85ac8a0
   }
 !endif
 
+  #
+  # Firmware Performance Data Table (FPDT)
+  #
+  INF MdeModulePkg/Universal/ReportStatusCodeRouter/RuntimeDxe/ReportStatusCodeRouterRuntimeDxe.inf
+  INF MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableDxe/FirmwarePerformanceDxe.inf
+
 [FV.FVMAIN_COMPACT]
 FvAlignment        = 16
 ERASE_POLARITY     = 1


### PR DESCRIPTION
Platform/ARM/VExpressPkg: Add FPDT support to Arm FVP

Added compatibility for Firmware Performance Data Table, an ACPI table, to store firmware boot stage timings.

Signed-off-by: Jenna May <jenna.may@arm.com>