### PR TITLE
Drivers/OptionRomPkg: Deprecate gEfiScsiPassThruProtocolGuid

### DIFF
--- a/Drivers/OptionRomPkg/AtapiPassThruDxe/AtapiPassThru.h
+++ b/Drivers/OptionRomPkg/AtapiPassThruDxe/AtapiPassThru.h
@@ -13,7 +13,6 @@
 
 #include <Uefi.h>
 
-#include <Protocol/ScsiPassThru.h>
 #include <Protocol/ScsiPassThruExt.h>
 #include <Protocol/PciIo.h>
 #include <Protocol/DriverSupportedEfiVersion.h>

--- a/Drivers/OptionRomPkg/AtapiPassThruDxe/AtapiPassThruDxe.inf
+++ b/Drivers/OptionRomPkg/AtapiPassThruDxe/AtapiPassThruDxe.inf
@@ -56,14 +56,9 @@
 
 
 [Protocols]
-  gEfiScsiPassThruProtocolGuid                  # PROTOCOL BY_START
   gEfiExtScsiPassThruProtocolGuid               # PROTOCOL BY_START
   gEfiPciIoProtocolGuid                         # PROTOCOL TO_START
   gEfiDriverSupportedEfiVersionProtocolGuid     # PROTOCOL ALWAYS_PRODUCED
-
-[FeaturePcd]
-  gOptionRomPkgTokenSpaceGuid.PcdSupportScsiPassThru
-  gOptionRomPkgTokenSpaceGuid.PcdSupportExtScsiPassThru
 
 [Pcd]
   gOptionRomPkgTokenSpaceGuid.PcdDriverSupportedEfiVersion

--- a/Drivers/OptionRomPkg/OptionRomPkg.dec
+++ b/Drivers/OptionRomPkg/OptionRomPkg.dec
@@ -33,10 +33,6 @@
   ## GUID for RenesasFirmwarePD720202 firmware image
   gRenesasFirmwarePD720202ImageId = {0xA059EBC4, 0xD73D, 0x4279, {0x81,0xBF,0xE4,0xA8,0x93,0x08,0xB9,0x23}}
 
-[PcdsFeatureFlag]
-  gOptionRomPkgTokenSpaceGuid.PcdSupportScsiPassThru|TRUE|BOOLEAN|0x00010001
-  gOptionRomPkgTokenSpaceGuid.PcdSupportExtScsiPassThru|TRUE|BOOLEAN|0x00010002
-
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   gOptionRomPkgTokenSpaceGuid.PcdDriverSupportedEfiVersion|0x0002000a|UINT32|0x00010003
 

--- a/Drivers/OptionRomPkg/OptionRomPkg.dsc
+++ b/Drivers/OptionRomPkg/OptionRomPkg.dsc
@@ -64,10 +64,6 @@
 # Pcd Section - list of all EDK II PCD Entries defined by this Platform
 #
 ################################################################################
-[PcdsFeatureFlag]
-  gOptionRomPkgTokenSpaceGuid.PcdSupportScsiPassThru|TRUE
-  gOptionRomPkgTokenSpaceGuid.PcdSupportExtScsiPassThru|TRUE
-
 [PcdsFixedAtBuild]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x27
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000042

--- a/Drivers/OptionRomPkg/ReadMe.txt
+++ b/Drivers/OptionRomPkg/ReadMe.txt
@@ -1,11 +1,8 @@
 AtapiPassThru:
   For now, AtapiPassThru driver in this package is to test Scsi Bus support:
-  ScsiBus driver should support both/either ScsiPassThru and ExtScsiPassThru
-  installed on a controller handle.
+  ScsiBus driver should support ExtScsiPassThru installed on a controller handle.
    
-  AtapiPassThru driver in this package can selectively produce ScsiPassThru
-  and/or ExtScsiPassThru protocol based on feature flags of PcdSupportScsiPassThru
-  and PcdSupportExtScsiPassThru.
+  AtapiPassThru driver in this package produce  ExtScsiPassThru protocol.
 
 CirrusLogic5430:
   Sample implementation of UGA Draw or Graphics Output Protocol for the Cirrus


### PR DESCRIPTION
This PR addresses the usage of gEfiScsiPassThruProtocolGuid that has been removed from the UEFI spec 2.10A and 2.11 but are still present in the codebase. To align with the updated spec the legacy ScsiPassThruProtocol has been deprecated and the implementation has been updated to only use ExtScsiPassThruProtocol, which provides enhanced support for device enumeration, target/LUN discovery, and broader SCSI compatibility.

Note: This PR should be merged before edk2 PR - https://github.com/tianocore/edk2/pull/11665 to avoid build errors.