### PR TITLE
Platform/Loongson: Add SATA support

### DIFF
--- a/Platform/Loongson/LoongArchQemuPkg/Loongson.dsc
+++ b/Platform/Loongson/LoongArchQemuPkg/Loongson.dsc
@@ -566,11 +566,17 @@
   OvmfPkg/VirtioNetDxe/VirtioNet.inf
 
   #
-  # IDE/SCSI
+  # SCSI
   #
-  MdeModulePkg/Bus/Pci/SataControllerDxe/SataControllerDxe.inf
   MdeModulePkg/Bus/Scsi/ScsiBusDxe/ScsiBusDxe.inf
   MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDiskDxe.inf
+
+  #
+  # SATA
+  #
+  MdeModulePkg/Bus/Pci/SataControllerDxe/SataControllerDxe.inf
+  MdeModulePkg/Bus/Ata/AtaBusDxe/AtaBusDxe.inf
+  MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.inf
 
   #
   # NVME Driver

--- a/Platform/Loongson/LoongArchQemuPkg/Loongson.fdf
+++ b/Platform/Loongson/LoongArchQemuPkg/Loongson.fdf
@@ -176,11 +176,17 @@ INF  OvmfPkg/VirtioGpuDxe/VirtioGpu.inf
 INF  OvmfPkg/PlatformDxe/Platform.inf
 
 #
-# SATA/SCSI
+# SCSI
 #
-INF  MdeModulePkg/Bus/Pci/SataControllerDxe/SataControllerDxe.inf
 INF  MdeModulePkg/Bus/Scsi/ScsiBusDxe/ScsiBusDxe.inf
 INF  MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDiskDxe.inf
+
+#
+# SATA
+#
+INF  MdeModulePkg/Bus/Pci/SataControllerDxe/SataControllerDxe.inf
+INF  MdeModulePkg/Bus/Ata/AtaBusDxe/AtaBusDxe.inf
+INF  MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.inf
 
 #
 # NVME


### PR DESCRIPTION
SATA CD-ROMS are still conventionally used in many virtual environments, so it's nice to support them out of the box.

Tested with QEMU 9.2.3 with the following controller and drive:

qemu-system-loongarch64    -bios QEMU_EFI_xxx.fd \
    -drive id=disk,file=sata.img,if=none \
    -device ahci,id=ahci \
    -device ide-hd,drive=disk,bus=ahci.0 \
    -device virtio-gpu-pci \
    -device nec-usb-xhci,id=xhci,addr=0x1b \
    -device usb-tablet,id=tablet,bus=xhci.0,port=1 \
    -device usb-kbd,id=keyboard,bus=xhci.0,port=2

REF: https://github.com/tianocore/edk2/pull/11309
issues: https://github.com/loongson/Firmware/issues/27

Reported-by: SignKirigami <prcups@krgm.moe>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>
Signed-off-by: Xianglai Li <lixianglai@loongson.cn>
Tested-by: SignKirigami <prcups@krgm.moe>
Tested-by: Dongyan Qian <qiandongyan@loongson.cn>