### PR TITLE
AmdPlatformPkg: Fix Potential Buffer Over-read in HiiConfigToBlock

### DIFF
--- a/Platform/AMD/AmdPlatformPkg/Universal/HiiConfigRouting/AmdHiiConfigRouting.c
+++ b/Platform/AMD/AmdPlatformPkg/Universal/HiiConfigRouting/AmdHiiConfigRouting.c
@@ -1037,6 +1037,11 @@ HiiConfigToBlock (
       goto Exit;
     }
 
+    if (Width > (HiiNumber.NumberPtrLength + 1) / 2) {
+      DEBUG ((DEBUG_WARN, "HiiConfigToBlock: Value length is less than Width\n"));
+      Width = (HiiNumber.NumberPtrLength + 1) / 2;
+    }
+
     //
     // Update the Block with configuration info
     //


### PR DESCRIPTION
Adds a length check in HiiConfigToBlock to ensure that the Width parameter does not exceed the number of bytes actually parsed from the VALUE= hex string.

Example: If a string contains '&OFFSET=0000&WIDTH=0008&VALUE=FF', the code would previously attempt to copy 8 bytes from a buffer that only contains 1 byte of parsed data, leading to an out-of-bounds read of the internal HII_NUMBER buffer.