### PR TITLE
OutOfBandManagement/IpmiFeaturePkg: Add missing EFIAPI

### DIFF
--- a/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/Library/IpmiBaseLib/IpmiBaseLib.c
+++ b/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/Library/IpmiBaseLib/IpmiBaseLib.c
@@ -25,6 +25,7 @@ EFI_EVENT                 mEfiIpmiProtocolEvent;
 
 **/
 EFI_STATUS
+EFIAPI
 NotifyIpmiTransportCallback (
   IN EFI_EVENT Event,
   IN VOID      *Context

--- a/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/Library/SmmIpmiBaseLib/SmmIpmiBaseLib.c
+++ b/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/Library/SmmIpmiBaseLib/SmmIpmiBaseLib.c
@@ -27,6 +27,7 @@ EFI_EVENT                 mEfiIpmiProtocolEvent;
 
 **/
 EFI_STATUS
+EFIAPI
 NotifyIpmiTransportCallback (
   IN CONST EFI_GUID                *Protocol,
   IN VOID                          *Interface,


### PR DESCRIPTION
Add missing EFIAPI in implementation of UEFI event notification functions.