### PR TITLE
MinPlatformPkg: Fix SecBoardInitLibNull build failure.

### DIFF
--- a/Platform/Intel/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLib.c
+++ b/Platform/Intel/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLib.c
@@ -6,7 +6,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include <PiDxe.h>
-#include <Library/BoardInitLib.h>
 #include <Library/PcdLib.h>
 
 EFI_STATUS


### PR DESCRIPTION
NULL library should not need to include BoardInitLib.h which requires MinPlatformPkg.dec in INF