### PR TITLE
Platform/ARM/VExpressPkg: fix build failure for InitailiseProcStrings()

### DIFF
--- a/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
+++ b/Platform/ARM/VExpressPkg/ConfigurationManager/ConfigurationManagerDxe/ConfigurationManager.c
@@ -1438,25 +1438,6 @@ PopulatePlatformTpmInfoFfa (
   return EFI_SUCCESS;
 }
 
-STATIC
-EFI_STATUS
-InitialiseProcStrings (
-  )
-{
-  EFI_STATUS  Status;
-  UINTN       Index;
-
-  for (Index = 0; Index < ARRAY_SIZE (StringMapping); Index++) {
-    Status = CopyString (StringMapping[Index].Src, StringMapping[Index].Dest, StringMapping[Index].Length);
-
-    if (Status != EFI_SUCCESS) {
-      break;
-    }
-  }
-
-  return Status;
-}
-
 /** Initialize the platform TPM information.
 
   @param [in]  This        Pointer to the Configuration Manager Protocol.
@@ -1482,6 +1463,25 @@ PopulatePlatformTpmInfo (
   return Status;
 }
 #endif
+
+STATIC
+EFI_STATUS
+InitialiseProcStrings (
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Index;
+
+  for (Index = 0; Index < ARRAY_SIZE (StringMapping); Index++) {
+    Status = CopyString (StringMapping[Index].Src, StringMapping[Index].Dest, StringMapping[Index].Length);
+
+    if (Status != EFI_SUCCESS) {
+      break;
+    }
+  }
+
+  return Status;
+}
 
 /** Initialize the platform configuration repository.
 


### PR DESCRIPTION
commit fa884a143e2ba ("Platform/ARM/VExpressPkg: add fTPM information")
make a mistack including InitialiseProcStrings() into ENABLE_TPM guard
so it triggers build failure when ENABLE_TPM is disabled.
    
Fixes: fa884a143e2ba ("Platform/ARM/VExpressPkg: add fTPM information")
Signed-off-by: Yeoreum Yun <yeoreum.yun@arm.com>
