### PR TITLE
Features/Intel: Use RngLib to get Random number.

### DIFF
--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/KeyService.c
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/KeyService.c
@@ -11,6 +11,7 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/BaseCryptLib.h>
 #include "KeyService.h"
+#include <Library/RngLib.h>
 
 /**
   Compares the contents of two buffers with slow algorithm
@@ -75,10 +76,15 @@ KeyLibGenerateSalt (
   IN UINTN      SaltSize
   )
 {
+  UINT32        RandomNumber;
+
   if (SaltValue == NULL) {
     return FALSE;
   }
-  if (!RandomSeed (NULL, 0)) {
+  if (!GetRandomNumber32 (&RandomNumber)) {
+    return FALSE;
+  }
+  if (!RandomSeed((UINT8 *)&RandomNumber, sizeof(RandomNumber))){
     return FALSE;
   }
   if (!RandomBytes(SaltValue, SaltSize)) {

--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMm.inf
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMm.inf
@@ -43,6 +43,7 @@
   MemoryAllocationLib
   BaseCryptLib
   PlatformPasswordLib
+  RngLib
 
 [Guids]
   gUserAuthenticationGuid                       ## CONSUMES  ## GUID


### PR DESCRIPTION
Use RngLib to get the Random number instead of passing seed value is NULL and seed size is zero.