### PR TITLE
Platform/Qualcomm/RB3Gen2: Enable booting edk2 at EL2

### DIFF
--- a/Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
+++ b/Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
@@ -100,6 +100,7 @@ DEFINE NETWORK_HTTP_BOOT_ENABLE       = FALSE
   CpuExceptionHandlerLib|ArmPkg/Library/ArmExceptionLib/ArmExceptionLib.inf
   ArmSmcLib|MdePkg/Library/ArmSmcLib/ArmSmcLib.inf
   ArmHvcLib|ArmPkg/Library/ArmHvcLib/ArmHvcLib.inf
+  ArmTransferListLib|ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
   ArmGenericTimerCounterLib|ArmPkg/Library/ArmGenericTimerVirtCounterLib/ArmGenericTimerVirtCounterLib.inf
 
   PlatformPeiLib|ArmPlatformPkg/PlatformPei/PlatformPeiLib.inf

--- a/Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
+++ b/Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
@@ -145,7 +145,7 @@ DEFINE NETWORK_HTTP_BOOT_ENABLE       = FALSE
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
 
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
-  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
+  ArmMmuLib|UefiCpuPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
   TimerLib|ArmPkg/Library/ArmArchTimerLib/ArmArchTimerLib.inf
 
   ArmPlatformLib|Silicon/Qualcomm/KodiakPkg/Library/KodiakLib/KodiakLib.inf

--- a/Silicon/Qualcomm/KodiakPkg/Library/KodiakLib/KodiakHelper.S
+++ b/Silicon/Qualcomm/KodiakPkg/Library/KodiakLib/KodiakHelper.S
@@ -6,8 +6,34 @@
 
 #include <AsmMacroLib.h>
 #include <Library/ArmLib.h>
+#include "KodiakHelper.h"
 
 ASM_FUNC(ArmPlatformPeiBootAction)
-  ret
+// Many Qualcomm targets use Gunyah as a firmware-launched hypervisor, making
+// EL2 unavailable for Non-secure firmware and operating systems, preventing
+// use of alternative hypervisors.
+
+// Quoting Arm Base Boot Requirements here:
+//
+// 6.3.1.1. UEFI boot at EL2
+//   Systems must boot UEFI at EL2, to enable the installation of a hypervisor
+//   or a virtualization-aware operating system.
+
+// So lets use a TZ SMC call supported on these Qcom targets to clean up
+// EL2/Gunyah configuration and transition to booting edk2 (UEFI) at EL2
+// exiting Gunyah. All the SMMU configuration gets cleaned up and handed
+// over in EL2 in bypass mode. The edk2 is able to configure EL2 MMU/SMMU as
+// you would expect on an Arm silicon executing edk2 in EL2.
+
+  EL1_OR_EL2(x0)
+1:ldr   w0, =TZ_EL2_SWITCH_SMC_ID
+  ldr   w1, =TZ_EL2_SWITCH_PARAM_ID
+  mov   w2, wzr
+  mov   w3, wzr
+  ldr   w4, =TZ_EL2_SWITCH_PARAM2_EXIT_GUNYAH
+  smc   #0
+// From this point onwards executing in EL2
+
+2:ret
 
 ASM_FUNCTION_REMOVE_IF_UNREFERENCED

--- a/Silicon/Qualcomm/KodiakPkg/Library/KodiakLib/KodiakHelper.h
+++ b/Silicon/Qualcomm/KodiakPkg/Library/KodiakLib/KodiakHelper.h
@@ -1,0 +1,15 @@
+/** @file
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef KODIAK_HELPER_H_
+#define KODIAK_HELPER_H_
+
+#define TZ_EL2_SWITCH_SMC_ID                0x02000121
+#define TZ_EL2_SWITCH_PARAM_ID              0x00000023
+#define TZ_EL2_SWITCH_PARAM2_EXIT_GUNYAH    0x1
+
+#endif /* KODIAK_HELPER_H_ */


### PR DESCRIPTION
Many Qualcomm targets use Gunyah as a firmware-launched hypervisor, making EL2 unavailable for Non-secure firmware and operating systems, preventing use of alternative hypervisors.

Quoting Arm Base Boot Requirements here:

```
6.3.1.1. UEFI boot at EL2
  Systems must boot UEFI at EL2, to enable the installation of a hypervisor
  or a virtualization-aware operating system.
```

So lets use a TZ SMC call supported on these Qcom targets to clean up EL2/Gunyah configuration and transition to booting edk2 (UEFI) at EL2 exiting Gunyah. All the SMMU configuration gets cleaned up and handed over in EL2 in bypass mode. The edk2 is able to configure EL2 MMU/SMMU as you would expect on an Arm silicon executing edk2 in EL2.

Apart from that there are some build fixes included to follow library paths in upstream edk2.