### PR TITLE
Platform/ASRockRack: Fix cache size value

### DIFF
--- a/Platform/ASRockRack/AltraBoardPkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheData.c
+++ b/Platform/ASRockRack/AltraBoardPkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheData.c
@@ -22,8 +22,8 @@ SMBIOS_PLATFORM_DXE_TABLE_DATA (SMBIOS_TABLE_TYPE7, PlatformCache) = {
     },
     ADDITIONAL_STR_INDEX_1,                 // Socket Designation
     0x182,                                  // Write Back, Enabled, Internal, Not Socketed, Cache Level 3
-    {0x8010, 1},                            // Maximum Cache Size: 1M
-    {0x8010, 1},                            // Installed Size: 1M
+    {0x0010, 1},                            // Maximum Cache Size: 1M
+    {0x0010, 1},                            // Installed Size: 1M
     { 0, 0, 0, 0, 0, 1},                    // Supported SRAM Type: Synchronous
     { 0, 0, 0, 0, 0, 1},                    // Current SRAM Type: Synchronous
     0,                                      // Cache Speed


### PR DESCRIPTION
Fix the cache size value in the SMBIOS Type 7 table. The first value is the 15-bit size, not the complete 16-bit value including the granularity.