### PR TITLE
QemuOpenBoardPkg: Enable TimerLib for PEI Core in Stage2

### DIFF
--- a/Platform/Qemu/QemuOpenBoardPkg/Include/Dsc/Stage2.dsc.inc
+++ b/Platform/Qemu/QemuOpenBoardPkg/Include/Dsc/Stage2.dsc.inc
@@ -13,6 +13,9 @@
   PciHostBridgeUtilityLib | OvmfPkg/Library/PciHostBridgeUtilityLib/PciHostBridgeUtilityLib.inf
   DxeHardwareInfoLib      | OvmfPkg/Library/HardwareInfoLib/DxeHardwareInfoLib.inf
 
+[LibraryClasses.Common.PEI_CORE]
+  TimerLib                | OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLib.inf
+
 [LibraryClasses.Common.PEIM]
   MpInitLib               | UefiCpuPkg/Library/MpInitLib/PeiMpInitLib.inf
   TimerLib                | OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLib.inf


### PR DESCRIPTION
During Stage2 the default TimerLib resolves to BaseTimerLibNullTemplate, leading to a PeiCore ASSERT when timing services are invoked. Map TimerLib to BaseAcpiTimerLib for PEI Core to provide a valid implementation.

Log Before:
ASSERT [PeiCore] /local/mnt/workspace/build/edk2/MdePkg/Library/BaseTimerLibNullTemplate/TimerLibNull.c(70): ((BOOLEAN)(0==1))
!!!! IA32 Exception Type - 03(#BP - Breakpoint)  CPU Apic ID - 00000000 !!!!
EIP  - FFEEF662, CS  - 00000008, EFLAGS - 00000046
EAX  - 00000095, ECX - 0100F941, EDX - 000003F8, EBX - 0100F8AC
ESP  - 0100F89C, EBP - 0100F9B4, ESI - FFF7F078, EDI - 010001B0
DS   - 00000010, ES  - 00000010, FS  - 00000010, GS  - 00000010, SS - 00000010
CR0  - 60000011, CR2 - 00000000, CR3 - 00000000, CR4 - 00000200
DR0  - 00000000, DR1 - 00000000, DR2 - 00000000, DR3 - 00000000
DR6  - FFFF0FF0, DR7 - 00000400
GDTR - FFFFD368 00000017, IDTR - 0100FEBC 0000010F
LDTR - 00000000, TR - 00000000
FXSAVE_STATE - 0100F5E0
!!!! Find image based on IP(0xFFEEF662) /local/mnt/workspace/build/Build/QemuOpenBoardPkg/DEBUG_GCC5/IA32/MdeModulePkg/Core/Pei/PeiMain/DEBUG/PeiCore.dll (ImageBase=00000000FFEEF140, EntryPoint=00000000FFEF647F) !!!!

Tested to boot to shell.