### PR TITLE
Platform/ASRockRack/AltraBoardPkg: fix SMBIOS cache size 2 type

### DIFF
--- a/Platform/ASRockRack/AltraBoardPkg/Library/OemMiscLib/OemMiscLib.c
+++ b/Platform/ASRockRack/AltraBoardPkg/Library/OemMiscLib/OemMiscLib.c
@@ -161,7 +161,7 @@ OemGetCacheInformation (
   )
 {
   SMBIOS_CACHE_SIZE   CacheSize16;
-  SMBIOS_CACHE_SIZE2  CacheSize32;
+  SMBIOS_CACHE_SIZE_2 CacheSize32;
   UINT64              CacheSize64;
   UINT8               Granularity32;
 


### PR DESCRIPTION
Resolves this build failure:
```
edk2-altrad8ud-1l2t> rm -f /build/edk2-workspace/Build/Altra1L2T/RELEASE_GCC5/AARCH64/MdeModulePkg/Library/BaseSortLib/BaseSortLib/OUTPUT/BaseSortLib.lib
edk2-altrad8ud-1l2t> /build/edk2-workspace/edk2-platforms/Platform/ASRockRack/AltraBoardPkg/Library/OemMiscLib/OemMiscLib.c: In function ‘OemGetCacheInformation’:
edk2-altrad8ud-1l2t> /build/edk2-workspace/edk2-platforms/Platform/ASRockRack/AltraBoardPkg/Library/OemMiscLib/OemMiscLib.c:164:3: error: unknown type name ‘SMBIOS_CACHE_SIZE2’; did you mean ‘SMBIOS_CACHE_SIZE_2’?
edk2-altrad8ud-1l2t>   164 |   SMBIOS_CACHE_SIZE2  CacheSize32;
edk2-altrad8ud-1l2t>       |   ^~~~~~~~~~~~~~~~~~
edk2-altrad8ud-1l2t>       |   SMBIOS_CACHE_SIZE_2
```