### PR TITLE
Platform/ARM/JunoPkg: apply dynamic SMBIOS table generation for type 4 & 7

### DIFF
--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -120,6 +120,19 @@ EDKII_PLATFORM_REPOSITORY_INFO ArmJunoPlatformRepositoryInfo = {
     },
   },
 
+  { // SMBIOS
+    {
+      SMBIOS_TYPE_CACHE_INFORMATION,
+      CREATE_STD_SMBIOS_TABLE_GEN_ID (EStdSmbiosTableIdType07),
+      NULL
+    },
+    {
+      SMBIOS_TYPE_PROCESSOR_INFORMATION,
+      CREATE_STD_SMBIOS_TABLE_GEN_ID (EStdSmbiosTableIdType04),
+      NULL
+    }
+  },
+
   // Boot architecture information
   { EFI_ACPI_6_2_ARM_PSCI_COMPLIANT },      // BootArchFlags
 
@@ -1596,6 +1609,17 @@ GetStandardNameSpaceObject (
                  CmObjectId,
                  PlatformRepo->CmAcpiTableList,
                  (sizeof (PlatformRepo->CmAcpiTableList[0]) * TableCount),
+                 TableCount,
+                 CmObject
+                 );
+      break;
+
+    case EStdObjSmbiosTableList:
+      TableCount = ARRAY_SIZE (PlatformRepo->SmbiosTableList);
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->SmbiosTableList,
+                 sizeof (PlatformRepo->SmbiosTableList),
                  TableCount,
                  CmObject
                  );

--- a/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
+++ b/Platform/ARM/JunoPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.h
@@ -141,6 +141,10 @@ typedef EFI_STATUS (*CM_OBJECT_HANDLER_PROC) (
 */
 #define PLAT_ACPI_TABLE_COUNT   11
 
+/** The number of SMBIOS tables to install
+*/
+#define PLAT_SMBIOS_TABLE_COUNT     2
+
 /** The number of platform generic timer blocks
 */
 #define PLAT_GTBLOCK_COUNT          1
@@ -222,6 +226,9 @@ typedef struct PlatformRepositoryInfo {
 
   /// List of ACPI tables
   CM_STD_OBJ_ACPI_TABLE_INFO            CmAcpiTableList[PLAT_ACPI_TABLE_COUNT];
+
+  /// List of SMBIOS tables
+  CM_STD_OBJ_SMBIOS_TABLE_INFO          SmbiosTableList[PLAT_SMBIOS_TABLE_COUNT];
 
   /// Boot architecture information
   CM_ARM_BOOT_ARCH_INFO                 BootArchInfo;

--- a/Platform/ARM/JunoPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.c
+++ b/Platform/ARM/JunoPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.c
@@ -676,10 +676,12 @@ STATIC CONST VOID *DefaultCommonTables[]=
   &mArmDefaultType1,
   &mArmDefaultType2,
   &mArmDefaultType3,
+#ifndef DYNAMIC_TABLES_FRAMEWORK
   &mArmDefaultType7_a53_l1i,
   &mArmDefaultType7_a53_l1d,
   &mArmDefaultType7_a53_l2,
   &mArmDefaultType4_a53,
+#endif
   &mArmDefaultType9_0,
   &mArmDefaultType9_1,
   &mArmDefaultType9_2,
@@ -813,8 +815,10 @@ InstallAllStructures (
   Status=InstallStructures (Smbios,DefaultCommonTables);
   ASSERT_EFI_ERROR (Status);
 
+#ifndef DYNAMIC_TABLES_FRAMEWORK
   Status=InstallStructures (Smbios,ExtraTables);
   ASSERT_EFI_ERROR (Status);
+#endif
 
   // Generate memory descriptors for the two memory ranges we know about
   Status = InstallMemoryStructure ( Smbios, PcdGet64 (PcdSystemMemoryBase), PcdGet64 (PcdSystemMemorySize));


### PR DESCRIPTION
Apply dynamic SMBIOS table generation for Processor (Type 4) and
Cache (Type 7) records.

Once all SMBIOS records are migrated to dynamic table generation,
SmbiosPlatformDxe will be removed.

Signed-off-by: Yeoreum Yun <yeoreum.yun@arm.com>