### PR TITLE
Features/Intel:Failure to Clear Password Data

### DIFF
--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.c
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.c
@@ -623,6 +623,8 @@ EXIT:
     }
   }
   SmmFunctionHeader->ReturnStatus = Status;
+  ZeroMem(&SmmCommunicateSetPassword, sizeof(SmmCommunicateSetPassword));
+  ZeroMem(&SmmCommunicateVerifyPassword, sizeof(SmmCommunicateVerifyPassword));
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
Clearing password at EXIT in both cases SMM_PASSWORD_FUNCTION_SET_PASSWORD and SMM_PASSWORD_FUNCTION_VERIFY_PASSWORD