### PR TITLE
Silicon/Intel/IntelSiliconPkg: Fix the wrong size of CopyMem

### DIFF
--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/DmaProtection.h
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/DmaProtection.h
@@ -61,7 +61,7 @@
 // This is the initial max PCI DATA number.
 // The number may be enlarged later.
 //
-#define MAX_VTD_PCI_DATA_NUMBER             0x100
+#define VTD_PCI_DATA_ALLOC_CHUNK            0x100
 
 typedef struct {
   UINTN                            VtdUnitBaseAddress;

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/DmarAcpiTable.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/DmarAcpiTable.c
@@ -33,7 +33,7 @@ VtdDumpDmarTable (
 {
   VtdLibDumpAcpiDmar (NULL, NULL, (EFI_ACPI_DMAR_HEADER *) (UINTN) mAcpiDmarTable);
 
-  VTdLogAddDataEvent (VTDLOG_DXE_DMAR_TABLE, mAcpiDmarTable->Header.Length, (VOID *)mAcpiDmarTable, mAcpiDmarTable->Header.Length);   
+  VTdLogAddDataEvent (VTDLOG_DXE_DMAR_TABLE, mAcpiDmarTable->Header.Length, (VOID *)mAcpiDmarTable, mAcpiDmarTable->Header.Length);
 }
 
 /**
@@ -111,7 +111,7 @@ ProcessDrhd (
   EFI_STATUS                                        Status;
   VTD_SOURCE_ID                                     SourceId;
 
-  mVtdUnitInformation[VtdIndex].PciDeviceInfo = AllocateZeroPool (sizeof (PCI_DEVICE_INFORMATION) + sizeof (PCI_DEVICE_DATA) * MAX_VTD_PCI_DATA_NUMBER);
+  mVtdUnitInformation[VtdIndex].PciDeviceInfo = AllocateZeroPool (sizeof (PCI_DEVICE_INFORMATION) + sizeof (PCI_DEVICE_DATA) * VTD_PCI_DATA_ALLOC_CHUNK);
   if (mVtdUnitInformation[VtdIndex].PciDeviceInfo == NULL) {
     ASSERT (FALSE);
     return EFI_OUT_OF_RESOURCES;
@@ -122,7 +122,7 @@ ProcessDrhd (
   DEBUG ((DEBUG_INFO,"  VTD (%d) BaseAddress -  0x%016lx\n", VtdIndex, DmarDrhd->RegisterBaseAddress));
 
   mVtdUnitInformation[VtdIndex].PciDeviceInfo->Segment                = DmarDrhd->SegmentNumber;
-  mVtdUnitInformation[VtdIndex].PciDeviceInfo->PciDeviceDataMaxNumber = MAX_VTD_PCI_DATA_NUMBER;
+  mVtdUnitInformation[VtdIndex].PciDeviceInfo->PciDeviceDataMaxNumber = VTD_PCI_DATA_ALLOC_CHUNK;
 
   if ((DmarDrhd->Flags & EFI_ACPI_DMAR_DRHD_FLAGS_INCLUDE_PCI_ALL) != 0) {
     mVtdUnitInformation[VtdIndex].PciDeviceInfo->IncludeAllFlag = TRUE;

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/PciInfo.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/PciInfo.c
@@ -98,15 +98,15 @@ RegisterPciDevice (
       //
       // Reallocate
       //
-      NewPciDeviceInfo = AllocateZeroPool (sizeof (PCI_DEVICE_INFORMATION) + sizeof (PCI_DEVICE_DATA) * (PciDeviceInfo->PciDeviceDataMaxNumber + MAX_VTD_PCI_DATA_NUMBER));
+      NewPciDeviceInfo = AllocateZeroPool (sizeof (PCI_DEVICE_INFORMATION) + sizeof (PCI_DEVICE_DATA) * (PciDeviceInfo->PciDeviceDataMaxNumber + VTD_PCI_DATA_ALLOC_CHUNK));
       if (NewPciDeviceInfo == NULL) {
         return EFI_OUT_OF_RESOURCES;
       }
 
-      CopyMem (NewPciDeviceInfo, PciDeviceInfo, sizeof (PCI_DEVICE_INFORMATION) + sizeof (PCI_DEVICE_DATA) * (PciDeviceInfo->PciDeviceDataMaxNumber + MAX_VTD_PCI_DATA_NUMBER));
+      CopyMem (NewPciDeviceInfo, PciDeviceInfo, sizeof (PCI_DEVICE_INFORMATION) + sizeof (PCI_DEVICE_DATA) * (PciDeviceInfo->PciDeviceDataMaxNumber));
       FreePool (PciDeviceInfo);
 
-      NewPciDeviceInfo->PciDeviceDataMaxNumber += MAX_VTD_PCI_DATA_NUMBER;
+      NewPciDeviceInfo->PciDeviceDataMaxNumber += VTD_PCI_DATA_ALLOC_CHUNK;
       mVtdUnitInformation[VtdIndex].PciDeviceInfo = NewPciDeviceInfo;
       PciDeviceInfo = NewPciDeviceInfo;
     }


### PR DESCRIPTION
The size of CopyMem is wrong, it should bePciDeviceDataMaxNumber instead of PciDeviceDataMaxNumber + MAX_VTD_PCI_DATA_NUMBER.