### PR TITLE
CODEOWNERS: add Ricardo Salveti for Qualcomm Silicon/Platforms

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -96,8 +96,8 @@
 /Silicon/Qemu/SbsaQemu/** @ardbiesheuvel @leiflindholm
 
 # Qualcomm platforms and silicon
-/Platform/Qualcomm/** @leiflindholm @b49020
-/Silicon/Qualcomm/** @leiflindholm @b49020
+/Platform/Qualcomm/** @leiflindholm @b49020 @ricardosalveti
+/Silicon/Qualcomm/** @leiflindholm @b49020 @ricardosalveti
 
 # Raspberry Pi platforms and silicon
 /Platform/RaspberryPi/** @ardbiesheuvel @leiflindholm

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -53,6 +53,7 @@ out-of-sync with CODEOWNERS and/or REVIEWERS over time and need an occasional re
 | Peng Xie               | xiepeng@phytium.com.cn           |                                                      |
 | Ran Wang               | wangran@bosc.ac.cn               |                                                      |
 | Ray Ni                 | ray.ni@intel.com                 | [@niruiyu](https://github.com/niruiyu)               |
+| Ricardo Salveti        | ricardo.salveti@oss.qualcomm.com | [@ricardosalveti](https://github.com/ricardosalveti) |
 | Rebecca Cran           | rebecca@os.amperecomputing.com   | [@bexcran](https://github.com/bexcran)               |
 | Sai Chaganty           | rangasai.v.chaganty@intel.com    | [@SaiChaganty](https://github.com/SaiChaganty)       |
 | Saloni Kasbekar        | saloni.kasbekar@intel.com        | [@SaloniKasbekar](https://github.com/SaloniKasbekar) |


### PR DESCRIPTION
Add Ricardo Salveti de Araujo as a maintainer for Qualcomm platforms and silicon.