### PR TITLE
Platform/ARM/VExpressPkg: use UefiDevicePathLibBase.inf in StandaloneMm

### DIFF
--- a/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
+++ b/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
@@ -204,7 +204,7 @@
   Platform/ARM/Drivers/NorFlashDxe/NorFlashStandaloneMm.inf
   MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf {
     <LibraryClasses>
-      DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
+      DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLibBase.inf
       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
       NULL|MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLibStandaloneMm.inf
       BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf


### PR DESCRIPTION
edk2 commit 066275413411 ("MdePkg/Library: Remove MM_STANDALONE LibraryClass in UefiDevicePathLib.inf") remove supports UefiDevicePathLib.inf in StandaloneMm but make it use UefiDevicePathLibBase.inf in MdePkg.

Change the UefiDevicePathLib as UefiDevicePathLibBase.inf to fix build failure.