### PR TITLE
MinPlatformPkg: Fix build failure of undefined PCD.

### DIFF
--- a/Platform/Intel/MinPlatformPkg/Include/Dsc/MinPlatformFeaturesPcd.dsc.inc
+++ b/Platform/Intel/MinPlatformPkg/Include/Dsc/MinPlatformFeaturesPcd.dsc.inc
@@ -25,3 +25,6 @@
  gMinPlatformPkgTokenSpaceGuid.PcdPerformanceEnable             |FALSE
 
  gMinPlatformPkgTokenSpaceGuid.PcdStandaloneMmEnable            |FALSE
+
+[PcdsFixedAtBuild]
+ gMinPlatformPkgTokenSpaceGuid.PcdFspWrapperBootMode            |FALSE


### PR DESCRIPTION
Some builds failed with below error:
PcdFspWrapperBootMode is not defined in DSC file.

Fixing this issue by defining this PCD in MinPlatform common include DSC file.