### PR TITLE
MinPlatformPkg/TestPointCheckLib:Add NULL pointer check to prevent page fault.

### DIFF
--- a/Platform/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckAcpi.c
+++ b/Platform/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckAcpi.c
@@ -619,6 +619,9 @@ DumpAcpiRsdt (
   EntryPtr = (UINT32 *)(Rsdt + 1);
   for (Index = 0; Index < EntryCount; Index ++, EntryPtr ++) {
     Table = (EFI_ACPI_DESCRIPTION_HEADER *)((UINTN)(*EntryPtr));
+    if (Table == NULL) {
+      continue;
+    }
     if (DumpPrint) {
       DumpAcpiTable (Table);
     }
@@ -676,6 +679,9 @@ DumpAcpiXsdt (
   for (Index = 0; Index < EntryCount; Index ++) {
     CopyMem (&EntryPtr, (VOID *)(BasePtr + Index * sizeof(UINT64)), sizeof(UINT64));
     Table = (EFI_ACPI_DESCRIPTION_HEADER *)((UINTN)(EntryPtr));
+    if (Table == NULL) {
+      continue;
+    }
     if (DumpPrint) {
       DumpAcpiTable (Table);
     }


### PR DESCRIPTION
Pointer dereference without NULL check causing page fault. Added NULL check to avoid page fault.

Fixes: #997