### PR TITLE
    Platform/ARM/VExpressPkg: Increase stack size to execute SCT tests

### DIFF
--- a/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
@@ -139,7 +139,11 @@
 
   # Non-Trusted SRAM
   gArmPlatformTokenSpaceGuid.PcdCPUCoresStackBase|0x2E000000
+!if $(TARGET) != RELEASE
+  gArmPlatformTokenSpaceGuid.PcdCPUCorePrimaryStackSize|0x8000
+!else
   gArmPlatformTokenSpaceGuid.PcdCPUCorePrimaryStackSize|0x4000
+!endif
 
   # System Memory
   # When RME is supported by the FVP the top 64MB of DRAM1 (i.e. at the top


### PR DESCRIPTION
edk2-test (SCT) [0] is useful for verifying EDK2.
However, SCT cannot be executed on the FVP_RevC platform due to a stack overflow issue.

As a result, the following crash occurs when SCT is executed on FVP_RevC:
```
  FS2:> SCT.efi -p Serial
  Load support files ...
  Load proxy files ...
  add-symbol-file /home/yeoyun01/work/uefi/Build/UefiSct/RELEASE_GCC5/AARCH64/SctPkg/TestInfrastructure/SCT/Framework/Sct/DEBUG/SCT.dll 0xF97E8000
  Loading driver at 0x000F97E7000 EntryPoint=0x000F97EF484 SCT.efi
  add-symbol-file /home/yeoyun01/work/uefi/Build/UefiSct/RELEASE_GCC5/AARCH64/SctPkg/TestInfrastructure/SCT/Drivers/StandardTest/StandardTest/DEBUG/StandardTest.dll 0xF9A22000
  Loading driver at 0x000F9A21000 EntryPoint=0x000F9A27F44 StandardTest.efi
  add-symbol-file /home/yeoyun01/work/uefi/Build/UefiSct/RELEASE_GCC5/AARCH64/SctPkg/TestInfrastructure/SCT/Drivers/TestProfile/TestProfile/DEBUG/TestProfile.dll 0xF9A34000
  Loading driver at 0x000F9A33000 EntryPoint=0x000F9A361D0 TestProfile.efi
  add-symbol-file /home/yeoyun01/work/uefi/Build/UefiSct/RELEASE_GCC5/AARCH64/SctPkg/TestInfrastructure/SCT/Drivers/TestRecovery/TestRecovery/DEBUG/TestRecovery.dll 0xF9A66000
  Loading driver at 0x000F9A65000 EntryPoint=0x000F9A66730 TestRecovery.efi
  add-symbol-file /home/yeoyun01/work/uefi/Build/UefiSct/RELEASE_GCC5/AARCH64/SctPkg/TestInfrastructure/SCT/Drivers/TestLogging/TestLogging/DEBUG/TestLogging.dll 0xF9A2E000
  Loading driver at 0x000F9A2D000 EntryPoint=0x000F9A30098 TestLogging.efi

  Recursive exception occurred while dumping the CPU state
```
In practice, SCT is typically used for DEBUG builds rather than RELEASE targets. Therefore, increasing the stack size when the build target is DEBUG allows SCT to run successfully on the FVP_RevC platform.

Link: https://github.com/tianocore/edk2-test.git [0]
Signed-off-by: Yeoreum Yun <yeoreum.yun@arm.com>