### PR TITLE
REVIEWERS, CONTRIBUTORS.md: add more reviewers for MinPlatformPkg

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -63,6 +63,7 @@ out-of-sync with CODEOWNERS and/or REVIEWERS over time and need an occasional re
 | Theo Jehl              | theojehl76@gmail.com             | [@theomacx86](https://github.com/theomacx86)         |
 | Thomas Abraham         | thomas.abraham@arm.com           |                                                      |
 | USER0FISH              | libing1202@outlook.com           | [@USER0FISH](https://github.com/USER0FISH)           |
+| Vishal Oliyil Kunnil   | vishalo@qti.qualcomm.com         | [@vishalo](https://github.com/vishalo)               |
 | Wenyi Xie              | xiewenyi2@huawei.com             |                                                      |
 | Xianglai li            | lixianglai@loongson.cn           | [@lixianglai](https://github.com/lixianglai)         |
 | Yang Wang              | wangyang@bosc.ac.cn              |                                                      |

--- a/REVIEWERS
+++ b/REVIEWERS
@@ -29,7 +29,7 @@
 /Features/Intel/UserInterface/** @lgao4
 
 /Platform/Intel/BoardModulePkg/** @lgao4
-/Platform/MinPlatformPkg/** @lgao4 @ydong10
+/Platform/MinPlatformPkg/** @abdattar @lgao4 @vishalo @ydong10
 /Platform/Intel/AlderlakeOpenBoardPkg/** @SaloniKasbekar
 /Platform/Intel/Tools/** @YuweiChen1110
 


### PR DESCRIPTION
Add Abdul and Vishal as reviewers for the now vendor- and architecture- neutral MinPlatformPkg.

Also add an accompanying entry for Vishal in CONTRIBUTORS.md.