### PR TITLE
Platform/ARM/Morello: Remove unused variable

### DIFF
--- a/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/Morello/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -791,7 +791,6 @@ GetArchCommonNameSpaceObject (
   )
 {
   EFI_STATUS                             Status;
-  EDKII_PLATFORM_REPOSITORY_INFO         *PlatformRepo;
   EDKII_COMMON_PLATFORM_REPOSITORY_INFO  *CommonPlatRepo;
 
   if ((This == NULL) || (CmObject == NULL)) {
@@ -801,7 +800,6 @@ GetArchCommonNameSpaceObject (
   }
 
   Status = EFI_NOT_FOUND;
-  PlatformRepo = This->PlatRepoInfo;
   CommonPlatRepo = This->PlatRepoInfo->CommonPlatRepoInfo;
 
   // Search for the FVP platform specific Arch Common namespace objects


### PR DESCRIPTION
Found by compiling in GCC5 or GCC with stronger warnings currently PR-d in https://github.com/tianocore/edk2/pull/11761