### PR TITLE
Features/Intel: Failed to check return status

### DIFF
--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/KeyService.c
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/KeyService.c
@@ -78,8 +78,12 @@ KeyLibGenerateSalt (
   if (SaltValue == NULL) {
     return FALSE;
   }
-  RandomSeed(NULL, 0);
-  RandomBytes(SaltValue, SaltSize);
+  if (!RandomSeed (NULL, 0)) {
+    return FALSE;
+  }
+  if (!RandomBytes(SaltValue, SaltSize)) {
+    return FALSE;
+  }
   return TRUE;
 }
 

--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.c
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.c
@@ -221,12 +221,16 @@ SavePasswordToVariable (
   EFI_STATUS                        Status;
   USER_PASSWORD_VAR_STRUCT          UserPasswordVarStruct;
   BOOLEAN                           HashOk;
+  BOOLEAN                           SaltGenerated;
 
   //
   // If password is NULL, it means we want to clean password field saved in variable region.
   //
   if (Password != NULL) {
-    KeyLibGenerateSalt (UserPasswordVarStruct.PasswordSalt, sizeof(UserPasswordVarStruct.PasswordSalt));
+    SaltGenerated = KeyLibGenerateSalt (UserPasswordVarStruct.PasswordSalt, sizeof(UserPasswordVarStruct.PasswordSalt));
+    if (!SaltGenerated) {
+      return EFI_OUT_OF_RESOURCES;
+    }
     HashOk = KeyLibGeneratePBKDF2Hash (
                HASH_TYPE_SHA256,
                (UINT8 *)Password,


### PR DESCRIPTION
KeyLibGenerateSalt function fails to check the return values of RandomSeed and RandomBytes function calls. Also SavePasswordToVariable fails to check return value from KeyLibGenerateSalt. Added error handling code to check the return values of RandomSeed, RandomBytes functions and KeyLibGenerateSalt in SavePasswordToVariable.