### PR TITLE
IntelSiliconPkg: Add CONFIG_BLOCK_HEADER2 with multi-instance support

### DIFF
--- a/Silicon/Intel/IntelSiliconPkg/Include/ConfigBlock.h
+++ b/Silicon/Intel/IntelSiliconPkg/Include/ConfigBlock.h
@@ -1,7 +1,7 @@
 /** @file
   Header file for Config Block Lib implementation
 
-  Copyright (c) 2019 - 2020 Intel Corporation. All rights reserved. <BR>
+  Copyright (c) 2019 - 2026 Intel Corporation. All rights reserved. <BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -35,6 +35,62 @@ typedef struct _CONFIG_BLOCK {
   // Config Block Data
   //
 } CONFIG_BLOCK;
+
+///
+/// Attributes bit definition: set in CONFIG_BLOCK_HEADER.Attributes to indicate
+/// that this config block uses CONFIG_BLOCK_HEADER2 and carries a Namespace GUID
+/// at offset 32.
+///
+#define CONFIG_BLOCK_HEADER2_ATTRIBUTE  BIT0
+
+///
+/// Version 2 Config Block Header - supports multi-instance IP blocks.
+/// The Namespace disambiguates multiple blocks sharing the same GuidHob.Name.
+/// Namespace can be a UUID v4 GUID to disambiguate between different logical
+/// partitions, or a UUID v5 GUID derived from a UUID v4 GUID and an instance
+/// index when more than one instance of a logical partition exists.
+///
+/// This struct is layout-compatible with CONFIG_BLOCK_HEADER: the fields
+/// GuidHob, Revision, Attributes, and Reserved are at identical offsets,
+/// so a CONFIG_BLOCK_HEADER2 * can safely be cast to CONFIG_BLOCK_HEADER *.
+///
+typedef struct _CONFIG_BLOCK_HEADER2 {
+  EFI_HOB_GUID_TYPE GuidHob;        ///< Offset 0-23  GUID extension HOB header
+  UINT8             Revision;       ///< Offset 24    Revision of this config block
+  UINT8             Attributes;     ///< Offset 25    Identifying properties; BIT0 = CONFIG_BLOCK_HEADER2_ATTRIBUTE
+  UINT8             Reserved[2];    ///< Offset 26-27 Reserved for future use
+  UINT8             Reserved2[4];   ///< Offset 28-31 Reserved for future use; naturally aligns Namespace
+  EFI_GUID          Namespace;      ///< Offset 32-47 Disambiguates scope for identically structured blocks
+} CONFIG_BLOCK_HEADER2;
+
+///
+/// Config Block using the version 2 header.
+///
+typedef struct _CONFIG_BLOCK2 {
+  CONFIG_BLOCK_HEADER2           Header;   ///< Offset 0-47  Config Block Header
+  //
+  // Config Block Data
+  //
+} CONFIG_BLOCK2;
+
+///
+/// Compile-time assertions that enforce the layout-compatibility and alignment
+/// guarantees for CONFIG_BLOCK_HEADER2.
+///
+#ifdef STATIC_ASSERT
+STATIC_ASSERT (
+  OFFSET_OF (CONFIG_BLOCK_HEADER2, Reserved2) == sizeof (CONFIG_BLOCK_HEADER),
+  "CONFIG_BLOCK_HEADER2 fields before Reserved2 must exactly match CONFIG_BLOCK_HEADER's layout so a CONFIG_BLOCK_HEADER2 * can be safely cast to CONFIG_BLOCK_HEADER *"
+  );
+STATIC_ASSERT (
+  (OFFSET_OF (CONFIG_BLOCK_HEADER2, Namespace) % 8) == 0,
+  "CONFIG_BLOCK_HEADER2.Namespace must start on an 8-byte aligned offset"
+  );
+STATIC_ASSERT (
+  (sizeof (CONFIG_BLOCK_HEADER2) % 8) == 0,
+  "CONFIG_BLOCK_HEADER2 size must be a multiple of 8 bytes so the body of the config block is 8-byte aligned"
+  );
+#endif
 
 ///
 /// Config Block Table Header

--- a/Silicon/Intel/IntelSiliconPkg/Include/Library/ConfigBlockLib.h
+++ b/Silicon/Intel/IntelSiliconPkg/Include/Library/ConfigBlockLib.h
@@ -1,7 +1,7 @@
 /** @file
   Header file for Config Block Lib implementation
 
-  Copyright (c) 2019 - 2020 Intel Corporation. All rights reserved. <BR>
+  Copyright (c) 2019 - 2026 Intel Corporation. All rights reserved. <BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -59,6 +59,64 @@ GetConfigBlock (
   IN     VOID      *ConfigBlockTableAddress,
   IN     EFI_GUID  *ConfigBlockGuid,
   OUT    VOID      **ConfigBlockAddress
+  );
+
+/**
+  Retrieve a Config Block by type GUID and instance GUID.
+
+  Walks the config block table matching GuidHob.Name against ConfigBlockGuid.
+  Among matching blocks, returns the one whose Attributes has
+  CONFIG_BLOCK_HEADER2_ATTRIBUTE (BIT0) set and whose Namespace matches
+  the provided Namespace GUID. Config blocks that use the original
+  CONFIG_BLOCK_HEADER format are never returned by this API, even if
+  ConfigBlockGuid matches. Use GetConfigBlock() for those instead.
+
+  @param[in]   ConfigBlockTableAddress  Pointer to the config block table.
+  @param[in]   ConfigBlockGuid          IP type GUID (matches GuidHob.Name).
+  @param[in]   Namespace                Scoping GUID (matches Header2.Namespace).
+                                        Namespace can be a UUID v4 GUID to
+                                        disambiguate between different logical
+                                        partitions, or a UUID v5 GUID derived
+                                        from a UUID v4 GUID and an instance
+                                        index when more than one instance of a
+                                        logical partition exists.
+  @param[out]  ConfigBlockAddress       On success, pointer to the matching config block.
+
+  @retval EFI_SUCCESS               Config block found.
+  @retval EFI_NOT_FOUND             No matching block exists.
+  @retval EFI_INVALID_PARAMETER     A required pointer argument is NULL.
+**/
+EFI_STATUS
+EFIAPI
+GetConfigBlockByInstance (
+  IN     VOID      *ConfigBlockTableAddress,
+  IN     EFI_GUID  *ConfigBlockGuid,
+  IN     EFI_GUID  *Namespace,
+  OUT    VOID      **ConfigBlockAddress
+  );
+
+/**
+  Retrieve the next config block in a config block table.
+
+  Starts the search after CurrentConfigBlock (or from the beginning if NULL).
+  If ConfigBlockGuid is non-NULL, only blocks matching that GUID are returned.
+
+  @param[in]           ConfigBlockTableAddress  Pointer to the config block table.
+  @param[in, optional] ConfigBlockGuid          If non-NULL, filter by IP type GUID.
+  @param[in, optional] CurrentConfigBlock       Starting point. NULL returns the first match.
+  @param[out]          NextConfigBlock          On success, pointer to the next matching block.
+
+  @retval EFI_SUCCESS               Next config block found.
+  @retval EFI_NOT_FOUND             No further matching block exists.
+  @retval EFI_INVALID_PARAMETER     ConfigBlockTableAddress or NextConfigBlock is NULL.
+**/
+EFI_STATUS
+EFIAPI
+GetNextConfigBlock (
+  IN            VOID      *ConfigBlockTableAddress,
+  IN  OPTIONAL  EFI_GUID  *ConfigBlockGuid,
+  IN  OPTIONAL  VOID      *CurrentConfigBlock,
+  OUT           VOID      **NextConfigBlock
   );
 
 #endif // _CONFIG_BLOCK_LIB_H_

--- a/Silicon/Intel/IntelSiliconPkg/Library/BaseConfigBlockLib/BaseConfigBlockLib.c
+++ b/Silicon/Intel/IntelSiliconPkg/Library/BaseConfigBlockLib/BaseConfigBlockLib.c
@@ -1,7 +1,7 @@
 /** @file
   Library functions for Config Block management.
 
-Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -84,7 +84,20 @@ AddConfigBlock (
   }
 
   TempConfigBlk = (CONFIG_BLOCK *)((UINTN)ConfigBlkTblAddrPtr + (UINTN)(ConfigBlkTblAddrPtr->Header.GuidHob.Header.HobLength - ConfigBlkTblAddrPtr->AvailableSize));
-  CopyMem (&TempConfigBlk->Header, &ConfigBlkAddrPtr->Header, sizeof(CONFIG_BLOCK_HEADER));
+
+  //
+  // If the template carries CONFIG_BLOCK_HEADER2 format, copy the full version 2
+  // header (including the Namespace GUID at offset 32); otherwise copy only the
+  // base CONFIG_BLOCK_HEADER.
+  //
+  if ((ConfigBlkAddrPtr->Header.Attributes & CONFIG_BLOCK_HEADER2_ATTRIBUTE) != 0) {
+    if (ConfigBlkSize < sizeof (CONFIG_BLOCK_HEADER2)) {
+      return EFI_INVALID_PARAMETER;
+    }
+    CopyMem (&TempConfigBlk->Header, &ConfigBlkAddrPtr->Header, sizeof (CONFIG_BLOCK_HEADER2));
+  } else {
+    CopyMem (&TempConfigBlk->Header, &ConfigBlkAddrPtr->Header, sizeof (CONFIG_BLOCK_HEADER));
+  }
 
   ConfigBlkTblAddrPtr->NumberOfBlocks++;
   ConfigBlkTblAddrPtr->AvailableSize = ConfigBlkTblAddrPtr->AvailableSize - ConfigBlkSize;
@@ -114,11 +127,11 @@ GetConfigBlock (
   UINT16                    OffsetIndex;
   CONFIG_BLOCK              *TempConfigBlk;
   CONFIG_BLOCK_TABLE_HEADER *ConfigBlkTblAddrPtr;
-  UINT32                    ConfigBlkTblHdrSize;
-  UINT32                    ConfigBlkOffset;
+  UINTN                     ConfigBlkTblHdrSize;
+  UINTN                     ConfigBlkOffset;
   UINT16                    NumOfBlocks;
 
-  ConfigBlkTblHdrSize = (UINT32)(sizeof (CONFIG_BLOCK_TABLE_HEADER));
+  ConfigBlkTblHdrSize = (UINTN)(sizeof (CONFIG_BLOCK_TABLE_HEADER));
   ConfigBlkTblAddrPtr = (CONFIG_BLOCK_TABLE_HEADER *)ConfigBlockTableAddress;
   NumOfBlocks = ConfigBlkTblAddrPtr->NumberOfBlocks;
 
@@ -133,6 +146,142 @@ GetConfigBlock (
       return EFI_SUCCESS;
     }
     ConfigBlkOffset = ConfigBlkOffset + TempConfigBlk->Header.GuidHob.Header.HobLength;
+  }
+
+  return EFI_NOT_FOUND;
+}
+
+/**
+  Retrieve a Config Block by type GUID and instance GUID.
+
+  Walks the config block table matching GuidHob.Name against ConfigBlockGuid.
+  Among matching blocks, returns the one whose Attributes has
+  CONFIG_BLOCK_HEADER2_ATTRIBUTE (BIT0) set and whose Namespace matches
+  the provided Namespace GUID. Config blocks that use the original
+  CONFIG_BLOCK_HEADER format are never returned by this API, even if
+  ConfigBlockGuid matches. Use GetConfigBlock() for those instead.
+
+  @param[in]   ConfigBlockTableAddress  Pointer to the config block table.
+  @param[in]   ConfigBlockGuid          IP type GUID (matches GuidHob.Name).
+  @param[in]   Namespace                Scoping GUID (matches Header2.Namespace).
+                                        Namespace can be a UUID v4 GUID to
+                                        disambiguate between different logical
+                                        partitions, or a UUID v5 GUID derived
+                                        from a UUID v4 GUID and an instance
+                                        index when more than one instance of a
+                                        logical partition exists.
+  @param[out]  ConfigBlockAddress       On success, pointer to the matching config block.
+
+  @retval EFI_SUCCESS               Config block found.
+  @retval EFI_NOT_FOUND             No matching block exists.
+  @retval EFI_INVALID_PARAMETER     A required pointer argument is NULL.
+**/
+EFI_STATUS
+EFIAPI
+GetConfigBlockByInstance (
+  IN     VOID      *ConfigBlockTableAddress,
+  IN     EFI_GUID  *ConfigBlockGuid,
+  IN     EFI_GUID  *Namespace,
+  OUT    VOID      **ConfigBlockAddress
+  )
+{
+  UINT16                     OffsetIndex;
+  CONFIG_BLOCK              *TempConfigBlk;
+  CONFIG_BLOCK2             *TempConfigBlk2;
+  CONFIG_BLOCK_TABLE_HEADER *ConfigBlkTblAddrPtr;
+  UINTN                      ConfigBlkTblHdrSize;
+  UINTN                      ConfigBlkOffset;
+  UINT16                     NumOfBlocks;
+
+  if ((ConfigBlockTableAddress == NULL) || (ConfigBlockGuid == NULL) ||
+      (Namespace == NULL)              || (ConfigBlockAddress == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ConfigBlkTblHdrSize = (UINTN)(sizeof (CONFIG_BLOCK_TABLE_HEADER));
+  ConfigBlkTblAddrPtr = (CONFIG_BLOCK_TABLE_HEADER *)ConfigBlockTableAddress;
+  NumOfBlocks         = ConfigBlkTblAddrPtr->NumberOfBlocks;
+  ConfigBlkOffset     = 0;
+
+  for (OffsetIndex = 0; OffsetIndex < NumOfBlocks; OffsetIndex++) {
+    if ((ConfigBlkTblHdrSize + ConfigBlkOffset) > ConfigBlkTblAddrPtr->Header.GuidHob.Header.HobLength) {
+      break;
+    }
+    TempConfigBlk = (CONFIG_BLOCK *)((UINTN)ConfigBlkTblAddrPtr + ConfigBlkTblHdrSize + ConfigBlkOffset);
+    if (CompareGuid (&TempConfigBlk->Header.GuidHob.Name, ConfigBlockGuid)) {
+      if ((TempConfigBlk->Header.Attributes & CONFIG_BLOCK_HEADER2_ATTRIBUTE) != 0) {
+        if (TempConfigBlk->Header.GuidHob.Header.HobLength >= sizeof (CONFIG_BLOCK_HEADER2)) {
+          TempConfigBlk2 = (CONFIG_BLOCK2 *)TempConfigBlk;
+          if (CompareGuid (&TempConfigBlk2->Header.Namespace, Namespace)) {
+            *ConfigBlockAddress = (VOID *)TempConfigBlk;
+            return EFI_SUCCESS;
+          }
+        }
+      }
+    }
+    ConfigBlkOffset += TempConfigBlk->Header.GuidHob.Header.HobLength;
+  }
+
+  return EFI_NOT_FOUND;
+}
+
+/**
+  Retrieve the next config block in a config block table.
+
+  @param[in]           ConfigBlockTableAddress  Pointer to the config block table.
+  @param[in, optional] ConfigBlockGuid          If non-NULL, filter by IP type GUID.
+  @param[in, optional] CurrentConfigBlock       Starting point. NULL returns the first match.
+                                                Must be a pointer previously returned by this function or NULL.
+  @param[out]          NextConfigBlock          On success, pointer to the next matching block.
+
+  @retval EFI_SUCCESS               Next config block found.
+  @retval EFI_NOT_FOUND             No further matching block exists.
+  @retval EFI_INVALID_PARAMETER     ConfigBlockTableAddress or NextConfigBlock is NULL.
+**/
+EFI_STATUS
+EFIAPI
+GetNextConfigBlock (
+  IN            VOID      *ConfigBlockTableAddress,
+  IN  OPTIONAL  EFI_GUID  *ConfigBlockGuid,
+  IN  OPTIONAL  VOID      *CurrentConfigBlock,
+  OUT           VOID      **NextConfigBlock
+  )
+{
+  UINT16                     OffsetIndex;
+  CONFIG_BLOCK              *TempConfigBlk;
+  CONFIG_BLOCK_TABLE_HEADER *ConfigBlkTblAddrPtr;
+  UINTN                      ConfigBlkTblHdrSize;
+  UINTN                      ConfigBlkOffset;
+  UINT16                     NumOfBlocks;
+  BOOLEAN                    SearchStarted;
+
+  if ((ConfigBlockTableAddress == NULL) || (NextConfigBlock == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ConfigBlkTblHdrSize = (UINTN)(sizeof (CONFIG_BLOCK_TABLE_HEADER));
+  ConfigBlkTblAddrPtr = (CONFIG_BLOCK_TABLE_HEADER *)ConfigBlockTableAddress;
+  NumOfBlocks         = ConfigBlkTblAddrPtr->NumberOfBlocks;
+  ConfigBlkOffset     = 0;
+  SearchStarted       = (CurrentConfigBlock == NULL);
+
+  for (OffsetIndex = 0; OffsetIndex < NumOfBlocks; OffsetIndex++) {
+    if ((ConfigBlkTblHdrSize + ConfigBlkOffset) > ConfigBlkTblAddrPtr->Header.GuidHob.Header.HobLength) {
+      break;
+    }
+    TempConfigBlk = (CONFIG_BLOCK *)((UINTN)ConfigBlkTblAddrPtr + ConfigBlkTblHdrSize + ConfigBlkOffset);
+
+    if (!SearchStarted) {
+      if ((VOID *)TempConfigBlk == CurrentConfigBlock) {
+        SearchStarted = TRUE;
+      }
+    } else {
+      if ((ConfigBlockGuid == NULL) || CompareGuid (&TempConfigBlk->Header.GuidHob.Name, ConfigBlockGuid)) {
+        *NextConfigBlock = (VOID *)TempConfigBlk;
+        return EFI_SUCCESS;
+      }
+    }
+    ConfigBlkOffset += TempConfigBlk->Header.GuidHob.Header.HobLength;
   }
 
   return EFI_NOT_FOUND;


### PR DESCRIPTION
## Description

Introduce `CONFIG_BLOCK_HEADER2`, a layout-compatible superset of `CONFIG_BLOCK_HEADER` that appends a `Namespace` GUID at offset 32. The `Namespace` disambiguates multiple config blocks that share the same `GuidHob.Name`, enabling platforms with more than one instance of a given config block schema to coexist in the same config block table.

`CONFIG_BLOCK_HEADER2_ATTRIBUTE` (`BIT0` of the `Attributes` field) is the explicit format discriminator.  `AddConfigBlock()` is updated to copy the full extended header when this bit is set, existing users of
`CONFIG_BLOCK_HEADER` are unaffected.

Two new library APIs are added to `ConfigBlockLib`:
  - `GetConfigBlockByInstance()`: look up a block by type GUID and `Namespace` GUID.
  - `GetNextConfigBlock()`: iterate blocks in the table, with an optional filter by type GUID.