### PR TITLE
Silicon/Marvell/Drivers/SmbiosPlatformDxe: Fix build on CLANGDWARF

### DIFF
--- a/Silicon/Marvell/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c
+++ b/Silicon/Marvell/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c
@@ -227,8 +227,8 @@ STATIC SMBIOS_TABLE_TYPE7 mArmadaDefaultType7_a72_l1i = {
   CacheTypeInstruction,    //instruction cache
   CacheAssociativityOther, //three way
   // SMBIOS 3.1.0 fields
-  48,    //48k I-cache max
-  48,    //48k installed
+  {48,0}, //48k I-cache max
+  {48,0}, //48k installed
 };
 
 STATIC SMBIOS_TABLE_TYPE7 mArmadaDefaultType7_a72_l1d = {
@@ -248,8 +248,8 @@ STATIC SMBIOS_TABLE_TYPE7 mArmadaDefaultType7_a72_l1d = {
   CacheTypeData,           //data cache
   CacheAssociativity2Way,  //two way
   // SMBIOS 3.1.0 fields
-  32,    //32k D-cache max
-  32,    //32k installed
+  {32,0}, //32k D-cache max
+  {32,0}, //32k installed
 };
 
 STATIC SMBIOS_TABLE_TYPE7 mArmadaDefaultType7_a72_l2 = {
@@ -269,8 +269,8 @@ STATIC SMBIOS_TABLE_TYPE7 mArmadaDefaultType7_a72_l2 = {
   CacheTypeUnified,        //instruction cache
   CacheAssociativity16Way, //16 way associative
   // SMBIOS 3.1.0 fields
-  512,   //512k D-cache max
-  512,   //512k installed
+  {512,0}, //512k D-cache max
+  {512,0}, //512k installed
 };
 
 STATIC SMBIOS_TABLE_TYPE7 mArmadaDefaultType7_l3 = {
@@ -290,8 +290,8 @@ STATIC SMBIOS_TABLE_TYPE7 mArmadaDefaultType7_l3 = {
   CacheTypeUnified,        //instruction cache
   CacheAssociativity8Way,  //8 way associative
   // SMBIOS 3.1.0 fields
-  1024,  //1M cache max
-  1024,  //1M installed
+  {1024,0}, //1M cache max
+  {1024,0}, //1M installed
 };
 
 STATIC CONST CHAR8 *mArmadaDefaultType7Strings[] = {


### PR DESCRIPTION
The SmbiosPlatformDxe module fails to build on pretentious compilers since the newly added SMBIOS_CACHE_SIZE_2 entries are defined as a (bitfield) struct with two members (MdePkg/Include/IndustryStandard/SmBios.h):
```
typedef struct {
  UINT32    Size           : 31;
  UINT32    Granularity64K : 1;
} SMBIOS_CACHE_SIZE_2;
```
And the assignment is being done as to a regular integer.

This commit converts the definitions from "N" to "{N,0}"

Here's an example of an error when building `SolidRun/Armada80x0McBin`:
```
/home/alex/work/edk2/hdev/src/PlatformsPkg/Silicon/Marvell/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c:231:3: error: implicit truncation from 'int' to bit-field changes value from 48 to 0 [-Werror,-Wbitfield-constant-conversion]
  231 |   48,    //48k installed
      |   ^~
/home/alex/work/edk2/hdev/src/PlatformsPkg/Silicon/Marvell/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c:230:3: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
  230 |   48,    //48k I-cache max
      |   ^~~~~~~~~~~~~~~~~~~~~~~~
      |   {
  231 |   48,    //48k installed
      |   ~~
      |     }
 ...
```