### PR TITLE
OutOfBandManagement/IpmiFeaturePkg: Add missing EFIAPI

### DIFF
--- a/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c
+++ b/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c
@@ -470,6 +470,7 @@ SendPreBootSignaltoBmc (
   @retval EFI_SUCCESS   Indicates that Ipmi initialization completed successfully.
 **/
 EFI_STATUS
+EFIAPI
 PeimIpmiInterfaceInit (
   IN       EFI_PEI_FILE_HANDLE  FileHandle,
   IN CONST EFI_PEI_SERVICES     **PeiServices
@@ -492,6 +493,7 @@ PeimIpmiInterfaceInit (
 } // PeimIpmiInterfaceInit()
 
 EFI_STATUS
+EFIAPI
 PeiGetIpmiBmcStatus (
   IN      PEI_IPMI_TRANSPORT_PPI  *This,
   OUT BMC_STATUS                  *BmcStatus,

--- a/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.h
+++ b/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.h
@@ -60,6 +60,7 @@ EFI_SUCCESS           - Success
 ;
 
 EFI_STATUS
+EFIAPI
 PeiIpmiSendCommand (
   IN      PEI_IPMI_TRANSPORT_PPI  *This,
   IN      UINT8                   NetFunction,
@@ -96,6 +97,7 @@ Returns:
 ;
 
 EFI_STATUS
+EFIAPI
 PeiGetIpmiBmcStatus (
   IN  PEI_IPMI_TRANSPORT_PPI  *This,
   OUT BMC_STATUS              *BmcStatus,

--- a/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiIpmiHooks.c
+++ b/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiIpmiHooks.c
@@ -11,6 +11,7 @@
 #include <PeiIpmiHooks.h>
 
 EFI_STATUS
+EFIAPI
 PeiIpmiSendCommand (
   IN      PEI_IPMI_TRANSPORT_PPI  *This,
   IN      UINT8                   NetFunction,
@@ -71,6 +72,7 @@ Returns:
 } // IpmiSendCommand()
 
 EFI_STATUS
+EFIAPI
 PeiIpmiSendCommand2 (
   IN      IPMI_TRANSPORT2  *This,
   IN      UINT8            NetFunction,
@@ -189,6 +191,7 @@ Returns:
 } // IpmiSendCommand()
 
 EFI_STATUS
+EFIAPI
 PeiIpmiSendCommand2Ex (
   IN      IPMI_TRANSPORT2        *This,
   IN      UINT8                  NetFunction,

--- a/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiIpmiHooks.h
+++ b/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiIpmiHooks.h
@@ -23,6 +23,7 @@
 //
 
 EFI_STATUS
+EFIAPI
 PeiIpmiSendCommand (
   IN      PEI_IPMI_TRANSPORT_PPI  *This,
   IN      UINT8                   NetFunction,
@@ -64,6 +65,7 @@ Returns:
 ;
 
 EFI_STATUS
+EFIAPI
 PeiIpmiSendCommand2 (
   IN      IPMI_TRANSPORT2  *This,
   IN      UINT8            NetFunction,
@@ -105,6 +107,7 @@ Returns:
 ;
 
 EFI_STATUS
+EFIAPI
 PeiIpmiSendCommand2Ex (
   IN      IPMI_TRANSPORT2        *This,
   IN      UINT8                  NetFunction,


### PR DESCRIPTION
Add missing EFIAPI to MMBI IPMI infrastructure functions to bypass GCC build errors.

# GCC ERRORS
 from incompatible pointer type ‘EFI_STATUS (*)(PEI_IPMI_TRANSPORT_PPI *, BMC_STATUS *, SM_COM_ADDRESS *)’ {aka ‘long long unsigned int (*)(struct _PEI_IPMI_TRANSPORT_PPI *, unsigned int *, SM_COM_ADDRESS *)’} [-Werror=incompatible-pointer-types]
  323 |   mIpmiInstance->IpmiTransportPpi.GetBmcStatus      = **PeiGetIpmiBmcStatus**;
      |                                                     ^
/home/Edk2Platforms/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c: At top level:
/home/Edk2Platforms/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c:473:1: error: conflicting types for ‘PeimIpmiInterfaceInit’; have ‘EFI_STATUS(void *, const EFI_PEI_SERVICES **)’ {aka ‘long long unsigned int(void *, const struct _EFI_PEI_SERVICES **)’}
  473 | **PeimIpmiInterfaceInit** (
      | ^~~~~~~~~~~~~~~~~~~~~
In file included from <command-line>:
/home/Intel/Build/DEBUG_GCC/X64/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi/DEBUG/AutoGen.h:183:1: note: previous declaration of ‘**PeimIpmiInterfaceInit**’ with type ‘EFI_STATUS(void *, const EFI_PEI_SERVICES **)’ {aka ‘long long unsigned int(void *, const struct _EFI_PEI_SERVICES **)’}
  183 | PeimIpmiInterfaceInit 


KcsPhysicalLayer’:
/home//Edk2Platforms/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c:322:53: error: assignment to ‘PEI_IPMI_SEND_COMMAND’ {aka ‘long long unsigned int (__attribute__((ms_abi)) *)(struct _PEI_IPMI_TRANSPORT_PPI *, unsigned char,  unsigned char,  unsigned char,  unsigned char *, unsigned int,  unsigned char *, unsigned int *)’} from incompatible pointer type ‘EFI_STATUS (*)(PEI_IPMI_TRANSPORT_PPI *, UINT8,  UINT8,  UINT8,  UINT8 *, UINT32,  UINT8 *, UINT32 *)’ {aka ‘long long unsigned int (*)(struct _PEI_IPMI_TRANSPORT_PPI *, unsigned char,  unsigned char,  unsigned char,  unsigned char *, unsigned int,  unsigned char *, unsigned int *)’} [-Werror=incompatible-pointer-types]
  322 |   mIpmiInstance->IpmiTransportPpi.IpmiSubmitCommand = **PeiIpmiSendCommand**;
      |                                                     ^
/home//Edk2Platforms/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c:323:53: error: assignment to ‘PEI_IPMI_GET_CHANNEL_STATUS’ {aka ‘long long unsigned int (__attribute__((ms_abi)) *)(struct _PEI_IPMI_TRANSPORT_PPI *, unsigned int *, SM_COM_ADDRESS *)’} from incompatible pointer type ‘EFI_STATUS (*)(PEI_IPMI_TRANSPORT_PPI *, BMC_STATUS *, SM_COM_ADDRESS *)’ {aka ‘long long unsigned int (*)(struct _PEI_IPMI_TRANSPORT_PPI *, unsigned int *, SM_COM_ADDRESS *)’} [-Werror=incompatible-pointer-types]
  323 |   mIpmiInstance->IpmiTransportPpi.GetBmcStatus      = **PeiGetIpmiBmcStatus**;
      |                                                     ^
cc1: all warnings being treated as errors


/home/Edk2Platforms/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c:215:52: error: assignment to ‘PEI_IPMI_SEND_COMMAND’ {aka ‘long long unsigned int (__attribute__((ms_abi)) *)(struct _PEI_IPMI_TRANSPORT_PPI *, unsigned char,  unsigned char,  unsigned char,  unsigned char *, unsigned int,  unsigned char *, unsigned int *)’} from incompatible pointer type ‘EFI_STATUS (*)(PEI_IPMI_TRANSPORT_PPI *, UINT8,  UINT8,  UINT8,  UINT8 *, UINT32,  UINT8 *, UINT32 *)’ {aka ‘long long unsigned int (*)(struct _PEI_IPMI_TRANSPORT_PPI *, unsigned char,  unsigned char,  unsigned char,  unsigned char *, unsigned int,  unsigned char *, unsigned int *)’} [-Werror=incompatible-pointer-types]
  215 |   IpmiInstance->IpmiTransportPpi.IpmiSubmitCommand = **PeiIpmiSendCommand**;
      |                                                    ^
/home/Edk2Platforms/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c: In function ‘PeiInitializeIpmiKcsPhysicalLayer’:
/home/Edk2Platforms/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c:322:53: error: assignment to ‘PEI_IPMI_SEND_COMMAND’ {aka ‘long long unsigned int (__attribute__((ms_abi)) *)(struct _PEI_IPMI_TRANSPORT_PPI *, unsigned char,  unsigned char,  unsigned char,  unsigned char *, unsigned int,  unsigned char *, unsigned int *)’} from incompatible pointer type ‘EFI_STATUS (*)(PEI_IPMI_TRANSPORT_PPI *, UINT8,  UINT8,  UINT8,  UINT8 *, UINT32,  UINT8 *, UINT32 *)’ {aka ‘long long unsigned int (*)(struct _PEI_IPMI_TRANSPORT_PPI *, unsigned char,  unsigned char,  unsigned char,  unsigned char *, unsigned int,  unsigned char *, unsigned int *)’} [-Werror=incompatible-pointer-types]
  322 |   mIpmiInstance->IpmiTransportPpi.IpmiSubmitCommand = **PeiIpmiSendCommand**;
      |                                                     ^
cc1: all warnings being treated as errors

/home/Edk2Platforms/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c:40:59: error: assignment to ‘IPMI_SEND_COMMAND2’ {aka ‘long long unsigned int (__attribute__((ms_abi)) *)(struct _IPMI_TRANSPORT2 *, unsigned char,  unsigned char,  unsigned char,  unsigned char *, unsigned int,  unsigned char *, unsigned int *)’} from incompatible pointer type ‘EFI_STATUS (*)(IPMI_TRANSPORT2 *, UINT8,  UINT8,  UINT8,  UINT8 *, UINT32,  UINT8 *, UINT32 *)’ {aka ‘long long unsigned int (*)(struct _IPMI_TRANSPORT2 *, unsigned char,  unsigned char,  unsigned char,  unsigned char *, unsigned int,  unsigned char *, unsigned int *)’} [-Werror=incompatible-pointer-types]
   40 |   IpmiInstance->IpmiTransport2Ppi.IpmiSubmitCommand2      = **PeiIpmiSendCommand2**;
      |                                                           ^
/home/Edk2Platforms/Features/Intel/OutOfBandManagement/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c:41:59: error: assignment to ‘IPMI_SEND_COMMAND2Ex’ {aka ‘long long unsigned int (__attribute__((ms_abi)) *)(struct _IPMI_TRANSPORT2 *, unsigned char,  unsigned char,  unsigned char,  unsigned char *, unsigned int,  unsigned char *, unsigned int *, SYSTEM_INTERFACE_TYPE)’} from incompatible pointer type ‘EFI_STATUS (*)(IPMI_TRANSPORT2 *, UINT8,  UINT8,  UINT8,  UINT8 *, UINT32,  UINT8 *, UINT32 *, SYSTEM_INTERFACE_TYPE)’ {aka ‘long long ufnsigned int (*)(struct _IPMI_TRANSPORT2 *, unsigned char,  unsigned char,  unsigned char,  unsigned char *, unsigned int,  unsigned char *, unsigned int *, SYSTEM_INTERFACE_TYPE)’} [-Werror=incompatible-pointer-types]
   41 |   IpmiInstance->IpmiTransport2Ppi.IpmiSubmitCommand2Ex    = **PeiIpmiSendCommand2Ex**;


