### PR TITLE
RISC-V/PlatformPkg: Fix the library dependencies of PlatformSecLib

### DIFF
--- a/Platform/RISC-V/PlatformPkg/Library/RiscVPlatformSecLib/RiscVPlatformSecLib.inf
+++ b/Platform/RISC-V/PlatformPkg/Library/RiscVPlatformSecLib/RiscVPlatformSecLib.inf
@@ -36,6 +36,7 @@
   PcdLib
   PrePiLib
   SerialPortLib
+  PeiServicesLib
 
 [Packages]
   EmbeddedPkg/EmbeddedPkg.dec


### PR DESCRIPTION
When I explored the u540 code, I discovered that the PlatformSecLib library was missing the PeiServicesLib library.