### PR TITLE
Ext4Pkg: remove unused variable in collation code

### DIFF
--- a/Features/Ext4Pkg/Ext4Dxe/Collation.c
+++ b/Features/Ext4Pkg/Ext4Dxe/Collation.c
@@ -66,7 +66,6 @@ Ext4InitialiseUnicodeCollationInternal (
   UINTN                           NumHandles;
   EFI_HANDLE                      *Handles;
   EFI_UNICODE_COLLATION_PROTOCOL  *Uci;
-  BOOLEAN                         Iso639Language;
   CHAR8                           *Language;
   EFI_STATUS                      RetStatus;
   EFI_STATUS                      Status;


### PR DESCRIPTION
Iso639Language is not used anywhere in the code, so GCC flags it as an unused variable.