### PR TITLE
Console Variable fix for TestPointCheckLib

### DIFF
--- a/Platform/Intel/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeTestPointCheckLib.inf
+++ b/Platform/Intel/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeTestPointCheckLib.inf
@@ -85,6 +85,16 @@
   gEfiImageSecurityDatabaseGuid
   gSmiHandlerProfileGuid
   gEdkiiPiSmmCommunicationRegionTableGuid
+  gEfiTtyTermGuid
+  gEfiPcAnsiGuid
+  gEfiVT100Guid
+  gEfiVT100PlusGuid
+  gEfiVTUTF8Guid
+  gEfiTtyTermGuid
+  gEdkiiLinuxTermGuid
+  gEdkiiXtermR6Guid
+  gEdkiiVT400Guid
+  gEdkiiSCOTermGuid
 
 [Protocols]
   gEfiPciIoProtocolGuid


### PR DESCRIPTION
ConInDev, ConOutDev & ErrOutDev variables have list of device paths which have terminal console devices appended at the end. For only the user selected terminal type, the device path will have the necessary protocols installed at any point in time. TestPointCheckLib tries to discover these non existing terminal types and reports as an error. This patch fixes this by checking if the device path is a terminal type, and if so, then ignore the terminal node and only check for the existence of the parent path.