### PR TITLE
Correct the path of libfdt inf

### DIFF
--- a/Platform/Bosc/XiangshanSeriesPkg/NanhuDev/NanhuDev.dsc
+++ b/Platform/Bosc/XiangshanSeriesPkg/NanhuDev/NanhuDev.dsc
@@ -407,7 +407,7 @@
       HobLib|EmbeddedPkg/Library/PrePiHobLib/PrePiHobLib.inf
       PrePiHobListPointerLib|OvmfPkg/RiscVVirt/Library/PrePiHobListPointerLib/PrePiHobListPointerLib.inf
       MemoryAllocationLib|EmbeddedPkg/Library/PrePiMemoryAllocationLib/PrePiMemoryAllocationLib.inf
-      FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf  # Map to deprecated library for this module only
+      FdtLib|MdePkg/Library/BaseFdtLib/BaseFdtLib.inf  # Map to deprecated library for this module only
   }
 
   #

--- a/Platform/Loongson/LoongArchQemuPkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.c
+++ b/Platform/Loongson/LoongArchQemuPkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.c
@@ -18,7 +18,7 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/PcdLib.h>
-#include <libfdt.h>
+#include <Library/FdtLib.h>
 #include "QemuFwCfgLibInternal.h"
 
 STATIC UINTN mFwCfgSelectorAddress;
@@ -411,10 +411,10 @@ QemuFwCfgInitialize (
   //
   // Make sure we have a valid device tree blob
   //
-  ASSERT (fdt_check_header (DeviceTreeBase) == 0);
+  ASSERT (FdtCheckHeader (DeviceTreeBase) == 0);
 
   for (Prev = 0;; Prev = Node) {
-    Node = fdt_next_node (DeviceTreeBase, Prev, NULL);
+    Node = FdtNextNode (DeviceTreeBase, Prev, NULL);
     if (Node < 0) {
       break;
     }
@@ -422,7 +422,7 @@ QemuFwCfgInitialize (
     //
     // Check for memory node
     //
-    Type = fdt_getprop (DeviceTreeBase, Node, "compatible", &Len);
+    Type = FdtGetProp (DeviceTreeBase, Node, "compatible", &Len);
     if ((Type)
       && (AsciiStrnCmp (Type, "qemu,fw-cfg-mmio", Len) == 0))
     {
@@ -430,7 +430,7 @@ QemuFwCfgInitialize (
       // Get the 'reg' property of this node. For now, we will assume
       // two 8 byte quantities for base and size, respectively.
       //
-      RegProp = fdt_getprop (DeviceTreeBase, Node, "reg", &Len);
+      RegProp = FdtGetProp (DeviceTreeBase, Node, "reg", &Len);
       if ((RegProp != 0)
         && (Len == (2 * sizeof (UINT64))))
       {

--- a/Platform/Loongson/LoongArchQemuPkg/Library/SerialPortLib/EarlySerialPortLib16550.c
+++ b/Platform/Loongson/LoongArchQemuPkg/Library/SerialPortLib/EarlySerialPortLib16550.c
@@ -14,7 +14,7 @@
 #include <Library/PlatformHookLib.h>
 #include <Library/BaseLib.h>
 #include <Guid/FdtHob.h>
-#include <libfdt.h>
+#include <Library/FdtLib.h>
 
 //
 // PCI Defintions.
@@ -139,17 +139,17 @@ GetSerialConsolePortAddress (
   CONST CHAR8   *NodeStatus;
   CONST UINT64  *RegProperty;
 
-  if ((Fdt == NULL) || (fdt_check_header (Fdt) != 0)) {
+  if ((Fdt == NULL) || (FdtCheckHeader (Fdt) != 0)) {
     return EFI_INVALID_PARAMETER;
   }
 
   // The "chosen" node resides at the root of the DT. Fetch it.
-  ChosenNode = fdt_path_offset (Fdt, "/chosen");
+  ChosenNode = FdtPathOffset (Fdt, "/chosen");
   if (ChosenNode < 0) {
     return EFI_NOT_FOUND;
   }
 
-  Prop = fdt_getprop (Fdt, ChosenNode, "stdout-path", &PropSize);
+  Prop = FdtGetProp (Fdt, ChosenNode, "stdout-path", &PropSize);
   if (PropSize < 0) {
     return EFI_NOT_FOUND;
   }
@@ -164,28 +164,28 @@ GetSerialConsolePortAddress (
 
   // Aliases cannot start with a '/', so it must be the actual path.
   if (Prop[0] == '/') {
-    SerialConsoleNode = fdt_path_offset_namelen (Fdt, Prop, PathLen);
+    SerialConsoleNode = FdtPathOffset_namelen (Fdt, Prop, PathLen);
   } else {
     // Lookup the alias, as this contains the actual path.
-    Path = fdt_get_alias_namelen (Fdt, Prop, PathLen);
+    Path = FdtGetAliasNameLen (Fdt, Prop, PathLen);
     if (Path == NULL) {
       return EFI_NOT_FOUND;
     }
 
-    SerialConsoleNode = fdt_path_offset (Fdt, Path);
+    SerialConsoleNode = FdtPathOffset (Fdt, Path);
   }
 
-  NodeStatus = fdt_getprop (Fdt, SerialConsoleNode, "status", &Len);
+  NodeStatus = FdtGetProp (Fdt, SerialConsoleNode, "status", &Len);
   if ((NodeStatus != NULL) && (AsciiStrCmp (NodeStatus, "okay") != 0)) {
     return EFI_NOT_FOUND;
   }
 
-  RegProperty = fdt_getprop (Fdt, SerialConsoleNode, "reg", &Len);
+  RegProperty = FdtGetProp (Fdt, SerialConsoleNode, "reg", &Len);
   if (Len != 16) {
     return EFI_INVALID_PARAMETER;
   }
 
-  *SerialConsoleAddress = fdt64_to_cpu (ReadUnaligned64 (RegProperty));
+  *SerialConsoleAddress = Fdt64ToCpu (ReadUnaligned64 (RegProperty));
 
   return EFI_SUCCESS;
 }

--- a/Silicon/Bosc/NanHuPkg/Sec/Platform.c
+++ b/Silicon/Bosc/NanHuPkg/Sec/Platform.c
@@ -13,7 +13,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
 #include <Include/Library/PrePiLib.h>
-#include <libfdt.h>
+#include <Library/FdtLib.h>
 #include <Guid/FdtHob.h>
 
 /**
@@ -62,15 +62,15 @@ PopulateIoResources (
   UINT64  *Reg;
   INT32   Node, LenP;
 
-  Node = fdt_node_offset_by_compatible (FdtBase, -1, Compatible);
+  Node = FdtNodeOffsetByCompatible (FdtBase, -1, Compatible);
   while (Node != -FDT_ERR_NOTFOUND) {
-    Reg = (UINT64 *)fdt_getprop (FdtBase, Node, "reg", &LenP);
+    Reg = (UINT64 *)FdtGetProp (FdtBase, Node, "reg", &LenP);
     if (Reg) {
       ASSERT (LenP == (2 * sizeof (UINT64)));
       AddIoMemoryBaseSizeHob (SwapBytes64 (Reg[0]), SwapBytes64 (Reg[1]));
     }
 
-    Node = fdt_node_offset_by_compatible (FdtBase, Node, Compatible);
+    Node = FdtNodeOffsetByCompatible (FdtBase, Node, Compatible);
   }
 }
 
@@ -98,12 +98,12 @@ PlatformPeimInitialization (
 
   DEBUG ((DEBUG_INFO, "%a: Build FDT HOB - FDT at address: 0x%x \n", __func__, DeviceTreeAddress));
   Base = DeviceTreeAddress;
-  if (fdt_check_header (Base) != 0) {
+  if (FdtCheckHeader (Base) != 0) {
     DEBUG ((DEBUG_ERROR, "%a: Corrupted DTB\n", __func__));
     return EFI_UNSUPPORTED;
   }
 
-  FdtSize  = fdt_totalsize (Base);
+  FdtSize  = FdtTotalSize (Base);
   FdtPages = EFI_SIZE_TO_PAGES (FdtSize);
   NewBase  = AllocatePages (FdtPages);
   if (NewBase == NULL) {
@@ -111,7 +111,7 @@ PlatformPeimInitialization (
     return EFI_UNSUPPORTED;
   }
 
-  fdt_open_into (Base, NewBase, EFI_PAGES_TO_SIZE (FdtPages));
+  FdtOpenInto (Base, NewBase, EFI_PAGES_TO_SIZE (FdtPages));
 
   FdtHobData = BuildGuidHob (&gFdtHobGuid, sizeof *FdtHobData);
   if (FdtHobData == NULL) {

--- a/Silicon/Marvell/Applications/DumpFdt/DumpFdt.c
+++ b/Silicon/Marvell/Applications/DumpFdt/DumpFdt.c
@@ -20,7 +20,7 @@
 #include <Protocol/Shell.h>
 #include <Library/ShellLib.h>
 #include <Library/ShellCommandLib.h>
-#include <libfdt.h>
+#include <Library/FdtLib.h>
 
 #define CMD_NAME_STRING       L"dumpfdt"
 
@@ -101,7 +101,7 @@ DumpFdt (
   IN VOID*                FdtBlob
   )
 {
-  struct fdt_header *bph;
+  struct FDT_HEADER *bph;
   UINT32 off_dt;
   UINT32 off_str;
   CONST CHAR8* p_struct;
@@ -117,12 +117,12 @@ DumpFdt (
 
   {
     // Can 'memreserve' be printed by below code?
-    INTN num = fdt_num_mem_rsv (FdtBlob);
+    INTN num = FdtGetNumberOfReserveMapEntries (FdtBlob);
     INTN i, err;
     UINT64 addr = 0, size = 0;
 
     for (i = 0; i < num; i++) {
-      err = fdt_get_mem_rsv (FdtBlob, i, &addr, &size);
+      err = FdtGetReserveMapEntry (FdtBlob, i, &addr, &size);
       if (err) {
         DEBUG ((DEBUG_ERROR, "Error (%d) : Cannot get memreserve section (%d)\n", err, i));
       }
@@ -263,7 +263,7 @@ InstallFdt (
     // Ensure that the FDT header is valid and that the Size of the Device Tree
     // is smaller than the size of the read file
     //
-    if (fdt_check_header (mFdtBlobBase)) {
+    if (FdtCheckHeader (mFdtBlobBase)) {
         DEBUG ((DEBUG_ERROR, "InstallFdt() - FDT blob seems to be corrupt\n"));
         mFdtBlobBase = NULL;
         Status = EFI_LOAD_ERROR;

--- a/Silicon/NXP/NxpQoriqLs.dsc.inc
+++ b/Silicon/NXP/NxpQoriqLs.dsc.inc
@@ -75,7 +75,7 @@
   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
   DebugAgentLib|MdeModulePkg/Library/DebugAgentLibNull/DebugAgentLibNull.inf
   DmaLib|EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.inf
-  FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf
+  FdtLib|MdePkg/Library/BaseFdtLib/BaseFdtLib.inf
   ShellLib|ShellPkg/Library/UefiShellLib/UefiShellLib.inf
   ShellCommandLib|ShellPkg/Library/UefiShellCommandLib/UefiShellCommandLib.inf
   FileHandleLib|MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf

--- a/Silicon/Phytium/PhytiumCommonPkg/PhytiumCommonPkg.dsc.inc
+++ b/Silicon/Phytium/PhytiumCommonPkg/PhytiumCommonPkg.dsc.inc
@@ -46,7 +46,7 @@
   DebugAgentTimerLib|EmbeddedPkg/Library/DebugAgentTimerLibNull/DebugAgentTimerLibNull.inf
   DxeServicesLib|MdePkg/Library/DxeServicesLib/DxeServicesLib.inf
 
-  FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf
+  FdtLib|MdePkg/Library/BaseFdtLib/BaseFdtLib.inf
   FileExplorerLib|MdeModulePkg/Library/FileExplorerLib/FileExplorerLib.inf
   FileHandleLib|MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf
 

--- a/Silicon/Sophgo/SG2042Pkg/Sec/Platform.c
+++ b/Silicon/Sophgo/SG2042Pkg/Sec/Platform.c
@@ -13,7 +13,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
 #include <Include/Library/PrePiLib.h>
-#include <libfdt.h>
+#include <Library/FdtLib.h>
 #include <Guid/FdtHob.h>
 
 /**
@@ -62,15 +62,15 @@ PopulateIoResources (
   UINT64  *Reg;
   INT32   Node, LenP;
 
-  Node = fdt_node_offset_by_compatible (FdtBase, -1, Compatible);
+  Node = FdtNodeOffsetByCompatible (FdtBase, -1, Compatible);
   while (Node != -FDT_ERR_NOTFOUND) {
-    Reg = (UINT64 *)fdt_getprop (FdtBase, Node, "reg", &LenP);
+    Reg = (UINT64 *)FdtGetProp (FdtBase, Node, "reg", &LenP);
     if (Reg) {
       ASSERT (LenP == (2 * sizeof (UINT64)));
       AddIoMemoryBaseSizeHob (SwapBytes64 (Reg[0]), SwapBytes64 (Reg[1]));
     }
 
-    Node = fdt_node_offset_by_compatible (FdtBase, Node, Compatible);
+    Node = FdtNodeOffsetByCompatible (FdtBase, Node, Compatible);
   }
 }
 
@@ -98,12 +98,12 @@ PlatformPeimInitialization (
 
   DEBUG ((DEBUG_INFO, "%a: Build FDT HOB - FDT at address: 0x%x \n", __func__, DeviceTreeAddress));
   Base = DeviceTreeAddress;
-  if (fdt_check_header (Base) != 0) {
+  if (FdtCheckHeader (Base) != 0) {
     DEBUG ((DEBUG_ERROR, "%a: Corrupted DTB\n", __func__));
     return EFI_UNSUPPORTED;
   }
 
-  FdtSize  = fdt_totalsize (Base);
+  FdtSize  = FdtTotalSize (Base);
   FdtPages = EFI_SIZE_TO_PAGES (FdtSize);
   NewBase  = AllocatePages (FdtPages);
   if (NewBase == NULL) {
@@ -111,7 +111,7 @@ PlatformPeimInitialization (
     return EFI_UNSUPPORTED;
   }
 
-  fdt_open_into (Base, NewBase, EFI_PAGES_TO_SIZE (FdtPages));
+  FdtOpenInto (Base, NewBase, EFI_PAGES_TO_SIZE (FdtPages));
 
   FdtHobData = BuildGuidHob (&gFdtHobGuid, sizeof *FdtHobData);
   if (FdtHobData == NULL) {


### PR DESCRIPTION
libfdt has been moved from EmbeddedPkg/Library/FdtLib/FdtLib.inf to MdePkg/Library/BaseFdtLib/BaseFdtLib.inf. This patch fixes this issue.

