### PR TITLE
Ampere/ASRockRack: handle move of RealTimeClockLib.h

### DIFF
--- a/Platform/ASRockRack/AltraBoardPkg/Library/ISL1208RealTimeClockLib/ISL1208RealTimeClockLib.inf
+++ b/Platform/ASRockRack/AltraBoardPkg/Library/ISL1208RealTimeClockLib/ISL1208RealTimeClockLib.inf
@@ -23,6 +23,7 @@
   ArmPkg/ArmPkg.dec
   ArmPlatformPkg/ArmPlatformPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
   Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dec
   Silicon/Ampere/AmpereSiliconPkg/AmpereSiliconPkg.dec


### PR DESCRIPTION
RealTimeClockLib.h moved from EmbeddedPkg to MdeModulePkg some time ago.