### PR TITLE
Features/ManageabilityPkg: Fix error return of IpmiGetSystemUuid

### DIFF
--- a/Features/ManageabilityPkg/Library/IpmiCommandLib/IpmiCommandLibNetFnApp.c
+++ b/Features/ManageabilityPkg/Library/IpmiCommandLib/IpmiCommandLibNetFnApp.c
@@ -395,6 +395,8 @@ IpmiGetSystemUuid (
       (VOID *)&GetSystemUuidResponse.SystemUuid,
       sizeof (EFI_GUID)
       );
+  } else {
+    return EFI_DEVICE_ERROR;
   }
 
   return Status;


### PR DESCRIPTION
If the call to IpmiSubmitCommand in IpmiGetSystemUuid succeeds but a UUID wasn't able to be retrieved, make sure we return an error code instead of EFI_SUCCESS.