### PR TITLE
Add GPTLib dependency for Qualcomm, Raspberry Pi platforms

### DIFF
--- a/Platform/Qualcomm/QualcommPlatformPkg/QualcommPlatformPkg.dsc.inc
+++ b/Platform/Qualcomm/QualcommPlatformPkg/QualcommPlatformPkg.dsc.inc
@@ -9,6 +9,7 @@
 [LibraryClasses.Common]
   SerialPortLib|Silicon/Qualcomm/Library/GeniSerialPortLib/GeniSerialPortLib.inf
   ReportFvLib|QualcommPlatformPkg/Library/PeiReportFvLib/PeiReportFvLib.inf
+  GptLib|MdeModulePkg/Library/GptLib/GptLib.inf
 
 [LibraryClasses.AARCH64]
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf

--- a/Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
+++ b/Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
@@ -55,6 +55,7 @@ DEFINE NETWORK_HTTP_BOOT_ENABLE       = FALSE
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
   BmpSupportLib|MdeModulePkg/Library/BaseBmpSupportLib/BaseBmpSupportLib.inf
+  GptLib|MdeModulePkg/Library/GptLib/GptLib.inf
   SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
   PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf

--- a/Platform/RaspberryPi/RPi3/RPi3.dsc
+++ b/Platform/RaspberryPi/RPi3/RPi3.dsc
@@ -68,6 +68,7 @@
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
   BmpSupportLib|MdeModulePkg/Library/BaseBmpSupportLib/BaseBmpSupportLib.inf
+  GptLib|MdeModulePkg/Library/GptLib/GptLib.inf
   SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
   PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf

--- a/Platform/RaspberryPi/RPi4/RPi4.dsc
+++ b/Platform/RaspberryPi/RPi4/RPi4.dsc
@@ -66,6 +66,7 @@
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
   BmpSupportLib|MdeModulePkg/Library/BaseBmpSupportLib/BaseBmpSupportLib.inf
+  GptLib|MdeModulePkg/Library/GptLib/GptLib.inf  
   SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
   PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf


### PR DESCRIPTION
Add GPTLib to the DSC files for GlymurOpenBoardPkg, RB3,
RaspberryPi3 and RaspberryPi4.

This dependency is required following edk2 PR #12745.

Ref: https://github.com/tianocore/edk2/pull/12745
