### PR TITLE
Platform/ARM/JunoPkg: fix Juno build failure

### DIFF
--- a/Platform/ARM/JunoPkg/ArmJuno.dsc
+++ b/Platform/ARM/JunoPkg/ArmJuno.dsc
@@ -45,7 +45,6 @@
 !endif
 
 [LibraryClasses.common]
-  ArmFfaLib|ArmPkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
   ArmMmuLib|UefiCpuPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
   ArmPlatformLib|Platform/ARM/JunoPkg/Library/ArmJunoLib/ArmJunoLib.inf

--- a/Platform/ARM/JunoPkg/PlatformStandaloneMm.dsc
+++ b/Platform/ARM/JunoPkg/PlatformStandaloneMm.dsc
@@ -43,6 +43,7 @@
 !if $(ENABLE_UEFI_SECURE_VARIABLE) == TRUE
   NorFlashDeviceLib|Platform/ARM/Library/P30NorFlashDeviceLib/P30NorFlashDeviceLib.inf
   NorFlashPlatformLib|Platform/ARM/JunoPkg/Library/NorFlashJunoLib/NorFlashJunoStMmLib.inf
+!endif
 
 ################################################################################
 #


### PR DESCRIPTION
Fix build failure of JunoPkg:

  - ArmFfaLib is located from ArmPkg to MdeModulePkg and it was included in ArmVExpress.dsc.inc file So remove it.

  - While integrating the PlatformStandaloneMm.dsc.inc, there was a mistaken for missing !endif