### PR TITLE
Platform/ARM/Library: FwsGptSystemLib: fix wrong sanity check of FWS Metadata

### DIFF
--- a/Platform/ARM/Features/Fwu/Readme.md
+++ b/Platform/ARM/Features/Fwu/Readme.md
@@ -368,4 +368,7 @@ You can test using Capsule Image generated in **How to generate Capsule Image** 
 
 # References
 [1] https://developer.arm.com/products/system-design/fixed-virtual-platforms
+
 [2] https://trustedfirmware-a.readthedocs.io/en/latest/getting_started/tools-build.html
+
+[3] https://developer.arm.com/documentation/den0118/latest/

--- a/Platform/ARM/Library/FwsGptSystemFipLib/FwsMetadataV2Ops.c
+++ b/Platform/ARM/Library/FwsGptSystemFipLib/FwsMetadataV2Ops.c
@@ -170,7 +170,7 @@ ValidateMetadataV2 (
     }
   }
 
-  for (BankIdx = FwFwsDesc->NumBanks; BankIdx < FwFwsDesc->NumBanks; BankIdx++) {
+  for (BankIdx = FwFwsDesc->NumBanks; BankIdx < FWU_METADATA_V2_MAX_NUM_BANKS; BankIdx++) {
     if (Metadata->BankState[BankIdx] != FWU_BANK_STATE_INVALID) {
       DEBUG ((
         DEBUG_ERROR,

--- a/Platform/ARM/Library/FwsGptSystemFipLib/FwsMetadataV2Ops.c
+++ b/Platform/ARM/Library/FwsGptSystemFipLib/FwsMetadataV2Ops.c
@@ -138,7 +138,8 @@ ValidateMetadataV2 (
 
   for (BankIdx = 0; BankIdx < FwFwsDesc->NumBanks; BankIdx++) {
     if ((Metadata->BankState[BankIdx] != FWU_BANK_STATE_VALID) &&
-        (Metadata->BankState[BankIdx] != FWU_BANK_STATE_ACCEPTED))
+        (Metadata->BankState[BankIdx] != FWU_BANK_STATE_ACCEPTED) &&
+        (Metadata->BankState[BankIdx] != FWU_BANK_STATE_INVALID))
     {
       DEBUG ((
         DEBUG_ERROR,


### PR DESCRIPTION
This patch set is to fix some wrong sanity check on FWS Metadata:

  - Missing valid state value.
  - Dead loop for wrong loop condition.
  - Documents fix.