### PR TITLE
AMD EDKII Platform Code v1.0.0.8 for 5th Generation EPYC Processors

### DIFF
--- a/Platform/AMD/AgesaPkg/Addendum/PciSegments/PciExpressPciCfg2/PciExpressPciCfg2.inf
+++ b/Platform/AMD/AgesaPkg/Addendum/PciSegments/PciExpressPciCfg2/PciExpressPciCfg2.inf
@@ -52,7 +52,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard                       ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdUse5LevelPageTable                  ## SOMETIMES_CONSUMES
 
-[Pcd.IA32,Pcd.X64,Pcd.AARCH64]
+[Pcd.IA32,Pcd.X64,Pcd.ARM,Pcd.AARCH64]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetNxForStack               ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdImageProtectionPolicy       ## SOMETIMES_CONSUMES

--- a/Platform/AMD/TurinBoard/Include/Dsc/PlatformCommonPcd.dsc.inc
+++ b/Platform/AMD/TurinBoard/Include/Dsc/PlatformCommonPcd.dsc.inc
@@ -305,7 +305,7 @@
     # IdsDebugPrint Filter. Refer to Library/IdsLib.h for details.
     # 0x100401008A30042C (GNB_TRACE | PCIE_MISC | NB_MISC | GFX_MISC  | CPU_TRACE | MEM_FLOW |
     #                     MEM_STATUS | MEM_PMU | FCH_TRACE | MAIN_FLOW | TEST_POINT | PSP_TRACE)
-    gEfiAmdAgesaPkgTokenSpaceGuid.PcdAmdIdsDebugPrintFilter|0x0000000300000000
+    gEfiAmdAgesaPkgTokenSpaceGuid.PcdAmdIdsDebugPrintFilter|0x0004000300000000
     gEfiAmdAgesaPkgTokenSpaceGuid.PcdAmdIdsDebugPrintEnable|TRUE
       gEfiAmdAgesaPkgTokenSpaceGuid.PcdAmdIdsDebugPrintSerialPortEnable|TRUE
     gEfiAmdAgesaPkgTokenSpaceGuid.PcdAmdIdsDebugPrintSerialPortDetectCableConnection|FALSE

--- a/Platform/AMD/TurinBoard/Universal/BoardAcpiDxe/Dsdt/Dsdt.asl
+++ b/Platform/AMD/TurinBoard/Universal/BoardAcpiDxe/Dsdt/Dsdt.asl
@@ -164,7 +164,7 @@ DefinitionBlock (
       Store(0, SUPF)
       // check for GUID and revision match
       If (LEqual (Arg0, ToUUID("E5C937D0-3553-4D7A-9117-EA4D19C3434D"))) {
-        If (LEqual(Arg1, 0x05)) {
+        If (OR(LEqual(Arg1, 0x05), LEqual(Arg1, 0x06))) {
           Store (Arg2, DIDX)
           Store (0x00, DFIN)
           If (LEqual(Arg2, 0x0C)) {


### PR DESCRIPTION
Update of AMD EDKII Platform Code for 5th Generation EPYC Processors (formerly Turin). This sample platform code was tested to work with the Turin 1.0.0.8 AGESA PI package, which is available from AMD under license and NDA.