### PR TITLE
MinPlatformPkg: Remove unnecessary packages

### DIFF
--- a/Platform/Intel/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLibNull.inf
+++ b/Platform/Intel/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLibNull.inf
@@ -22,9 +22,7 @@
   SecBoardInitLib.c
 
 [Packages]
-  MinPlatformPkg/MinPlatformPkg.dec
   MdePkg/MdePkg.dec
-  IntelFsp2Pkg/IntelFsp2Pkg.dec
 
 [LibraryClasses]
   BaseLib


### PR DESCRIPTION
SecBoardInitLibNull does not requires any package except MdePkg.dec

Signed-off-by: PaddyDeng <paddydeng@ami.com>