### PR TITLE
[Intel][Platforms] Fix the Build Failure on Unix System

### DIFF
--- a/Platform/Intel/build_bios.py
+++ b/Platform/Intel/build_bios.py
@@ -219,7 +219,7 @@ def pre_build(build_config, build_type="DEBUG", silent=False, toolchain=None, sk
 
         # Add BaseTools shell wrappers to the PATH
         config["PATH"] = os.path.join(config["BASE_TOOLS_PATH"],
-                                    "BinPipWrappers", "PosixLike") + \
+                                    "BinWrappers", "PosixLike") + \
                                         os.pathsep + config["PATH"]
 
     # Make BaseTools source


### PR DESCRIPTION
# Description

- In 5a16d243aa126721be61ca97059014b487fd8830 simplefy the code flow for removing "edk2basetools" supported along with the edk2 upstream (https://github.com/tianocore/edk2/pull/6162).

- However, correct wrapper shell script path got removed unconscious, it would casue the build failure due to "build" command not found.

- This patch would correct it from "BinPipWrappers" into "BinWrappers".

# Failure Symptoms

- Without this change, below failure would be observed,

```
Traceback (most recent call last):
  File "/root/Source/Fw/edk2-platforms/Platform/Intel/build_bios.py", line 1199, in <module>
    main()
  File "/root/Source/Fw/edk2-platforms/Platform/Intel/build_bios.py", line 1190, in main
    config = build(config)
             ^^^^^^^^^^^^^
  File "/root/Source/Fw/edk2-platforms/Platform/Intel/build_bios.py", line 501, in build
    _, _, _, exit_code = execute_script(command, config, shell=shell)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Source/Fw/edk2-platforms/Platform/Intel/build_bios.py", line 779, in execute_script
    execute = subprocess.Popen(command, **kwarg)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.12/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'build'
```

# Test Combination

- edk2 repository: ```a074649c6096d6dd36d03db5a55316d129e776b5```
- edk2-platforms repository: ```28acb27feebf5ab17d8371ff23c0061903794dba```
- edk2-non-osi repository: ```94d048981116e2e3eda52dad1a89958ee404098d```
- FSP repository: ```7c4aaf2266e82bfa3c3c984038514d6a0a85e6be```

- [Build_PASSED.txt](https://github.com/user-attachments/files/23171611/Build_PASSED.txt)
