### PR TITLE
Platform/Qualcomm/RB3Gen2: Add UFS driver and DTB support

### DIFF
--- a/Platform/Qualcomm/RB3Gen2/DeviceTree/Dummy.dts
+++ b/Platform/Qualcomm/RB3Gen2/DeviceTree/Dummy.dts
@@ -1,0 +1,17 @@
+/*  @file
+ *
+ *  Empty dts file that's only used as an example to build a RB3Gen2 platform.
+ *  User can override this with USER_PROVIDED_DTB=true option.
+ *
+ *  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
+ *
+ *  SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ */
+
+/dts-v1/;
+
+/ {
+    model = "Qualcomm Technologies, Inc. Robotics RB3gen2";
+    compatible = "qcom,qcs6490-rb3gen2", "qcom,qcm6490";
+};

--- a/Platform/Qualcomm/RB3Gen2/DeviceTree/DummyDeviceTree.inf
+++ b/Platform/Qualcomm/RB3Gen2/DeviceTree/DummyDeviceTree.inf
@@ -1,0 +1,21 @@
+#/** @file
+#    DummyDeviceTree.inf
+#
+#    Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
+#
+#    SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 1.30
+  BASE_NAME                      = DummyDeviceTree
+  FILE_GUID                      = 25462CDA-221F-47DF-AC1D-259CFAA4E326 # Same value for gDtPlatformDefaultDtbFileGuid
+  MODULE_TYPE                    = USER_DEFINED
+  VERSION_STRING                 = 1.0
+
+[Sources]
+  Dummy.dts
+
+[Packages]
+  MdePkg/MdePkg.dec

--- a/Platform/Qualcomm/RB3Gen2/DeviceTree/UserDTB.inf
+++ b/Platform/Qualcomm/RB3Gen2/DeviceTree/UserDTB.inf
@@ -1,0 +1,18 @@
+#/** @file
+#    UserDTB.inf
+#
+#    Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
+#
+#    SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 1.30
+  BASE_NAME                      = UserDTB
+  FILE_GUID                      = 25462CDA-221F-47DF-AC1D-259CFAA4E326 # Same value for gDtPlatformDefaultDtbFileGuid
+  MODULE_TYPE                    = USER_DEFINED
+  VERSION_STRING                 = 1.0
+
+[Binaries]
+  BIN|qcs6490-rb3gen2.dtb

--- a/Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
+++ b/Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
@@ -102,6 +102,7 @@ DEFINE NETWORK_HTTP_BOOT_ENABLE       = FALSE
   ArmHvcLib|ArmPkg/Library/ArmHvcLib/ArmHvcLib.inf
   ArmTransferListLib|ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
   ArmGenericTimerCounterLib|ArmPkg/Library/ArmGenericTimerVirtCounterLib/ArmGenericTimerVirtCounterLib.inf
+  DmaLib|EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.inf
 
   PlatformPeiLib|ArmPlatformPkg/PlatformPei/PlatformPeiLib.inf
   MemoryInitPeiLib|ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
@@ -365,6 +366,10 @@ DEFINE NETWORK_HTTP_BOOT_ENABLE       = FALSE
   # Qcom GENI - Serial Terminal
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x994000
 
+  # Ufs
+  gQcomPlatformTokenSpaceGuid.PcdQcomUfsHcDxeBaseAddress|0x1D84000
+  gQcomPlatformTokenSpaceGuid.PcdQcomUfsHcDxeSize|0x3000
+
   gArmTokenSpaceGuid.PcdSystemProductName|L"Qualcomm Dragonwing RB3 Gen 2"
   gArmTokenSpaceGuid.PcdSystemVersion|L"1.0"
   gArmTokenSpaceGuid.PcdBaseBoardManufacturer|L"Thundercomm"
@@ -547,6 +552,20 @@ DEFINE NETWORK_HTTP_BOOT_ENABLE       = FALSE
       NULL|MdeModulePkg/Library/BootManagerUiLib/BootManagerUiLib.inf
       NULL|MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenanceManagerUiLib.inf
   }
+
+  #
+  # Generic non-discoverable pcie used for many soc devices
+  #
+  MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
+
+  #
+  # Ufs
+  #
+  Silicon/Qualcomm/Drivers/QcomUfsHcDxe/QcomUfsHcDxe.inf
+  MdeModulePkg/Bus/Pci/UfsPciHcDxe/UfsPciHcDxe.inf
+  MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruDxe.inf
+  MdeModulePkg/Bus/Scsi/ScsiBusDxe/ScsiBusDxe.inf
+  MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDiskDxe.inf
 
   #
   # SMBIOS support

--- a/Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
+++ b/Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
@@ -26,6 +26,7 @@
   #
 
   DEFINE DEBUG_PRINT_ERROR_LEVEL = 0x8000004F
+  DEFINE USER_PROVIDED_DTB       = FALSE
 
 #
 # Network definition
@@ -551,6 +552,17 @@ DEFINE NETWORK_HTTP_BOOT_ENABLE       = FALSE
       NULL|MdeModulePkg/Library/DeviceManagerUiLib/DeviceManagerUiLib.inf
       NULL|MdeModulePkg/Library/BootManagerUiLib/BootManagerUiLib.inf
       NULL|MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenanceManagerUiLib.inf
+  }
+
+  #
+  # DTB support
+  #
+!if $(USER_PROVIDED_DTB) == FALSE
+  Platform/Qualcomm/RB3Gen2/DeviceTree/DummyDeviceTree.inf
+!endif
+  EmbeddedPkg/Drivers/DtPlatformDxe/DtPlatformDxe.inf {
+    <LibraryClasses>
+      DtPlatformDtbLoaderLib|EmbeddedPkg/Library/DxeDtPlatformDtbLoaderLibDefault/DxeDtPlatformDtbLoaderLibDefault.inf
   }
 
   #

--- a/Platform/Qualcomm/RB3Gen2/RB3Gen2.fdf
+++ b/Platform/Qualcomm/RB3Gen2/RB3Gen2.fdf
@@ -134,6 +134,20 @@ READ_LOCK_STATUS   = TRUE
   INF MdeModulePkg/Application/UiApp/UiApp.inf
 
   #
+  # Generic non-discoverable pcie used for many soc devices
+  #
+  INF MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
+
+  #
+  # Ufs
+  #
+  INF Silicon/Qualcomm/Drivers/QcomUfsHcDxe/QcomUfsHcDxe.inf
+  INF MdeModulePkg/Bus/Pci/UfsPciHcDxe/UfsPciHcDxe.inf
+  INF MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruDxe.inf
+  INF MdeModulePkg/Bus/Scsi/ScsiBusDxe/ScsiBusDxe.inf
+  INF MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDiskDxe.inf
+
+  #
   # SMBIOS support
   #
   INF ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassDxe.inf

--- a/Platform/Qualcomm/RB3Gen2/RB3Gen2.fdf
+++ b/Platform/Qualcomm/RB3Gen2/RB3Gen2.fdf
@@ -134,6 +134,16 @@ READ_LOCK_STATUS   = TRUE
   INF MdeModulePkg/Application/UiApp/UiApp.inf
 
   #
+  # DTB support
+  #
+!if $(USER_PROVIDED_DTB) == TRUE
+  INF RuleOverride = DTB Platform/Qualcomm/RB3Gen2/DeviceTree/UserDTB.inf
+!else
+  INF RuleOverride = DTB Platform/Qualcomm/RB3Gen2/DeviceTree/DummyDeviceTree.inf
+!endif
+  INF EmbeddedPkg/Drivers/DtPlatformDxe/DtPlatformDxe.inf
+
+  #
   # Generic non-discoverable pcie used for many soc devices
   #
   INF MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
@@ -196,3 +206,8 @@ READ_LOCK_STATUS   = TRUE
   }
 
 !include ArmVirtPkg/ArmVirtRules.fdf.inc
+
+[Rule.Common.USER_DEFINED.DTB]
+  FILE FREEFORM = $(NAMED_GUID) {
+    RAW BIN                |.dtb
+  }

--- a/Platform/Qualcomm/RB3Gen2/Readme.md
+++ b/Platform/Qualcomm/RB3Gen2/Readme.md
@@ -43,10 +43,17 @@ provide their own packaged cross-toolchains.
    $ cd edk2-platforms && git submodule update --init && cd $WORKSPACE
    ```
 
-3. Set up a **PACKAGES_PATH** to point to the locations of these three
+3. Provide devicetree blob (DTB) corresponding to the Qualcomm target like for
+   RB3Gen2:
+   ```
+   $ mkdir -p devicetree
+   $ cp <kernel-build-path-to-dtb>/qcs6490-rb3gen2.dtb devicetree/
+   ```
+
+4. Set up a **PACKAGES_PATH** to point to the locations of these three
    repositories:
 
-   `$ export PACKAGES_PATH=$PWD/edk2:$PWD/edk2-platforms`
+   `$ export PACKAGES_PATH=$PWD/edk2:$PWD/edk2-platforms:$PWD/devicetree`
 
 ## Manual building
 
@@ -61,6 +68,15 @@ provide their own packaged cross-toolchains.
    `make -C edk2/BaseTools`
 
 ### Build for RB3Gen2 platform
+
+Build with user provided DTB:
+
+```
+$ build -b RELEASE -a AARCH64 -t GCC -D USER_PROVIDED_DTB=true -p Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
+```
+
+Or build with dummy DTB just for test purpose:
+
 ```
 $ build -b RELEASE -a AARCH64 -t GCC -p Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
 ```

--- a/Silicon/Qualcomm/Drivers/QcomUfsHcDxe/QcomUfsHcDxe.c
+++ b/Silicon/Qualcomm/Drivers/QcomUfsHcDxe/QcomUfsHcDxe.c
@@ -1,0 +1,75 @@
+/** @file
+  Qcom UFS HC DXE driver
+
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/DebugLib.h>
+#include <Library/NonDiscoverableDeviceRegistrationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Protocol/UfsHostControllerPlatform.h>
+
+//
+// Ufs Host Controller Platform Protocol Instance
+//
+// Note here that it is assumed that the prior stage XBL has already
+// initialized the UFS controller.
+//
+EDKII_UFS_HC_PLATFORM_PROTOCOL gQcomUfsHc = {
+    EDKII_UFS_HC_PLATFORM_PROTOCOL_VERSION,
+    NULL,
+    NULL,
+    EdkiiUfsCardRefClkFreqObsolete,
+    TRUE,
+    TRUE
+};
+
+/**
+  The Entry Point of module. It follows the standard UEFI driver model.
+
+  @param[in] ImageHandle       The firmware allocated handle for the EFI image.
+  @param[in] SystemTable       A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS          The entry point is executed successfully.
+  @retval Other                Some error occurs when executing this entry point
+
+**/
+EFI_STATUS
+EFIAPI
+QcomUfsHcDriverEntry (
+  IN EFI_HANDLE            ImageHandle,
+  IN EFI_SYSTEM_TABLE      *SystemTable
+  )
+{
+  EFI_STATUS               Status;
+
+  Status = gBS->InstallProtocolInterface (
+             &ImageHandle,
+             &gEdkiiUfsHcPlatformProtocolGuid,
+             EFI_NATIVE_INTERFACE,
+             &gQcomUfsHc
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed to install UFS platform protocol, error: %r \n",
+      Status));
+    return Status;
+  }
+
+  Status = RegisterNonDiscoverableMmioDevice (
+             NonDiscoverableDeviceTypeUfs,
+             NonDiscoverableDeviceDmaTypeNonCoherent,
+             NULL,
+             NULL,
+             1,
+             PcdGet32 (PcdQcomUfsHcDxeBaseAddress),
+             PcdGet32 (PcdQcomUfsHcDxeSize)
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed to register UFS device, error: %r \n", Status));
+  }
+
+  return Status;
+}

--- a/Silicon/Qualcomm/Drivers/QcomUfsHcDxe/QcomUfsHcDxe.inf
+++ b/Silicon/Qualcomm/Drivers/QcomUfsHcDxe/QcomUfsHcDxe.inf
@@ -1,0 +1,40 @@
+#/** @file
+# Qcom UFS HC platform DXE driver
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 1.30
+  BASE_NAME                      = QcomUfsHcDxe
+  FILE_GUID                      = 9be976cc-5deb-4ea4-91f1-decdef6f492b
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = QcomUfsHcDriverEntry
+
+[Sources]
+  QcomUfsHcDxe.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  Silicon/Qualcomm/QcomPlatformPkg/QcomPlatformPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  NonDiscoverableDeviceRegistrationLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+
+[Protocols]
+  gEdkiiUfsHcPlatformProtocolGuid
+
+[Pcd]
+  gQcomPlatformTokenSpaceGuid.PcdQcomUfsHcDxeBaseAddress
+  gQcomPlatformTokenSpaceGuid.PcdQcomUfsHcDxeSize
+
+[Depex]
+  TRUE

--- a/Silicon/Qualcomm/QcomPlatformPkg/QcomPlatformPkg.dec
+++ b/Silicon/Qualcomm/QcomPlatformPkg/QcomPlatformPkg.dec
@@ -1,0 +1,20 @@
+#/** @file
+#
+#  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  DEC_SPECIFICATION              = 0x00010019
+  PACKAGE_NAME                   = QcomPlatformPkg
+  PACKAGE_GUID                   = 1201b766-3423-498a-8f73-dcadb1672200
+  PACKAGE_VERSION                = 0.1
+
+[Guids.common]
+  gQcomPlatformTokenSpaceGuid      = { 0x512a66e6, 0x74c6, 0x4a5a,  { 0xad, 0x01, 0x49, 0x2c, 0x5f, 0x3b, 0xab, 0x3b }}
+
+[PcdsFixedAtBuild.common]
+  gQcomPlatformTokenSpaceGuid.PcdQcomUfsHcDxeBaseAddress|0x0|UINT32|0x00000001
+  gQcomPlatformTokenSpaceGuid.PcdQcomUfsHcDxeSize|0x0|UINT32|0x00000002


### PR DESCRIPTION
Add support for UFS driver on RB3Gen2 platform. This driver is registered as non-discoverable device over PCIe I/O protocol supported by UFS pass through host controller driver framework.

This UFS driver assumes that the prior stage XBL on Qcom SoCs has fully initialized the UFS controller where the primary boot medium is UFS flash on Qcom SoCs. Given that the initialization is skipped here and only the UFS controller MMIO address space is registered for UFS I/O to take place.

With UFS storage driver in place, we are able to load the EFI payload on RB3Gen2 platform, following are the logs:
```
EFI stub: EFI_RNG_PROTOCOL unavailable
EFI stub: Loaded initrd from LINUX_EFI_INITRD_MEDIA_GUID device path
EFI stub: Generating empty DTB
EFI stub: Exiting boot services...
```
The next step is to add support for DTB loading which will allow to boot a Linux distro with kernel starting in EL2 mode.