### PR TITLE
Features/ManageabilityPkg: Fix IPMI vulnerabilities and memory leak

### DIFF
--- a/Features/ManageabilityPkg/Universal/IpmiBlobTransferDxe/IpmiBlobTransferDxe.c
+++ b/Features/ManageabilityPkg/Universal/IpmiBlobTransferDxe/IpmiBlobTransferDxe.c
@@ -85,6 +85,7 @@ CalculateCrc16Ccitt (
                                     not used.
 
   @retval EFI_SUCCESS            Successfully sends blob data.
+  @retval EFI_BUFFER_TOO_SMALL   Response buffer too small to hold the response.
   @retval EFI_OUT_OF_RESOURCES   Memory allocation fails.
   @retval EFI_PROTOCOL_ERROR     Communication errors.
   @retval EFI_CRC_ERROR          Data integrity checks fail.
@@ -172,6 +173,7 @@ IpmiBlobTransferSendIpmi (
 
   IpmiResponseData = AllocateZeroPool (IpmiResponseDataSize);
   if (IpmiResponseData == NULL) {
+    FreePool (IpmiSendData);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -200,7 +202,14 @@ IpmiBlobTransferSendIpmi (
   DEBUG_CODE_END ();
 
   if (EFI_ERROR (Status)) {
+    FreePool (IpmiResponseData);
     return Status;
+  }
+
+  if (IpmiResponseDataSize < sizeof (CompletionCode)) {
+    DEBUG ((DEBUG_ERROR, "%a: Response too short for Completion Code: %u bytes\n", __func__, IpmiResponseDataSize));
+    FreePool (IpmiResponseData);
+    return EFI_PROTOCOL_ERROR;
   }
 
   CompletionCode = *ModifiedResponseData;
@@ -214,6 +223,12 @@ IpmiBlobTransferSendIpmi (
   ModifiedResponseData  = ModifiedResponseData + sizeof (CompletionCode);
   IpmiResponseDataSize -= sizeof (CompletionCode);
 
+  if (IpmiResponseDataSize < sizeof (OpenBmcOen)) {
+    DEBUG ((DEBUG_ERROR, "%a: Response too short for OEN: %u bytes\n", __func__, IpmiResponseDataSize));
+    FreePool (IpmiResponseData);
+    return EFI_PROTOCOL_ERROR;
+  }
+
   // Check OEN code and verify it matches the OpenBMC OEN
   CopyMem (Oen, ModifiedResponseData, sizeof (OpenBmcOen));
   if (CompareMem (Oen, OpenBmcOen, sizeof (OpenBmcOen)) != 0) {
@@ -221,7 +236,11 @@ IpmiBlobTransferSendIpmi (
     return EFI_PROTOCOL_ERROR;
   }
 
-  if (IpmiResponseDataSize == sizeof (OpenBmcOen)) {
+  // Strip the OEN, we are done with it now
+  ModifiedResponseData  = ModifiedResponseData + sizeof (Oen);
+  IpmiResponseDataSize -= sizeof (Oen);
+
+  if (IpmiResponseDataSize == 0) {
     //
     // In this case, there was no response data sent. This is not an error.
     // Some messages do not require a response.
@@ -234,9 +253,12 @@ IpmiBlobTransferSendIpmi (
     return Status;
     // Now we need to validate the CRC then send the Response body back
   } else {
-    // Strip the OEN, we are done with it now
-    ModifiedResponseData  = ModifiedResponseData + sizeof (Oen);
-    IpmiResponseDataSize -= sizeof (Oen);
+    if (IpmiResponseDataSize < sizeof (Crc)) {
+      DEBUG ((DEBUG_ERROR, "%a: Response too short for CRC: %u bytes\n", __func__, IpmiResponseDataSize));
+      FreePool (IpmiResponseData);
+      return EFI_PROTOCOL_ERROR;
+    }
+
     // Then validate the Crc
     CopyMem (&Crc, ModifiedResponseData, sizeof (Crc));
     ModifiedResponseData  = ModifiedResponseData + sizeof (Crc);
@@ -244,8 +266,14 @@ IpmiBlobTransferSendIpmi (
 
     if (Crc == CalculateCrc16Ccitt (ModifiedResponseData, IpmiResponseDataSize)) {
       if ((ResponseData != NULL) && (ResponseDataSize != NULL)) {
+        if (IpmiResponseDataSize > *ResponseDataSize) {
+          DEBUG ((DEBUG_ERROR, "%a: Response too large for buffer: %u > %u\n", __func__, IpmiResponseDataSize, *ResponseDataSize));
+          FreePool (IpmiResponseData);
+          return EFI_BUFFER_TOO_SMALL;
+        }
+
         CopyMem (ResponseData, ModifiedResponseData, IpmiResponseDataSize);
-        CopyMem (ResponseDataSize, &IpmiResponseDataSize, sizeof (IpmiResponseDataSize));
+        *ResponseDataSize = IpmiResponseDataSize;
       }
 
       FreePool (IpmiResponseData);

--- a/Features/ManageabilityPkg/Universal/IpmiBlobTransferDxe/UnitTest/IpmiBlobTransferTestUnitTests.c
+++ b/Features/ManageabilityPkg/Universal/IpmiBlobTransferDxe/UnitTest/IpmiBlobTransferTestUnitTests.c
@@ -171,6 +171,178 @@ SendIpmiBadCompletion (
 **/
 UNIT_TEST_STATUS
 EFIAPI
+SendIpmiResponseTooShort (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID        *ResponseData;
+  UINT32      *ResponseDataSize;
+  EFI_STATUS  Status;
+  VOID        *MockResponseResults = NULL;
+  UINT32      MockResponseSize     = 0;
+
+  // Too short for completion code
+  MockResponseSize = 0;
+  ResponseDataSize = (UINT32 *)AllocateZeroPool (sizeof (UINT32));
+
+  MockIpmiSubmitCommand (NULL, MockResponseSize, EFI_SUCCESS);
+
+  ResponseData = (UINT8 *)AllocateZeroPool (10);
+  Status       = IpmiBlobTransferSendIpmi (IpmiBlobTransferSubcommandGetCount, NULL, 0, ResponseData, ResponseDataSize);
+
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_PROTOCOL_ERROR);
+
+  FreePool (ResponseDataSize);
+  FreePool (ResponseData);
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+SendIpmiResponseTooShortForOen (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID        *ResponseData;
+  UINT32      *ResponseDataSize;
+  EFI_STATUS  Status;
+  VOID        *MockResponseResults = NULL;
+  UINT32      MockResponseSize     = 1;
+
+  // Only has completion code, too short for OEN
+  MockResponseResults = (UINT8 *)AllocateZeroPool (MockResponseSize);
+  ResponseDataSize    = (UINT32 *)AllocateZeroPool (sizeof (UINT32));
+  *(UINT8 *)MockResponseResults = 0; // Success completion code
+
+  MockIpmiSubmitCommand ((UINT8 *)MockResponseResults, MockResponseSize, EFI_SUCCESS);
+
+  ResponseData = (UINT8 *)AllocateZeroPool (10);
+  Status       = IpmiBlobTransferSendIpmi (IpmiBlobTransferSubcommandGetCount, NULL, 0, ResponseData, ResponseDataSize);
+
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_PROTOCOL_ERROR);
+
+  FreePool (MockResponseResults);
+  FreePool (ResponseDataSize);
+  FreePool (ResponseData);
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+SendIpmiResponseTooLarge (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID        *ResponseData;
+  UINT32      *ResponseDataSize;
+  EFI_STATUS  Status;
+  VOID        *MockResponseResults = NULL;
+  UINT32      MockResponseSize     = 10;
+  UINT8       LargeResponse[]      = {
+    0x00,                         // CompletionCode
+    0xCF, 0xC2, 0x00,             // OpenBMC OEN
+    0x00, 0x00,                   // CRC (doesn't matter as we fail before check)
+    0x01, 0x02, 0x03, 0x04        // Data
+  };
+
+  // Response says 4 bytes of data, but caller only provides 2 bytes buffer
+  MockResponseResults = (UINT8 *)AllocateZeroPool (sizeof (LargeResponse));
+  ResponseDataSize    = (UINT32 *)AllocateZeroPool (sizeof (UINT32));
+  *ResponseDataSize   = 2; // Caller buffer size
+  CopyMem (MockResponseResults, LargeResponse, sizeof (LargeResponse));
+
+  // We need valid CRC for it to reach the size check
+  UINT16  CorrectCrc = CalculateCrc16Ccitt (LargeResponse + 6, 4);
+  CopyMem (MockResponseResults + 4, &CorrectCrc, sizeof (UINT16));
+
+  MockIpmiSubmitCommand ((UINT8 *)MockResponseResults, sizeof (LargeResponse), EFI_SUCCESS);
+
+  ResponseData = (UINT8 *)AllocateZeroPool (*ResponseDataSize);
+  Status       = IpmiBlobTransferSendIpmi (IpmiBlobTransferSubcommandGetCount, NULL, 0, ResponseData, ResponseDataSize);
+
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_BUFFER_TOO_SMALL);
+
+  FreePool (MockResponseResults);
+  FreePool (ResponseDataSize);
+  FreePool (ResponseData);
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+SendIpmiSubmitCommandError (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID        *ResponseData;
+  UINT32      *ResponseDataSize;
+  EFI_STATUS  Status;
+
+  ResponseDataSize  = (UINT32 *)AllocateZeroPool (sizeof (UINT32));
+  *ResponseDataSize = 10;
+
+  MockIpmiSubmitCommand (NULL, 0, EFI_DEVICE_ERROR);
+
+  ResponseData = (UINT8 *)AllocateZeroPool (*ResponseDataSize);
+  Status       = IpmiBlobTransferSendIpmi (IpmiBlobTransferSubcommandGetCount, NULL, 0, ResponseData, ResponseDataSize);
+
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_DEVICE_ERROR);
+
+  FreePool (ResponseDataSize);
+  FreePool (ResponseData);
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
 SendIpmiNoDataResponse (
   IN UNIT_TEST_CONTEXT  Context
   )
@@ -1050,6 +1222,10 @@ SetupAndRunUnitTests (
   Status = AddTestCase (IpmiBlobTransfer, "Test Bad CRC Calculation", "BadCrc", BadCrc, NULL, NULL, NULL);
   // IpmiBlobTransferSendIpmi
   Status = AddTestCase (IpmiBlobTransfer, "Send IPMI returns bad completion", "SendIpmiBadCompletion", SendIpmiBadCompletion, NULL, NULL, NULL);
+  Status = AddTestCase (IpmiBlobTransfer, "Send IPMI returns response too short", "SendIpmiResponseTooShort", SendIpmiResponseTooShort, NULL, NULL, NULL);
+  Status = AddTestCase (IpmiBlobTransfer, "Send IPMI returns response too short for OEN", "SendIpmiResponseTooShortForOen", SendIpmiResponseTooShortForOen, NULL, NULL, NULL);
+  Status = AddTestCase (IpmiBlobTransfer, "Send IPMI returns response too large for buffer", "SendIpmiResponseTooLarge", SendIpmiResponseTooLarge, NULL, NULL, NULL);
+  Status = AddTestCase (IpmiBlobTransfer, "Send IPMI returns error from SubmitCommand", "SendIpmiSubmitCommandError", SendIpmiSubmitCommandError, NULL, NULL, NULL);
   Status = AddTestCase (IpmiBlobTransfer, "Send IPMI returns successfully with no data", "SendIpmiNoDataResponse", SendIpmiNoDataResponse, NULL, NULL, NULL);
   Status = AddTestCase (IpmiBlobTransfer, "Send IPMI returns successfully with bad OEN", "SendIpmiBadOenResponse", SendIpmiBadOenResponse, NULL, NULL, NULL);
   Status = AddTestCase (IpmiBlobTransfer, "Send IPMI returns successfully with bad CRC", "SendIpmiBadCrcResponse", SendIpmiBadCrcResponse, NULL, NULL, NULL);


### PR DESCRIPTION
Fix vulnerabilities and a memory leak in the IPMI Blob Transfer driver:
- Prevent integer underflow and OOB read by validating response size before accessing CompletionCode, OEN, and CRC.
- Prevent buffer overflow by ensuring BMC response size does not exceed the caller's buffer capacity, avoiding potential memory overwriting.
- Fix memory leak by freeing IpmiResponseData and IpmiSendData.