### PR TITLE
Silicon/Tools: Fix build for FitGen

### DIFF
--- a/Platform/Intel/build_bios.py
+++ b/Platform/Intel/build_bios.py
@@ -261,17 +261,15 @@ def pre_build(build_config, build_type="DEBUG", silent=False, toolchain=None, sk
     #
     # build platform silicon tools
     #
-    # save the current workspace
-    saved_work_directory = config["WORKSPACE"]
     # change the workspace to silicon tools directory
-    config["WORKSPACE"] = os.path.join(config["WORKSPACE_SILICON"], "Tools")
+    silicon_tools_directory = os.path.join(config["WORKSPACE_SILICON"], "Tools")
 
-    command = ["nmake"]
+    command = ["nmake", "-f", os.path.join(silicon_tools_directory, "Makefile")]
     if os.name == 'nt' and toolchain is not None and \
         toolchain.startswith ('CLANG') and 'BASETOOLS_MINGW_PATH' in config:
-        command = ["mingw32-make"]
+        command = ["mingw32-make", "-C", silicon_tools_directory]
     if os.name == "posix":  # linux
-        command = ["make"]
+        command = ["make", "-C", silicon_tools_directory]
         # add path to generated FitGen binary to
         # environment path variable
         config["PATH"] += os.pathsep + \
@@ -297,9 +295,6 @@ def pre_build(build_config, build_type="DEBUG", silent=False, toolchain=None, sk
         _, _, result, return_code = execute_script(command, config, shell=shell)
         if return_code != 0:
             build_failed(config)
-
-    # restore WORKSPACE environment variable
-    config["WORKSPACE"] = saved_work_directory
 
     config["SILENT_MODE"] = 'TRUE' if silent else 'FALSE'
 

--- a/Silicon/Intel/Tools/GNUmakefile
+++ b/Silicon/Intel/Tools/GNUmakefile
@@ -7,22 +7,37 @@
 ##
 
 MAKEROOT = $(EDK_TOOLS_PATH)/Source/C
+ifneq ($(WORKSPACE),)
+  BUILDROOT=$(WORKSPACE)/BaseTools/Build/Source/C
+else
+  BUILDROOT=$(abspath $(MAKEROOT))
+endif
+
+ifeq (Windows, $(findstring Windows,$(OS)))
+  SEP:=$(shell echo \)
+else
+  SEP:=/
+endif
+
+GNU_MAKE_UTILS_PY := $(PYTHON_COMMAND) $(MAKEROOT)$(SEP)Makefiles$(SEP)GnuMakeUtils.py
+MD := $(GNU_MAKE_UTILS_PY) md
 
 APPLICATIONS = \
   FitGen \
 
 SUBDIRS := $(APPLICATIONS)
 
-$(APPLICATIONS): $(MAKEROOT)/bin
+$(APPLICATIONS): $(BUILDROOT)/bin
 
 .PHONY: subdirs $(SUBDIRS)
 subdirs: $(SUBDIRS)
 $(SUBDIRS):
-	$(MAKE) -C $@
+	$(MD) $(BUILDROOT)/$@
+	$(MAKE) OBJDIR=$(BUILDROOT)/$@ BUILDROOT=$(BUILDROOT) -C $@
 
 .PHONY: $(patsubst %,%-clean,$(sort $(SUBDIRS)))
 $(patsubst %,%-clean,$(sort $(SUBDIRS))):
-	-$(MAKE) -C $(@:-clean=) clean
+	-$(MAKE) OBJDIR=$(BUILDROOT)/$(@:-clean=) BUILDROOT=$(BUILDROOT) -C $(@:-clean=) clean
 
 clean: $(patsubst %,%-clean,$(sort $(SUBDIRS)))
 


### PR DESCRIPTION
Fix Intel tool build broken by f3ae34350b ("BaseTools: Add support for out-of-tree builds"):

- Adopt makefiles to provide the variables expected by app.makefile
- Do not change WORKSPACE just for the Intel tools, use the common one for all tools' builds.