### PR TITLE
Platform/ARM/VExpressPkg: support runtime capsule update

### DIFF
--- a/Platform/ARM/Features/Fwu/FmpSystemFipImageRuntime.dsc.inc
+++ b/Platform/ARM/Features/Fwu/FmpSystemFipImageRuntime.dsc.inc
@@ -1,0 +1,121 @@
+#/** @file
+# FmpDxe driver for AArch64 firmware update.
+#
+#  Copyright (c) 2024, Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+#**/
+[Defines]
+  # System fip firmware image type guid.
+  # This will be the filename of FmpDevicePkg and used to find firmware image
+  DEFINE FMP_SYSTEM_FIP_IMAGE_GUID = 49757D90-6C22-11EE-A556-1757EBA0420C
+
+[PcdsPatchableInModule.common]
+  #
+  # Firmware Update
+  #
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSystemFmpCapsuleImageTypeIdGuid|{GUID("$(FMP_SYSTEM_FIP_IMAGE_GUID)")}|VOID*|0x10
+
+[Components.common]
+  MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
+  MdeModulePkg/Application/CapsuleApp/CapsuleApp.inf {
+    <LibraryClasses>
+      PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+      BmpSupportLib|MdeModulePkg/Library/BaseBmpSupportLib/BaseBmpSupportLib.inf
+  }
+
+  FmpDevicePkg/FmpDxe/FmpDxeRuntime.inf {
+    <Defines>
+      #
+      # ESRT and FMP GUID for system firmware capsule update
+      #
+      FILE_GUID = $(FMP_SYSTEM_FIP_IMAGE_GUID)
+
+    <PcdsFixedAtBuild>
+      #
+      # Unicode name string that is used to populate FMP Image Descriptor for this capsule update module
+      #
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceImageIdName|L"System Fip Firmware Image"
+
+      #
+      # ESRT and FMP Lowest Support Version for this capsule update module
+      # 000.000.000.000
+      #
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceBuildTimeLowestSupportedVersion|0x00000000
+
+      gPlatformArmTokenSpaceGuid.PcdSystemFirmwareFmpLowestSupportedVersion|0x00000000
+      gPlatformArmTokenSpaceGuid.PcdSystemFirmwareFmpVersion|0x00000000
+      gPlatformArmTokenSpaceGuid.PcdSystemFirmwareFmpVersionString|"000.000.000.000"
+
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceProgressWatchdogTimeInSeconds|4
+
+      #
+      # Lock all updatable firmware devices at Exit boot Services.
+      # This allows to update firmware via CapsuleApp.
+      #
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceLockEventGuid|{GUID(gEfiEventExitBootServicesGuid)}
+
+      #
+      # Capsule Update Progress Bar Color.  Set to Purple (RGB) (255, 0, 255)
+      #
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceProgressColor|0x00FF00FF
+
+      #
+      # Certificates used to authenticate capsule update image
+      # This certificate converted to pcd format using BinToPcd.py
+      #
+      #
+      # Certificate used for FmpDevicePkg.
+      #
+      # Without generating Pcd certificate file, we couldn't build properly
+      # when ENABLE_FIRMWARE_UPDATE == TRUE.
+      #
+      # If you have your own certificate chain,
+      # Please generate the Pcd file with your Root certificate:
+      #     openssl x509 -in {ROOT_CERT_FILE} -out Root.cer -outform DER
+      #     BinToPcd.py -i Root.cer gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr \
+      #                 -x -o {CERT_PCD_FILE_PATH}
+      # And Build with:
+      #    -D FMP_SYSTEM_FIP_CERT_PCD_FILE={CERT_PCD_FILE_PATH}
+      #
+      # For test and development, you can generate all test certificate change and
+      # the Pcd file with:
+      #     python3 Features/Fwu/GenTestCert.py
+      #
+      # NOTE: This tool should run after edk2 build setup.
+      #
+      # The tool genreates all test certificates chain in 'TestCert' directory
+      # and generate below then Pcd file in.
+      #
+      #    Platform/ARM/VExpressPkg/Root.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
+      #
+      #
+      # And Build with:
+      #    -D FMP_SYSTEM_FIP_CERT_PCD_FILE=Platform/ARM/VExpressPkg/Root.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
+      #
+      #
+      !include $(FMP_SYSTEM_FIP_CERT_PCD_FILE)
+
+    <LibraryClasses>
+      #
+      # Generic libraries that are used "as is" by all FMP modules
+      #
+      FmpPayloadHeaderLib|FmpDevicePkg/Library/FmpPayloadHeaderLibV1/FmpPayloadHeaderLibV1.inf
+      FmpAuthenticationLib|SecurityPkg/Library/FmpAuthenticationLibPkcs7/FmpAuthenticationRuntimeLibPkcs7.inf
+      FmpDependencyLib|FmpDevicePkg/Library/FmpDependencyLib/FmpDependencyLib.inf
+      FmpDependencyCheckLib|FmpDevicePkg/Library/FmpDependencyCheckLibNull/FmpDependencyCheckLibNull.inf
+      FmpDependencyDeviceLib|FmpDevicePkg/Library/FmpDependencyDeviceLibNull/FmpDependencyDeviceLibNull.inf
+      #
+      # Platform specific capsule policy library
+      #
+      CapsuleUpdatePolicyLib|Platform/ARM/Library/CapsuleUpdateRuntimePolicyLib/CapsuleUpdateRuntimePolicyLib.inf
+      #
+      # Device specific library that processes a capsule and updates the FW storage device
+      #
+      FmpDeviceLib|ArmPkg/Library/FmpDevicePsaFwuLib/FmpDevicePsaFwuLib.inf
+
+    <PcdsFixedAtBuild>
+      gEfiMdeModulePkgTokenSpaceGuid.PcdRuntimeMemoryPageCount|2560
+  }

--- a/Platform/ARM/Features/Fwu/FmpSystemFipImageRuntime.fdf.inc
+++ b/Platform/ARM/Features/Fwu/FmpSystemFipImageRuntime.fdf.inc
@@ -1,0 +1,13 @@
+#/** @file
+# FmpDxe driver for AArch64 firmware update.
+#
+#  Copyright (c) 2025, Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+#**/
+
+  INF MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
+  INF MdeModulePkg/Application/CapsuleApp/CapsuleApp.inf
+  INF FILE_GUID = $(FMP_SYSTEM_FIP_IMAGE_GUID) FmpDevicePkg/FmpDxe/FmpDxeRuntime.inf

--- a/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
@@ -54,7 +54,7 @@
 !include DynamicTablesPkg/DynamicTables.dsc.inc
 
 !if $(ENABLE_FIRMWARE_UPDATE) == TRUE
-!include Platform/ARM/Features/Fwu/FmpSystemFipImage.dsc.inc
+!include Platform/ARM/Features/Fwu/FmpSystemFipImageRuntime.dsc.inc
 !endif
 
 [LibraryClasses.common]
@@ -129,6 +129,7 @@
   ## Disable Runtime Variable Cache.
   gEfiMdeModulePkgTokenSpaceGuid.PcdEnableVariableRuntimeCache|FALSE
 !endif
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportProcessCapsuleAtRuntime|TRUE
 
 [PcdsFixedAtBuild.common]
   # Only one core enters UEFI, and PSCI is implemented in EL3 by TF-A

--- a/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.fdf
+++ b/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.fdf
@@ -227,7 +227,7 @@ FvNameGuid         = 87940482-fc81-41c3-87e6-399cf85ac8a0
   # Firmware update
   #
 !if $(ENABLE_FIRMWARE_UPDATE) == TRUE
-  !include Platform/ARM/Features/Fwu/FmpSystemFipImage.fdf.inc
+  !include Platform/ARM/Features/Fwu/FmpSystemFipImageRuntime.fdf.inc
 !endif
 
 !if $(ENABLE_TPM) == TRUE

--- a/Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
@@ -72,6 +72,7 @@
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   UefiDecompressLib|MdePkg/Library/BaseUefiDecompressLib/BaseUefiDecompressLib.inf
   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
+  RuntimeMemoryAllocationLib|MdeModulePkg/Library/RuntimeMemoryAllocationLib/RuntimeMemoryAllocationLibNull.inf
 
   UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
@@ -287,6 +288,7 @@
   ArmFfaLib|MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+  RuntimeMemoryAllocationLib|MdeModulePkg/Library/RuntimeMemoryAllocationLib/RuntimeMemoryAllocationLib.inf
 !if $(ENABLE_FIRMWARE_UPDATE) == TRUE
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
 !else
@@ -294,9 +296,7 @@
 !endif
   ReportStatusCodeLib|MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/RuntimeDxeReportStatusCodeLib.inf
   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLibRuntimeDxe.inf
-!if $(SECURE_BOOT_ENABLE) == TRUE
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
-!endif
 !if $(TARGET) != RELEASE
   DebugLib|MdePkg/Library/DxeRuntimeDebugLibSerialPort/DxeRuntimeDebugLibSerialPort.inf
 !endif


### PR DESCRIPTION
This is runtime capsule update support with FmpDxeRuntime Driver.

Formerly, to update the firmware with capsule in FVP with fwupd, it follows below step:
  1. Locate Capsule in specific location
  2. reboot with DxeDriver to update firmware with capsule provided by fwupd.
  3. Firmware Update Dxe driver calls ProcessFmpImage() and update firmware with Capsule
  4. reboot to apply firmware.

These step requires 2 times of reboot -- first for update firmware and second to apply firmware.

With the runtime capsule update support, It could remove (2) and (3) steps.

Link: https://github.com/tianocore/edk2/pull/12193 [0]
