### PR TITLE
Global: Include AcpiHelperMacros.h for ACPI helper macros

### DIFF
--- a/Platform/ARM/SgiPkg/AcpiTables/Dbg2.aslc
+++ b/Platform/ARM/SgiPkg/AcpiTables/Dbg2.aslc
@@ -14,8 +14,8 @@
       /acpi-debug-port-table
 **/
 
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/DebugPort2Table.h>
-#include <Library/AcpiLib.h>
 #include "SgiAcpiHeader.h"
 
 #define SGI_DBG2_NUM_DEBUG_PORTS           1
@@ -54,7 +54,7 @@ typedef struct {
     OFFSET_OF (DBG2_DEBUG_DEVICE_INFORMATION, BaseAddressRegister), /* UINT16    BaseAddressRegister Offset */      \
     OFFSET_OF (DBG2_DEBUG_DEVICE_INFORMATION, AddressSize)          /* UINT16    AddressSize Offset */              \
   },                                                                                                                \
-  ARM_GAS32 (UartBase),                            /* EFI_ACPI_6_4_GENERIC_ADDRESS_STRUCTURE BaseAddressRegister */ \
+  ACPI_GAS32 (UartBase),                           /* EFI_ACPI_6_4_GENERIC_ADDRESS_STRUCTURE BaseAddressRegister */ \
   UartAddrLen,                                     /* UINT32  AddressSize */                                        \
   UartNameStr                                      /* UINT8   NameSpaceString[MAX_DBG2_NAME_LEN] */                 \
 }

--- a/Platform/ARM/SgiPkg/AcpiTables/Fadt.aslc
+++ b/Platform/ARM/SgiPkg/AcpiTables/Fadt.aslc
@@ -14,7 +14,7 @@
     - ACPI 6.4, Chapter 5, Section 5.2.9, Fixed ACPI Description Table
 **/
 
-#include <Library/AcpiLib.h>
+#include <AcpiHelperMacros.h>
 #include "SgiAcpiHeader.h"
 
 STATIC EFI_ACPI_6_4_FIXED_ACPI_DESCRIPTION_TABLE Fadt = {
@@ -61,22 +61,22 @@ STATIC EFI_ACPI_6_4_FIXED_ACPI_DESCRIPTION_TABLE Fadt = {
   0,                                                                        // UINT16     IaPcBootArch
   0,                                                                        // UINT8      Reserved1
   EFI_ACPI_6_4_HW_REDUCED_ACPI | EFI_ACPI_6_4_LOW_POWER_S0_IDLE_CAPABLE,    // UINT32     Flags
-  NULL_GAS,                                                                 // GAS        ResetReg
+  ACPI_NULL_GAS,                                                            // GAS        ResetReg
   0,                                                                        // UINT8      ResetValue
   EFI_ACPI_6_4_ARM_PSCI_COMPLIANT,                                          // UINT16     ArmBootArchFlags
   EFI_ACPI_6_4_FIXED_ACPI_DESCRIPTION_TABLE_MINOR_REVISION,                 // UINT8      MinorRevision
   0,                                                                        // UINT64     XFirmwareCtrl
   0,                                                                        // UINT64     XDsdt
-  NULL_GAS,                                                                 // GAS        XPm1aEvtBlk
-  NULL_GAS,                                                                 // GAS        XPm1bEvtBlk
-  NULL_GAS,                                                                 // GAS        XPm1aCntBlk
-  NULL_GAS,                                                                 // GAS        XPm1bCntBlk
-  NULL_GAS,                                                                 // GAS        XPm2CntBlk
-  NULL_GAS,                                                                 // GAS        XPmTmrBlk
-  NULL_GAS,                                                                 // GAS        XGpe0Blk
-  NULL_GAS,                                                                 // GAS        XGpe1Blk
-  NULL_GAS,                                                                 // GAS        SleepControlReg
-  NULL_GAS,                                                                 // GAS        SleepStatusReg
+  ACPI_NULL_GAS,                                                            // GAS        XPm1aEvtBlk
+  ACPI_NULL_GAS,                                                            // GAS        XPm1bEvtBlk
+  ACPI_NULL_GAS,                                                            // GAS        XPm1aCntBlk
+  ACPI_NULL_GAS,                                                            // GAS        XPm1bCntBlk
+  ACPI_NULL_GAS,                                                            // GAS        XPm2CntBlk
+  ACPI_NULL_GAS,                                                            // GAS        XPmTmrBlk
+  ACPI_NULL_GAS,                                                            // GAS        XGpe0Blk
+  ACPI_NULL_GAS,                                                            // GAS        XGpe1Blk
+  ACPI_NULL_GAS,                                                            // GAS        SleepControlReg
+  ACPI_NULL_GAS,                                                            // GAS        SleepStatusReg
   0                                                                         // UINT64     HypervisorVendorIdentity;
 };
 

--- a/Platform/ARM/SgiPkg/AcpiTables/Spcr.aslc
+++ b/Platform/ARM/SgiPkg/AcpiTables/Spcr.aslc
@@ -15,8 +15,8 @@
       serial-port-console-redirection-table
 **/
 
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/SerialPortConsoleRedirectionTable.h>
-#include <Library/AcpiLib.h>
 #include "SgiAcpiHeader.h"
 
 STATIC EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE Spcr = {
@@ -34,7 +34,7 @@ STATIC EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE Spcr = {
     EFI_ACPI_RESERVED_BYTE
   },
   // EFI_ACPI_6_4_GENERIC_ADDRESS_STRUCTURE  BaseAddress;
-  ARM_GAS32 (FixedPcdGet64 (PcdSerialRegisterBase)),
+  ACPI_GAS32 (FixedPcdGet64 (PcdSerialRegisterBase)),
   // UINT8                                   InterruptType;
   EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_INTERRUPT_TYPE_GIC,
   // UINT8                                   Irq;

--- a/Platform/RaspberryPi/AcpiTables/Dbg2MiniUart.aslc
+++ b/Platform/RaspberryPi/AcpiTables/Dbg2MiniUart.aslc
@@ -9,10 +9,10 @@
  *
  **/
 
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/Bcm2836.h>
 #include <IndustryStandard/RpiDebugPort2Table.h>
-#include <Library/AcpiLib.h>
 #include <Library/PcdLib.h>
 
 #include "AcpiTables.h"
@@ -42,7 +42,7 @@
       OFFSET_OF (DBG2_DEBUG_DEVICE_INFORMATION, BaseAddressRegister), /* UINT16    BaseAddressRegister Offset */      \
       OFFSET_OF (DBG2_DEBUG_DEVICE_INFORMATION, AddressSize)          /* UINT16    AddressSize Offset */              \
     },                                                                                                                \
-    ARM_GAS32 (UartBase),                            /* EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE BaseAddressRegister */ \
+    ACPI_GAS32 (UartBase),                           /* EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE BaseAddressRegister */ \
     UartAddrLen,                                     /* UINT32  AddressSize */                                        \
     UartNameStr                                      /* UINT8   NameSpaceString[MAX_DBG2_NAME_LEN] */                 \
   }

--- a/Platform/RaspberryPi/AcpiTables/Dbg2Pl011.aslc
+++ b/Platform/RaspberryPi/AcpiTables/Dbg2Pl011.aslc
@@ -9,10 +9,10 @@
  *
  **/
 
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/Bcm2836.h>
 #include <IndustryStandard/RpiDebugPort2Table.h>
-#include <Library/AcpiLib.h>
 #include <Library/PcdLib.h>
 
 #include "AcpiTables.h"
@@ -42,7 +42,7 @@
       OFFSET_OF (DBG2_DEBUG_DEVICE_INFORMATION, BaseAddressRegister), /* UINT16    BaseAddressRegister Offset */      \
       OFFSET_OF (DBG2_DEBUG_DEVICE_INFORMATION, AddressSize)          /* UINT16    AddressSize Offset */              \
     },                                                                                                                \
-    ARM_GAS32 (UartBase),                            /* EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE BaseAddressRegister */ \
+    ACPI_GAS32 (UartBase),                           /* EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE BaseAddressRegister */ \
     UartAddrLen,                                     /* UINT32  AddressSize */                                        \
     UartNameStr                                      /* UINT8   NameSpaceString[MAX_DBG2_NAME_LEN] */                 \
   }

--- a/Platform/RaspberryPi/AcpiTables/Fadt.aslc
+++ b/Platform/RaspberryPi/AcpiTables/Fadt.aslc
@@ -10,8 +10,8 @@
  *
  **/
 
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/Acpi.h>
-#include <Library/AcpiLib.h>
 #include <Library/PcdLib.h>
 
 #include "AcpiTables.h"
@@ -71,22 +71,22 @@ EFI_ACPI_6_3_FIXED_ACPI_DESCRIPTION_TABLE Fadt = {
   EFI_ACPI_RESERVED_BYTE,                                                   // UINT8      Reserved1
   EFI_ACPI_6_3_WBINVD | EFI_ACPI_6_3_SLP_BUTTON |                           // UINT32     Flags
   EFI_ACPI_6_3_HW_REDUCED_ACPI,
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  ResetReg
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  ResetReg
   0,                                                                        // UINT8      ResetValue
   EFI_ACPI_6_3_ARM_PSCI_COMPLIANT,                                          // UINT16     ArmBootArchFlags
   EFI_ACPI_6_3_FIXED_ACPI_DESCRIPTION_TABLE_MINOR_REVISION,                 // UINT8      MinorRevision
   0,                                                                        // UINT64     XFirmwareCtrl
   0,                                                                        // UINT64     XDsdt
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1aEvtBlk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1bEvtBlk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1aCntBlk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1bCntBlk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm2CntBlk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPmTmrBlk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XGpe0Blk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XGpe1Blk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  SleepControlReg
-  NULL_GAS                                                                  // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  SleepStatusReg
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1aEvtBlk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1bEvtBlk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1aCntBlk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1bCntBlk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm2CntBlk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPmTmrBlk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XGpe0Blk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XGpe1Blk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  SleepControlReg
+  ACPI_NULL_GAS                                                             // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  SleepStatusReg
 };
 
 //

--- a/Platform/RaspberryPi/AcpiTables/Madt.aslc
+++ b/Platform/RaspberryPi/AcpiTables/Madt.aslc
@@ -8,8 +8,8 @@
 *
 **/
 
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/Acpi.h>
-#include <Library/AcpiLib.h>
 #include <Library/ArmLib.h>
 #include <Library/PcdLib.h>
 

--- a/Platform/RaspberryPi/AcpiTables/SpcrMiniUart.aslc
+++ b/Platform/RaspberryPi/AcpiTables/SpcrMiniUart.aslc
@@ -8,10 +8,10 @@
 *
 **/
 
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/Bcm2836.h>
 #include <IndustryStandard/SerialPortConsoleRedirectionTable.h>
-#include <Library/AcpiLib.h>
 #include <Library/PcdLib.h>
 
 #include "AcpiTables.h"
@@ -37,7 +37,7 @@ STATIC EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE Spcr = {
     EFI_ACPI_RESERVED_BYTE
   },
   // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  BaseAddress;
-  ARM_GAS32 (RPI_UART_BASE_ADDRESS),
+  ACPI_GAS32 (RPI_UART_BASE_ADDRESS),
   // UINT8                                   InterruptType;
   EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_INTERRUPT_TYPE_GIC,
   // UINT8                                   Irq;

--- a/Platform/RaspberryPi/AcpiTables/SpcrPl011.aslc
+++ b/Platform/RaspberryPi/AcpiTables/SpcrPl011.aslc
@@ -8,10 +8,10 @@
 *
 **/
 
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/Bcm2836.h>
 #include <IndustryStandard/SerialPortConsoleRedirectionTable.h>
-#include <Library/AcpiLib.h>
 #include <Library/PcdLib.h>
 
 #include "AcpiTables.h"
@@ -37,7 +37,7 @@ STATIC EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE Spcr = {
     EFI_ACPI_RESERVED_BYTE
   },
   // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  BaseAddress;
-  ARM_GAS32 (RPI_UART_BASE_ADDRESS),
+  ACPI_GAS32 (RPI_UART_BASE_ADDRESS),
   // UINT8                                   InterruptType;
   EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_INTERRUPT_TYPE_GIC,
   // UINT8                                   Irq;

--- a/Silicon/Ampere/AmpereAltraPkg/AcpiCommonTables/Dbg2.aslc
+++ b/Silicon/Ampere/AmpereAltraPkg/AcpiCommonTables/Dbg2.aslc
@@ -6,12 +6,12 @@
 
 **/
 
-#include <Library/AcpiLib.h>
 #include <Library/ArmLib.h>
 #include <Library/PcdLib.h>
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/DebugPort2Table.h>
 #include <AcpiHeader.h>
+#include <AcpiHelperMacros.h>
 
 #pragma pack(1)
 
@@ -50,7 +50,7 @@ typedef struct {
       OFFSET_OF (DBG2_DEBUG_DEVICE_INFORMATION, BaseAddressRegister), /* UINT16    BaseAddressRegister Offset */      \
       OFFSET_OF (DBG2_DEBUG_DEVICE_INFORMATION, AddressSize)          /* UINT16    AddressSize Offset */              \
     },                                                                                                                \
-    ARM_GAS32 (UartBase),                            /* EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE BaseAddressRegister */ \
+    ACPI_GAS32 (UartBase),                           /* EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE BaseAddressRegister */ \
     UartAddrLen,                                     /* UINT32  AddressSize */                                        \
     UartNameStr                                      /* UINT8   NameSpaceString[DBG2_NAMESPACESTRING_FIELD_SIZE] */   \
   }

--- a/Silicon/Ampere/AmpereAltraPkg/AcpiCommonTables/Fadt.aslc
+++ b/Silicon/Ampere/AmpereAltraPkg/AcpiCommonTables/Fadt.aslc
@@ -6,7 +6,7 @@
 
 **/
 
-#include <Library/AcpiLib.h>
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/Acpi63.h>
 #include <AcpiHeader.h>
 
@@ -62,22 +62,22 @@ EFI_ACPI_6_3_FIXED_ACPI_DESCRIPTION_TABLE Fadt = {
   0,                                                                        // UINT16     IaPcBootArch
   0,                                                                        // UINT8      Reserved1
   FADT_FLAGS,                                                               // UINT32     Flags
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  ResetReg
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  ResetReg
   0,                                                                        // UINT8      ResetValue
   EFI_ACPI_6_3_ARM_PSCI_COMPLIANT,                                          // UINT16     ArmBootArchFlags
   EFI_ACPI_6_3_FIXED_ACPI_DESCRIPTION_TABLE_MINOR_REVISION,                 // UINT8      MinorRevision
   0,                                                                        // UINT64     XFirmwareCtrl
   0,                                                                        // UINT64     XDsdt
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1aEvtBlk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1bEvtBlk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1aCntBlk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1bCntBlk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm2CntBlk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPmTmrBlk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XGpe0Blk
-  NULL_GAS,                                                                 // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XGpe1Blk
-  ARM_GAS32(0),                                                             // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  SleepControlReg
-  ARM_GAS32(0),                                                             // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  SleepStatusReg
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1aEvtBlk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1bEvtBlk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1aCntBlk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm1bCntBlk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPm2CntBlk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XPmTmrBlk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XGpe0Blk
+  ACPI_NULL_GAS,                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  XGpe1Blk
+  ACPI_GAS32(0),                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  SleepControlReg
+  ACPI_GAS32(0),                                                            // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  SleepStatusReg
   0                                                                         // UINT64 HypervisorVendorIdentity
 };
 

--- a/Silicon/Ampere/AmpereAltraPkg/AcpiCommonTables/Spcr.aslc
+++ b/Silicon/Ampere/AmpereAltraPkg/AcpiCommonTables/Spcr.aslc
@@ -7,10 +7,10 @@
 **/
 
 #include <Library/PcdLib.h>
-#include <Library/AcpiLib.h>
 #include <IndustryStandard/Acpi63.h>
 #include <IndustryStandard/SerialPortConsoleRedirectionTable.h>
 #include <AcpiHeader.h>
+#include <AcpiHelperMacros.h>
 
 STATIC EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE Spcr = {
   __ACPI_HEADER (
@@ -27,7 +27,7 @@ STATIC EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE Spcr = {
     EFI_ACPI_RESERVED_BYTE
   },
   // EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE  BaseAddress;
-  ARM_GAS32 (FixedPcdGet64 (PcdSerialRegisterBase)),
+  ACPI_GAS32 (FixedPcdGet64 (PcdSerialRegisterBase)),
   // UINT8                                   InterruptType;
   EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_INTERRUPT_TYPE_GIC,
   // UINT8                                   Irq;

--- a/Silicon/Marvell/Armada7k8k/AcpiTables/Fadt.aslc
+++ b/Silicon/Marvell/Armada7k8k/AcpiTables/Fadt.aslc
@@ -9,7 +9,7 @@
 
 **/
 
-#include <Library/AcpiLib.h>
+#include <AcpiHelperMacros.h>
 
 #include "AcpiHeader.h"
 
@@ -59,22 +59,22 @@ EFI_ACPI_6_0_FIXED_ACPI_DESCRIPTION_TABLE Fadt = {
   0,                                            // UINT16     IaPcBootArch
   0,                                            // UINT8      Reserved1
   FADT_FLAGS,                                   // UINT32     Flags
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  ResetReg
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  ResetReg
   0,                                            // UINT8      ResetValue
   EFI_ACPI_6_0_ARM_PSCI_COMPLIANT,              // UINT16     ArmBootArch
   EFI_ACPI_6_0_FIXED_ACPI_DESCRIPTION_TABLE_MINOR_REVISION, // UINT8      MinorVersion
   0,                                            // UINT64     XFirmwareCtrl
   0,                                            // UINT64     XDsdt
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1aEvtBlk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1bEvtBlk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1aCntBlk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1bCntBlk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm2CntBlk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPmTmrBlk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XGpe0Blk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XGpe1Blk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  SleepControlReg
-  NULL_GAS                                      // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  SleepStatusReg
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1aEvtBlk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1bEvtBlk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1aCntBlk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1bCntBlk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm2CntBlk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPmTmrBlk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XGpe0Blk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XGpe1Blk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  SleepControlReg
+  ACPI_NULL_GAS                                 // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  SleepStatusReg
 };
 
 VOID CONST * CONST ReferenceAcpiTable = &Fadt;

--- a/Silicon/Marvell/Armada7k8k/AcpiTables/Madt.aslc
+++ b/Silicon/Marvell/Armada7k8k/AcpiTables/Madt.aslc
@@ -9,7 +9,7 @@
 
 **/
 
-#include <Library/AcpiLib.h>
+#include <AcpiHelperMacros.h>
 
 #include "AcpiHeader.h"
 

--- a/Silicon/Marvell/OcteonTx/AcpiTables/T91/Fadt.aslc
+++ b/Silicon/Marvell/OcteonTx/AcpiTables/T91/Fadt.aslc
@@ -9,7 +9,7 @@
 
 **/
 
-#include <Library/AcpiLib.h>
+#include <AcpiHelperMacros.h>
 
 #include "AcpiHeader.h"
 
@@ -59,22 +59,22 @@ EFI_ACPI_6_0_FIXED_ACPI_DESCRIPTION_TABLE Fadt = {
   0,                                            // UINT16     IaPcBootArch
   0,                                            // UINT8      Reserved1
   FADT_FLAGS,                                   // UINT32     Flags
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  ResetReg
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  ResetReg
   0,                                            // UINT8      ResetValue
   EFI_ACPI_6_0_ARM_PSCI_COMPLIANT,              // UINT16     ArmBootArch
   EFI_ACPI_6_0_FIXED_ACPI_DESCRIPTION_TABLE_MINOR_REVISION, // UINT8      MinorVersion
   0,                                            // UINT64     XFirmwareCtrl
   0,                                            // UINT64     XDsdt
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1aEvtBlk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1bEvtBlk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1aCntBlk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1bCntBlk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm2CntBlk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPmTmrBlk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XGpe0Blk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XGpe1Blk
-  NULL_GAS,                                     // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  SleepControlReg
-  NULL_GAS                                      // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  SleepStatusReg
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1aEvtBlk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1bEvtBlk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1aCntBlk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm1bCntBlk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPm2CntBlk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XPmTmrBlk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XGpe0Blk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  XGpe1Blk
+  ACPI_NULL_GAS,                                // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  SleepControlReg
+  ACPI_NULL_GAS                                 // EFI_ACPI_6_0_GENERIC_ADDRESS_STRUCTURE  SleepStatusReg
 };
 
 VOID CONST * CONST ReferenceAcpiTable = &Fadt;

--- a/Silicon/Marvell/OcteonTx/AcpiTables/T91/Madt.aslc
+++ b/Silicon/Marvell/OcteonTx/AcpiTables/T91/Madt.aslc
@@ -9,7 +9,7 @@
 
 **/
 
-#include <Library/AcpiLib.h>
+#include <AcpiHelperMacros.h>
 
 #include "AcpiHeader.h"
 

--- a/Silicon/Phytium/FT2000-4Pkg/Drivers/AcpiTables/Fadt.aslc
+++ b/Silicon/Phytium/FT2000-4Pkg/Drivers/AcpiTables/Fadt.aslc
@@ -7,8 +7,8 @@
 
 **/
 
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/Acpi.h>
-#include <Library/AcpiLib.h>
 #include <Platform.h>
 
 EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE Fadt = {
@@ -55,22 +55,22 @@ EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE Fadt = {
   0,                                                                        // UINT16     IaPcBootArch
   0,                                                                        // UINT8      Reserved1
   EFI_ACPI_6_1_HW_REDUCED_ACPI | EFI_ACPI_6_1_LOW_POWER_S0_IDLE_CAPABLE,    // UINT32     Flags
-  NULL_GAS,                                                       // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  ResetReg
+  ACPI_NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  ResetReg
   0,                                                              // UINT8      ResetValue
   EFI_ACPI_6_1_ARM_PSCI_COMPLIANT,                                // UINT16     ArmBootArchFlags
   EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE_MINOR_REVISION,       // UINT8      MinorRevision
   0,                                                              // UINT64     XFirmwareCtrl
   0,                                                              // UINT64     XDsdt
-  NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XPm1aEvtBlk
-  NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XPm1bEvtBlk
-  NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XPm1aCntBlk
-  NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XPm1bCntBlk
-  NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XPm2CntBlk
-  NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XPmTmrBlk
-  NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XGpe0Blk
-  NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XGpe1Blk
-  NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  SleepControlReg
-  NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  SleepStatusReg
+  ACPI_NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XPm1aEvtBlk
+  ACPI_NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XPm1bEvtBlk
+  ACPI_NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XPm1aCntBlk
+  ACPI_NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XPm1bCntBlk
+  ACPI_NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XPm2CntBlk
+  ACPI_NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XPmTmrBlk
+  ACPI_NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XGpe0Blk
+  ACPI_NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  XGpe1Blk
+  ACPI_NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  SleepControlReg
+  ACPI_NULL_GAS,                                                  // EFI_ACPI_6_1__GENERIC_ADDRESS_STRUCTURE  SleepStatusReg
   0                                                          // UINT64     Hypervisor Vendor Identify
 };
 

--- a/Silicon/Phytium/FT2000-4Pkg/Drivers/AcpiTables/Spcr.aslc
+++ b/Silicon/Phytium/FT2000-4Pkg/Drivers/AcpiTables/Spcr.aslc
@@ -7,9 +7,9 @@
 
 **/
 
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/SerialPortConsoleRedirectionTable.h>
-#include <Library/AcpiLib.h>
 #include <Library/ArmLib.h>
 #include <Library/PcdLib.h>
 #include <Platform.h>
@@ -33,7 +33,7 @@ STATIC EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE Spcr = {
     EFI_ACPI_RESERVED_BYTE
   },
   // EFI_ACPI_5_0_GENERIC_ADDRESS_STRUCTURE  BaseAddress;
-  ARM_GAS32 (FixedPcdGet64 (PcdSerialRegisterBase)),
+  ACPI_GAS32 (FixedPcdGet64 (PcdSerialRegisterBase)),
   // UINT8                                   InterruptType;
   EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_INTERRUPT_TYPE_GIC,
   // UINT8                                   Irq;

--- a/Silicon/Qemu/SbsaQemu/AcpiTables/Dbg2.aslc
+++ b/Silicon/Qemu/SbsaQemu/AcpiTables/Dbg2.aslc
@@ -6,10 +6,10 @@
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
 *
 **/
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/DebugPort2Table.h>
 #include <IndustryStandard/SbsaQemuAcpi.h>
-#include <Library/AcpiLib.h>
 #include <Library/PcdLib.h>
 
 #pragma pack(1)
@@ -54,7 +54,7 @@ STATIC DBG2_TABLE Dbg2 = {
       OFFSET_OF (DBG2_DEBUG_DEVICE_INFORMATION, BaseAddressRegister),
       OFFSET_OF (DBG2_DEBUG_DEVICE_INFORMATION, AddressSize)
     },
-    ARM_GAS32 (FixedPcdGet32(PcdSerialRegisterBase)),  /* BaseAddressRegister */
+    ACPI_GAS32 (FixedPcdGet32(PcdSerialRegisterBase)), /* BaseAddressRegister */
     0x1000,                                            /* AddressSize */
     SBSAQEMU_UART_STR,                                 /* NameSpaceString */
   }

--- a/Silicon/Qemu/SbsaQemu/AcpiTables/Fadt.aslc
+++ b/Silicon/Qemu/SbsaQemu/AcpiTables/Fadt.aslc
@@ -6,7 +6,7 @@
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
-#include <Library/AcpiLib.h>
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/SbsaQemuAcpi.h>
 
@@ -55,23 +55,23 @@ EFI_ACPI_6_0_FIXED_ACPI_DESCRIPTION_TABLE Fadt = {
   0,                                            // UINT8      Reserved1
   EFI_ACPI_6_0_HW_REDUCED_ACPI |
   EFI_ACPI_6_0_LOW_POWER_S0_IDLE_CAPABLE,       // UINT32     Flags
-  NULL_GAS,                                     // GAS        ResetReg
+  ACPI_NULL_GAS,                                // GAS        ResetReg
   0,                                            // UINT8      ResetValue
   EFI_ACPI_6_0_ARM_PSCI_COMPLIANT,              // UINT16     ArmBootArchFlags
   EFI_ACPI_6_0_FIXED_ACPI_DESCRIPTION_TABLE_MINOR_REVISION,
                                                 // UINT8      MinorRevision
   0,                                            // UINT64     XFirmwareCtrl
   0,                                            // UINT64     XDsdt
-  NULL_GAS,                                     // GAS        XPm1aEvtBlk
-  NULL_GAS,                                     // GAS        XPm1bEvtBlk
-  NULL_GAS,                                     // GAS        XPm1aCntBlk
-  NULL_GAS,                                     // GAS        XPm1bCntBlk
-  NULL_GAS,                                     // GAS        XPm2CntBlk
-  NULL_GAS,                                     // GAS        XPmTmrBlk
-  NULL_GAS,                                     // GAS        XGpe0Blk
-  NULL_GAS,                                     // GAS        XGpe1Blk
-  NULL_GAS,                                     // GAS        SleepControlReg
-  NULL_GAS,                                     // GAS        SleepStatusReg
+  ACPI_NULL_GAS,                                // GAS        XPm1aEvtBlk
+  ACPI_NULL_GAS,                                // GAS        XPm1bEvtBlk
+  ACPI_NULL_GAS,                                // GAS        XPm1aCntBlk
+  ACPI_NULL_GAS,                                // GAS        XPm1bCntBlk
+  ACPI_NULL_GAS,                                // GAS        XPm2CntBlk
+  ACPI_NULL_GAS,                                // GAS        XPmTmrBlk
+  ACPI_NULL_GAS,                                // GAS        XGpe0Blk
+  ACPI_NULL_GAS,                                // GAS        XGpe1Blk
+  ACPI_NULL_GAS,                                // GAS        SleepControlReg
+  ACPI_NULL_GAS,                                // GAS        SleepStatusReg
   0                                             // UINT64     HypervisorVendorId
 };
 

--- a/Silicon/Qemu/SbsaQemu/Drivers/SbsaQemuAcpiDxe/SbsaQemuAcpiDxe.c
+++ b/Silicon/Qemu/SbsaQemu/Drivers/SbsaQemuAcpiDxe/SbsaQemuAcpiDxe.c
@@ -7,6 +7,7 @@
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
 *
 **/
+#include <AcpiHelperMacros.h>
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/AcpiAml.h>
 #include <IndustryStandard/ArmCache.h>


### PR DESCRIPTION
Update platform ACPI table sources to include AcpiHelperMacros.h for the
ACPI helper macros that moved out of AcpiLib.h.

For files that only use the helper macros, replace the AcpiLib.h include
with AcpiHelperMacros.h. For SbsaQemuAcpiDxe, keep AcpiLib.h because the
driver also uses AcpiLib APIs, and add AcpiHelperMacros.h for the moved
macro definitions.

This change depends on the companion edk2 change:
"EmbeddedPkg,MdeModulePkg,DynamicTablesPkg: Move ACPI helper macros"
https://github.com/tianocore/edk2/pull/12640

Tested:
  Affected platform DSCs: AARCH64 GCC NOOPT

SGI affected platforms passed; other affected platforms fail due to
missing local assets/dependencies unrelated to the include migration.

More discussion in https://github.com/tianocore/edk2/pull/12465