### PR TITLE
Platform/ASRockRack: Fallback to board product field for SMBIOS type 01

### DIFF
--- a/Platform/ASRockRack/AltraBoardPkg/Library/OemMiscLib/OemMiscLib.c
+++ b/Platform/ASRockRack/AltraBoardPkg/Library/OemMiscLib/OemMiscLib.c
@@ -382,6 +382,12 @@ OemUpdateSmbiosInfo (
   switch (Field) {
     case ProductNameType01:
       AsciiString = IpmiFruInfoGet (FruProductName);
+      DEBUG ((DEBUG_INFO, "%a: Product Name: %a\n", __func__, AsciiString));
+      if (AsciiStrCmp (AsciiString, PLACEHOLDER_SMBIOS_STRING) == 0) {
+        AsciiString = IpmiFruInfoGet (FruBoardProductName);
+        DEBUG ((DEBUG_INFO, "%a: (2) Product Name: %a\n", __func__, AsciiString));
+      }
+
       if (AsciiString != NULL) {
         StringLength = AsciiStrLen (AsciiString) + 1;
         AsciiStrToUnicodeStrS (AsciiString, UnicodeString, StringLength);


### PR DESCRIPTION
ASRock Rack only populates the Product fields during production if it is a CTO 19 inch system (e.g. 1U10E-ALTRA/1L2T), causing the fields to default to "To be filled by O.E.M".

Fallback to the board product name in case it is not present.