### PR TITLE
MinPlatformPkg/TestPointCheckLib: Fix method declarations

### DIFF
--- a/Platform/Intel/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeTestPointCheckLib.c
+++ b/Platform/Intel/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeTestPointCheckLib.c
@@ -124,21 +124,25 @@ TestPointCheckSmiHandlerInstrument (
   );
 
 EFI_STATUS
+EFIAPI
 TestPointCheckUefiSecureBoot (
   VOID
   );
 
 EFI_STATUS
+EFIAPI
 TestPointCheckPiSignedFvBoot (
   VOID
   );
 
 EFI_STATUS
+EFIAPI
 TestPointCheckTcgTrustedBoot (
   VOID
   );
 
 EFI_STATUS
+EFIAPI
 TestPointCheckTcgMor (
   VOID
   );


### PR DESCRIPTION
On building packages which include debug library TestPointCheckLib in GCC5 we encounter the following non-fatal warnings (abbreviated):

TestPointCheckLib/DxeTestPointCheckLib.c:142:1: warning: type of ‘TestPointCheckTcgMor’ does not match original declaration [-Wlto-type-mismatch]
TestPointCheckLib/DxeCheckTcgMor.c:31:1: note: ‘TestPointCheckTcgMor’ was previously declared here

TestPointCheckLib/DxeTestPointCheckLib.c:137:1: warning: type of ‘TestPointCheckTcgTrustedBoot’ does not match original declaration [-Wlto-type-mismatch]
TestPointCheckLib/DxeCheckTcgTrustedBoot.c:28:1: note: ‘TestPointCheckTcgTrustedBoot’ was previously declared here

TestPointCheckLib/DxeTestPointCheckLib.c:132:1: warning: type of ‘TestPointCheckPiSignedFvBoot’ does not match original declaration [-Wlto-type-mismatch]
TestPointCheckLib/DxeCheckPiSignedFvBoot.c:19:1: note: ‘TestPointCheckPiSignedFvBoot’ was previously declared here

TestPointCheckLib/DxeTestPointCheckLib.c:127:1: warning: type of ‘TestPointCheckUefiSecureBoot’ does not match original declaration [-Wlto-type-mismatch]
TestPointCheckLib/DxeCheckUefiSecureBoot.c:40:1: note: ‘TestPointCheckUefiSecureBoot’ was previously declared here

Fix this by adding EFIAPI to method declarations which don't have it when their definitions do, in DxeTestPointCheckLib.c.