### PR TITLE
Platform/MinPlatformPkg: Scope Intel x86-specific PEI libs to IA32/X64 PEIM

### DIFF
--- a/Platform/MinPlatformPkg/Include/Dsc/CorePeiLib.dsc
+++ b/Platform/MinPlatformPkg/Include/Dsc/CorePeiLib.dsc
@@ -60,16 +60,18 @@
   Tcg2PhysicalPresenceLib|SecurityPkg/Library/PeiTcg2PhysicalPresenceLib/PeiTcg2PhysicalPresenceLib.inf
   TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
 
-!if gMinPlatformPkgTokenSpaceGuid.PcdFspWrapperBootMode == TRUE
-  FspMeasurementLib|IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/BaseFspMeasurementLib.inf
-  FspWrapperPlatformMultiPhaseLib|IntelFsp2WrapperPkg/Library/BaseFspWrapperPlatformMultiPhaseLibNull/BaseFspWrapperPlatformMultiPhaseLibNull.inf
-  FspWrapperMultiPhaseProcessLib|IntelFsp2WrapperPkg/Library/FspWrapperMultiPhaseProcessLib/FspWrapperMultiPhaseProcessLib.inf
-!endif
   TcgEventLogRecordLib|SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.inf
   TpmMeasurementLib|SecurityPkg/Library/PeiTpmMeasurementLib/PeiTpmMeasurementLib.inf
 
   VariableReadLib|MinPlatformPkg/Library/PeiVariableReadLib/PeiVariableReadLib.inf
 
   SmmRelocationLib|UefiCpuPkg/Library/SmmRelocationLib/SmmRelocationLib.inf
-  SmmControlLib|IntelSiliconPkg/Feature/SmmControl/Library/PeiSmmControlLib/PeiSmmControlLib.inf
   MmUnblockMemoryLib|UefiCpuPkg/Library/MmUnblockMemoryLib/MmUnblockMemoryLib.inf
+
+[LibraryClasses.IA32.PEIM, LibraryClasses.X64.PEIM]
+!if gMinPlatformPkgTokenSpaceGuid.PcdFspWrapperBootMode == TRUE
+  FspMeasurementLib|IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/BaseFspMeasurementLib.inf
+  FspWrapperPlatformMultiPhaseLib|IntelFsp2WrapperPkg/Library/BaseFspWrapperPlatformMultiPhaseLibNull/BaseFspWrapperPlatformMultiPhaseLibNull.inf
+  FspWrapperMultiPhaseProcessLib|IntelFsp2WrapperPkg/Library/FspWrapperMultiPhaseProcessLib/FspWrapperMultiPhaseProcessLib.inf
+!endif
+  SmmControlLib|IntelSiliconPkg/Feature/SmmControl/Library/PeiSmmControlLib/PeiSmmControlLib.inf


### PR DESCRIPTION
PeiSmmControlLib from IntelSiliconPkg is Intel x86-specific and should not be required for non-x86 platforms building MinPlatformPkg.

Move the SmmControlLib mapping from the global [LibraryClasses] section to [LibraryClasses.IA32.PEIM, LibraryClasses.X64.PEIM] in CorePeiLib.dsc. This allows non-Intel platforms to build MinPlatformPkg without adding Silicon/Intel to PACKAGES_PATH.

Tested by building QemuOpenBoardPkg for Intel platform and internal AARCH64 MinPlatform.