### PR TITLE
Features/Intel: Improper Return Status

### DIFF
--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.c
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.c
@@ -460,7 +460,7 @@ SmmPasswordHandler (
 
   if (TempCommBufferSize < sizeof (SMM_PASSWORD_COMMUNICATE_HEADER)) {
     DEBUG ((DEBUG_ERROR, "SmmPasswordHandler: SMM communication buffer size invalid!\n"));
-    return EFI_SUCCESS;
+    return EFI_INVALID_PARAMETER;
   }
 
   CommBufferPayloadSize = TempCommBufferSize - sizeof (SMM_PASSWORD_COMMUNICATE_HEADER);


### PR DESCRIPTION
SmmPasswordHandler returns EFI_SUCCESS even when the CommBufferSize is less than the expected header size.
Change the return statement to return an appropriate error code EFI_INVALID_PARAMETER instead of EFI_SUCCESS.