### PR TITLE
Features/Intel:Fix for MSVC variable build error

### DIFF
--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.c
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationSmm.c
@@ -363,6 +363,7 @@ IsPasswordStrong (
   HasUpperCase = FALSE;
   HasNumber = FALSE;
   HasSymbol = FALSE;
+  PrevChar = '\0';
   for (Index = 0; Index < PasswordSize - 1; Index++) {
     if (Password[Index] >= 'a' && Password[Index] <= 'z') {
       HasLowerCase = TRUE;


### PR DESCRIPTION
Initializing the Variable to 'NULL'
for resolving MSVC Build error.