### PR TITLE
When configuring the system to clear the user password,

### DIFF
--- a/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMm.inf
+++ b/Features/Intel/UserInterface/UserAuthFeaturePkg/UserAuthenticationDxeSmm/UserAuthenticationStandaloneMm.inf
@@ -56,4 +56,4 @@
   gEdkiiSmmLegacyBootProtocolGuid               ## CONSUMES
 
 [Depex]
-  gEfiSmmVariableProtocolGuid
+  gEfiSmmVariableProtocolGuid AND gSmmVariableWriteGuid


### PR DESCRIPTION
the direct variable update in PasswordSmmInit fails with an EFI_NOT_AVAILABLE_YET error. This occurs because the initial NV variable write relies on the EFI_VARIABLE_WRITE_ARCH_PROTOCOL, which has not yet been installed during the early DXE/SMM init phase.