### PR TITLE
KabylakeSiliconPkg: Fix mismatched function declaration

### DIFF
--- a/Silicon/Intel/KabylakeSiliconPkg/SystemAgent/Library/PeiSaPolicyLib/MrcOemPlatform.h
+++ b/Silicon/Intel/KabylakeSiliconPkg/SystemAgent/Library/PeiSaPolicyLib/MrcOemPlatform.h
@@ -258,11 +258,11 @@ SetMemoryVdd (
 
   @retval MrcStatus value.
 **/
-UINT32
+MrcStatus
 CheckPoint (
-  VOID   *GlobalData,
-  UINT32 Command,
-  VOID   *Pointer
+  IN VOID                *GlobalData,
+  IN MrcOemStatusCommand OemStatusCommand,
+  IN VOID                *Pointer
   );
 
 /**


### PR DESCRIPTION
On building Kabylake platforms in GCC5, we enounter (abbreviated):

SystemAgent/Library/PeiSaPolicyLib/MrcOemPlatform.c:610:1: error: conflicting types for ‘CheckPoint’ due to enum/integer mismatch; have ‘MrcStatus(void *, MrcOemStatusCommand,  void *)’ [-Werror=enum-int-mismatch]

SystemAgent/Library/PeiSaPolicyLib/MrcOemPlatform.h:262:1: note: previous declaration of ‘CheckPoint’ with type ‘UINT32(void *, UINT32,  void *)’ {aka ‘unsigned int(void *, unsigned int,  void *)’}

Fix the header declaration to match the function definition, including having the more specific enum types.