### PR TITLE
Platform/ARM: Add GptLib library mapping

### DIFF
--- a/Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
@@ -112,6 +112,9 @@
   ResetSystemLib|ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.inf
   ArmMonitorLib|ArmPkg/Library/ArmMonitorLib/ArmMonitorLib.inf
 
+  # GPT lib
+  GptLib|MdeModulePkg/Library/GptLib/GptLib.inf
+
   # ARM PL031 RTC Driver
   RealTimeClockLib|ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.inf
   TimeBaseLib|EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.inf


### PR DESCRIPTION
The following edk2 change introduces a GptLib dependency to PartitionDxe and the TPM measure-boot libraries:

MdeModulePkg, SecurityPkg: Fix GPT measurement mismatch (CVE-2024-13745)
https://github.com/tianocore/edk2/pull/12745

Add the GptLib mapping to ArmVExpress.dsc.inc to resolve the new library class dependency and fix affected ARM platform builds.