### PR TITLE
Ampere: Remove private ArmLib header from JadePkg and AmpereAltraPkg

### DIFF
--- a/Platform/Ampere/JadePkg/Drivers/AcpiPlatformDxe/AcpiPlatform.h
+++ b/Platform/Ampere/JadePkg/Drivers/AcpiPlatformDxe/AcpiPlatform.h
@@ -15,7 +15,6 @@
 #include <Guid/EventGroup.h>
 #include <Guid/PlatformInfoHob.h>
 #include <IndustryStandard/Acpi63.h>
-#include <Library/ArmLib/ArmLibPrivate.h>
 #include <Library/AcpiLib.h>
 #include <Library/AmpereCpuLib.h>
 #include <Library/BaseMemoryLib.h>

--- a/Silicon/Ampere/AmpereAltraPkg/Library/AmpereCpuLib/AmpereCpuLibCommon.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Library/AmpereCpuLib/AmpereCpuLibCommon.c
@@ -11,7 +11,6 @@
 
 #include <Guid/PlatformInfoHob.h>
 #include <Library/AmpereCpuLib.h>
-#include <Library/ArmLib/ArmLibPrivate.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/IoLib.h>


### PR DESCRIPTION
Drop inclusion of Library/ArmLib/ArmLibPrivate.h from:
- Platform/Ampere/JadePkg/Drivers/AcpiPlatformDxe/AcpiPlatform.h
- Silicon/Ampere/AmpereAltraPkg/Library/AmpereCpuLib/AmpereCpuLibCommon.c

The private header is unused in these sources and is being removed from the edk2 repository.

Test - compiled using:
GCC5_AARCH64_PREFIX=aarch64-linux-gnu- build -b DEBUG -a AARCH64   -t GCC5  -p ./Platform/Ampere/JadePkg/Jade.dsc
GCC5_AARCH64_PREFIX=aarch64-linux-gnu- build -b REELASE -a AARCH64   -t GCC5  -p ./Platform/Ampere/JadePkg/Jade.dsc

Note:
-- Pick up recent PR fixes for this platform for testing - https://github.com/tianocore/edk2-platforms/pull/926.
-- Disable Secure boot and Capsule for compilation.