### PR TITLE
Bring stuart CI support to edk2-platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
+
 .DS_Store
 *_extdep/
 *.pyc
 __pycache__/
 tags/
 .vscode/
+
+Build/
+Conf
+EDK2

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -1,0 +1,224 @@
+# @file
+# CI configuration settings for edk2-platforms.
+# Used to run CI on selected packages.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+import glob
+import logging
+import os
+
+from edk2toolext import codeql as codeql_helpers
+from edk2toolext.environment import shell_environment
+from edk2toolext.invocables.edk2_ci_build import CiBuildSettingsManager
+from edk2toolext.invocables.edk2_ci_setup import CiSetupSettingsManager
+from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
+from edk2toolext.invocables.edk2_setup import SetupSettingsManager
+from edk2toolext.invocables.edk2_update import UpdateSettingsManager
+from edk2toollib.utility_functions import GetHostInfo
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Settings(
+    CiSetupSettingsManager,
+    CiBuildSettingsManager,
+    UpdateSettingsManager,
+    SetupSettingsManager,
+    PrEvalSettingsManager,
+):
+
+    def __init__(self):
+        self.ActualPackages = []
+        self.ActualTargets = []
+        self.ActualArchitectures = []
+        self.ActualToolChainTag = ""
+        self.ActualScopes = None
+        self.PackagePaths = ["Silicon/Intel", "Platform/Intel", "Platform"]
+        self.SupportedPackages = ["BoardModulePkg", "MinPlatformPkg", "IntelSiliconPkg"]
+
+    # ####################################################################################### #
+    #                             Extra CmdLine configuration                                 #
+    # ####################################################################################### #
+
+    def AddCommandLineOptions(self, parserObj):
+        try:
+            codeql_helpers.add_command_line_option(parserObj)
+        except NameError:
+            pass
+
+    def RetrieveCommandLineOptions(self, args):
+        try:
+            self.codeql = codeql_helpers.is_codeql_enabled_on_command_line(args)
+        except NameError:
+            pass
+
+    # ####################################################################################### #
+    #                        Default Support for this Ci Build                                #
+    # ####################################################################################### #
+
+    def GetPackagesSupported(self):
+        """return iterable of edk2 packages supported by this build.
+        These should be edk2 workspace relative paths"""
+
+        return (self.SupportedPackages)
+
+    def GetArchitecturesSupported(self):
+        """return iterable of edk2 architectures supported by this build"""
+        return ("IA32", "X64", "AARCH64")
+
+    def GetTargetsSupported(self):
+        """return iterable of edk2 target tags supported by this build"""
+        return ("DEBUG", "RELEASE", "NOOPT")
+
+    # ####################################################################################### #
+    #                     Verify and Save requested Ci Build Config                           #
+    # ####################################################################################### #
+
+    def SetPackages(self, list_of_requested_packages):
+        """Confirm the requested package list is valid and configure SettingsManager
+        to build the requested packages.
+
+        Raise RuntimeException if a requested_package is not supported
+        """
+        unsupported = set(list_of_requested_packages) - set(self.GetPackagesSupported())
+        if len(unsupported) > 0:
+            LOGGER.critical("Unsupported Package Requested: " + " ".join(unsupported))
+            raise RuntimeException(
+                "Unsupported Package Requested: " + " ".join(unsupported)
+            )
+        self.ActualPackages = list_of_requested_packages
+
+    def SetArchitectures(self, list_of_requested_architectures):
+        """Confirm the requests architecture list is valid and configure SettingsManager
+        to run only the requested architectures.
+
+        Raise UnsupportedException if a list_of_requested_architectures is not supported
+        """
+        unsupported = set(list_of_requested_architectures) - set(
+            self.GetArchitecturesSupported()
+        )
+        if len(unsupported) > 0:
+            LOGGER.critical(
+                "Unsupported Architecture Requested: " + " ".join(unsupported)
+            )
+            raise UnsupportedException(
+                "Unsupported Architecture Requested: " + " ".join(unsupported)
+            )
+        self.ActualArchitectures = list_of_requested_architectures
+
+    def SetTargets(self, list_of_requested_target):
+        """Confirm the request target list is valid and configure SettingsManager
+        to run only the requested targets.
+
+        Raise RuntimeException if a requested_target is not supported
+        """
+        unsupported = set(list_of_requested_target) - set(self.GetTargetsSupported())
+        if len(unsupported) > 0:
+            LOGGER.critical("Unsupported Targets Requested: " + " ".join(unsupported))
+            raise RuntimeException(
+                "Unsupported Targets Requested: " + " ".join(unsupported)
+            )
+        self.ActualTargets = list_of_requested_target
+
+    # ####################################################################################### #
+    #                         Actual Configuration for Ci Build                               #
+    # ####################################################################################### #
+
+    def GetActiveScopes(self):
+        """return tuple containing scopes that should be active for this process"""
+        if self.ActualScopes is None:
+            # cibuild enables CI plugins
+            # edk2-build enables nasm ext_dep
+            # host-based-test runs unit tests and ensures test dsc contains all unit tests
+            scopes = ("cibuild", "edk2-build", "host-based-test")
+
+            self.ActualToolChainTag = shell_environment.GetBuildVars().GetValue(
+                "TOOL_CHAIN_TAG", ""
+            )
+
+            is_linux = GetHostInfo().os.upper() == "LINUX"
+
+            if is_linux and self.ActualToolChainTag.upper().startswith("GCC"):
+                if "AARCH64" in self.ActualArchitectures:
+                    scopes += ("gcc_aarch64_linux",)
+                if "RISCV64" in self.ActualArchitectures:
+                    scopes += ("gcc_riscv64_unknown",)
+
+            try:
+                scopes += codeql_helpers.get_scopes(self.codeql)
+
+                if self.codeql:
+                    shell_environment.GetBuildVars().SetValue(
+                        "STUART_CODEQL_AUDIT_ONLY", "TRUE", "Set in CISettings.py"
+                    )
+                    codeql_filter_files = [
+                        str(n)
+                        for n in glob.glob(
+                            os.path.join(
+                                self.GetWorkspaceRoot(), "**/CodeQlFilters.yml"
+                            ),
+                            recursive=True,
+                        )
+                    ]
+                    shell_environment.GetBuildVars().SetValue(
+                        "STUART_CODEQL_FILTER_FILES",
+                        ",".join(codeql_filter_files),
+                        "Set in CISettings.py",
+                    )
+            except NameError:
+                pass
+
+            self.ActualScopes = scopes
+        return self.ActualScopes
+
+    def GetRequiredSubmodules(self):
+        """return iterable containing RequiredSubmodule objects.
+        If no RequiredSubmodules return an empty iterable
+        """
+        rs = []
+        return rs
+
+    def GetName(self):
+        return "edk2platforms"
+
+    def GetDependencies(self):
+        """Return Git Repository Dependencies
+
+        Return an iterable of dictionary objects with the following fields
+        {
+            Path: <required> Workspace relative path
+            Url: <required> Url of git repo
+            Commit: <optional> Commit to checkout of repo
+            Branch: <optional> Branch to checkout (will checkout most recent commit in branch)
+            Full: <optional> Boolean to do shallow or Full checkout.  (default is False)
+            ReferencePath: <optional> Workspace relative path to git repo to use as "reference"
+            Recurse: <optional> Specifies if Dependency should be recursively cloned.
+        }
+        """
+        return [
+            {
+                "Path": "EDK2",
+                "Url": "https://github.com/tianocore/edk2.git",
+                "Branch": "master",
+                "Recurse": {"CIFile": ".pytool/CISettings.py"},
+            }
+        ]
+
+    def GetPackagesPath(self):
+        """Return a list of workspace relative paths that should be mapped as edk2 PackagesPath"""
+        result = self.PackagePaths
+        for a in self.GetDependencies():
+            result.append(a["Path"])
+        return result
+
+    def GetWorkspaceRoot(self):
+        """get WorkspacePath"""
+        return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    def FilterPackagesToTest(
+        self, changedFilesList: list, potentialPackagesList: list
+    ) -> list:
+        """Filter potential packages to test based on changed files."""
+        return []

--- a/Platform/Intel/BoardModulePkg/BoardModulePkg.ci.yaml
+++ b/Platform/Intel/BoardModulePkg/BoardModulePkg.ci.yaml
@@ -1,0 +1,108 @@
+## @file
+# CI configuration for BoardModulePkg
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+{
+    "PrEval": {
+        "DscPath": "BoardModulePkg.dsc",
+    },
+    ## options defined .pytool/Plugin/LicenseCheck
+    "LicenseCheck": {
+        "IgnoreFiles": []
+    },
+    "EccCheck": {
+        ## Exception sample looks like below:
+        ## "ExceptionList": [
+        ##     "<ErrorID>", "<KeyWord>"
+        ## ]
+        "ExceptionList": [
+        ],
+        ## Both file path and directory path are accepted.
+        "IgnoreFiles": [
+        ]
+    },
+    ## options defined .pytool/Plugin/CompilerPlugin
+    "CompilerPlugin": {
+        "DscPath": "BoardModulePkg.dsc"
+    },
+
+    ## options defined .pytool/Plugin/CharEncodingCheck
+    "CharEncodingCheck": {
+        "IgnoreFiles": [
+        ]
+    },
+
+    ## options defined .pytool/Plugin/DependencyCheck
+    "DependencyCheck": {
+        "AcceptableDependencies": [
+            "MdePkg/MdePkg.dec",
+            "MdeModulePkg/MdeModulePkg.dec",
+            "BoardModulePkg/BoardModulePkg.dec",
+            "SecurityPkg/SecurityPkg.dec",
+            "IntelSiliconPkg/IntelSiliconPkg.dec",
+            "MinPlatformPkg/MinPlatformPkg.dec"
+        ],
+        # For host based unit tests
+        "AcceptableDependencies-HOST_APPLICATION":[
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+        ],
+        # For UEFI shell based apps
+        "AcceptableDependencies-UEFI_APPLICATION":[],
+        "IgnoreInf": []
+    },
+
+    ## options defined .pytool/Plugin/DscCompleteCheck
+    "DscCompleteCheck": {
+        "IgnoreInf": [
+        ],
+        "DscPath": "BoardModulePkg.dsc"
+    },
+
+    ## options defined .pytool/Plugin/GuidCheck
+    "GuidCheck": {
+        "IgnoreGuidName": [],
+        "IgnoreGuidValue": ["00000000-0000-0000-0000-000000000000"],
+        "IgnoreFoldersAndFiles": [],
+        "IgnoreDuplicates": [
+        ]
+    },
+
+    ## options defined .pytool/Plugin/LibraryClassCheck
+    "LibraryClassCheck": {
+        "IgnoreLibraryClass": [
+        ],
+        "IgnoreHeaderFile": []
+    },
+
+    ## options defined .pytool/Plugin/SpellCheck
+    "SpellCheck": {
+        "AuditOnly": True,           # Fails test but run in AuditOnly mode to collect log
+        "IgnoreStandardPaths": [     # Standard Plugin defined paths that should be ignore
+            "*.c", "*.asm", "*.h", "*.nasm", "*.s", "*.asl", "*.inf"
+        ],
+        "IgnoreFiles": [             # use gitignore syntax to ignore errors in matching files
+            ""
+        ],
+        "ExtendWords": [           # words to extend to the dictionary for this package
+        ],
+        "AdditionalIncludePaths": [] # Additional paths to spell check relative to package root (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "IgnoreFiles": [
+        ]            # package root relative file, folder, or glob pattern to ignore
+    },
+
+    ## options defined .pytool/Plugin/UncrustifyCheck
+    "UncrustifyCheck": {
+        "AuditOnly": True,
+    },
+
+    ## options defined .pytool/Plugin/LineEndingCheck
+    "LineEndingCheck": {
+        "IgnoreFiles": ["**/*"]   # Ignore all line endings to prevent non-visible merge delta from upstream
+    }
+}

--- a/Platform/Intel/BoardModulePkg/BoardModulePkg.dec
+++ b/Platform/Intel/BoardModulePkg/BoardModulePkg.dec
@@ -37,6 +37,9 @@
   ## @libraryclass     Provides a service to determine the firmware boot media device.
   FirmwareBootMediaInfoLib|Include/Library/FirmwareBootMediaInfoLib.h
 
+  ## @libraryclass     Provides board specific BDS hooks
+  BoardBdsHooksLib|Include/Library/BoardBdsHookLib.h
+
 [Guids]
   ## Include Include/Guid/BiosId.h
   gBiosIdGuid = { 0xC3E36D09, 0x8294, 0x4b97, { 0xA8, 0x57, 0xD5, 0x28, 0x8F, 0xE3, 0x3E, 0x28 } }

--- a/Platform/Intel/BoardModulePkg/BoardModulePkg.dsc
+++ b/Platform/Intel/BoardModulePkg/BoardModulePkg.dsc
@@ -38,6 +38,20 @@
   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
   UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
+  PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
+  TimerLib|MdePkg/Library/BaseTimerLibNullTemplate/BaseTimerLibNullTemplate.inf
+  Tcg2PhysicalPresenceLib|SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
+  Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+  Tcg2PpVendorLib|SecurityPkg/Library/Tcg2PpVendorLibNull/Tcg2PpVendorLibNull.inf
+  VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
+  Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
+  Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
+  IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
+  PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
+  ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
+  SortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
+  UefiHiiServicesLib|MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.inf
+
 
 [LibraryClasses.common.PEIM]
   FirmwareBootMediaLib|IntelSiliconPkg/Library/PeiDxeSmmBootMediaLib/PeiFirmwareBootMediaLib.inf
@@ -52,6 +66,12 @@
   FirmwareBootMediaLib|IntelSiliconPkg/Library/PeiDxeSmmBootMediaLib/DxeSmmFirmwareBootMediaLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+  BoardBdsHookLib|BoardModulePkg/Library/BoardBdsHookLib/BoardBdsHookLib.inf
+  DxeServicesTableLib|MdePkg/Library/DxeServicesTableLib/DxeServicesTableLib.inf
+  HiiLib|MdeModulePkg/Library/UefiHiiLib/UefiHiiLib.inf
+  UefiBootManagerLib|MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+
+
 
 [LibraryClasses.common.UEFI_DRIVER]
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
@@ -92,3 +112,7 @@
 
   BoardModulePkg/Library/PeiFirmwareBootMediaInfoLib/PeiFirmwareBootMediaInfoLib.inf
   BoardModulePkg/Library/BdsPs2KbcLib/BdsPs2KbcLib.inf
+
+  BoardModulePkg/BoardBdsHookDxe/BoardBdsHookDxe.inf
+  BoardModulePkg/Library/BoardBdsHookLib/BoardBdsHookLib.inf
+  BoardModulePkg/Library/BoardBootManagerLib/BoardBootManagerLib.inf

--- a/Platform/MinPlatformPkg/MinPlatformPkg.ci.yaml
+++ b/Platform/MinPlatformPkg/MinPlatformPkg.ci.yaml
@@ -1,0 +1,114 @@
+## @file
+# CI configuration for MinPlatformPkg
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+{
+    "PrEval": {
+        "DscPath": "MinPlatformPkg.dsc",
+    },
+    ## options defined .pytool/Plugin/LicenseCheck
+    "LicenseCheck": {
+        "IgnoreFiles": []
+    },
+    "EccCheck": {
+        ## Exception sample looks like below:
+        ## "ExceptionList": [
+        ##     "<ErrorID>", "<KeyWord>"
+        ## ]
+        "ExceptionList": [
+        ],
+        ## Both file path and directory path are accepted.
+        "IgnoreFiles": [
+        ]
+    },
+    ## options defined .pytool/Plugin/CompilerPlugin
+    "CompilerPlugin": {
+        "DscPath": "MinPlatformPkg.dsc"
+    },
+
+    ## options defined .pytool/Plugin/CharEncodingCheck
+    "CharEncodingCheck": {
+        "IgnoreFiles": [
+        ]
+    },
+
+    ## options defined .pytool/Plugin/DependencyCheck
+    "DependencyCheck": {
+        "AcceptableDependencies": [
+            "MdePkg/MdePkg.dec",
+            "MdeModulePkg/MdeModulePkg.dec",
+            "UefiCpuPkg/UefiCpuPkg.dec",
+            "PcAtChipsetPkg/PcAtChipsetPkg.dec",
+            "IntelFsp2Pkg/IntelFsp2Pkg.dec",
+            "MinPlatformPkg/MinPlatformPkg.dec",
+            "IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec",
+            "SecurityPkg/SecurityPkg.dec",
+            "IntelSiliconPkg/IntelSiliconPkg.dec",
+            "CryptoPkg/CryptoPkg.dec",
+            "StandaloneMmPkg/StandaloneMmPkg.dec"
+        ],
+        # For host based unit tests
+        "AcceptableDependencies-HOST_APPLICATION":[
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+        ],
+        # For UEFI shell based apps
+        "AcceptableDependencies-UEFI_APPLICATION":[],
+        "IgnoreInf": []
+    },
+
+    ## options defined .pytool/Plugin/DscCompleteCheck
+    "DscCompleteCheck": {
+        "IgnoreInf": [
+        ],
+        "DscPath": "MinPlatformPkg.dsc"
+    },
+
+    ## options defined .pytool/Plugin/GuidCheck
+    "GuidCheck": {
+        "IgnoreGuidName": [],
+        "IgnoreGuidValue": ["00000000-0000-0000-0000-000000000000"],
+        "IgnoreFoldersAndFiles": [],
+        "IgnoreDuplicates": [
+        ]
+    },
+
+    ## options defined .pytool/Plugin/LibraryClassCheck
+    "LibraryClassCheck": {
+        "IgnoreLibraryClass": [
+        ],
+        "IgnoreHeaderFile": []
+    },
+
+    ## options defined .pytool/Plugin/SpellCheck
+    "SpellCheck": {
+        "AuditOnly": True,           # Fails test but run in AuditOnly mode to collect log
+        "IgnoreStandardPaths": [     # Standard Plugin defined paths that should be ignore
+            "*.c", "*.asm", "*.h", "*.nasm", "*.s", "*.asl", "*.inf"
+        ],
+        "IgnoreFiles": [             # use gitignore syntax to ignore errors in matching files
+            "Library/LzmaCustomDecompressLib/Sdk/DOC/*"
+        ],
+        "ExtendWords": [           # words to extend to the dictionary for this package
+        ],
+        "AdditionalIncludePaths": [] # Additional paths to spell check relative to package root (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "IgnoreFiles": [
+        ]            # package root relative file, folder, or glob pattern to ignore
+    },
+
+    ## Disabling uncrustify until edk2-platforms updates
+    ## options defined .pytool/Plugin/UncrustifyCheck
+    "UncrustifyCheck": {
+        "AuditOnly": True,
+    },
+
+    ## options defined .pytool/Plugin/LineEndingCheck
+    "LineEndingCheck": {
+        "IgnoreFiles": ["**/*"]   # Ignore all line endings to prevent non-visible merge delta from upstream
+    }
+}

--- a/Platform/MinPlatformPkg/MinPlatformPkg.dsc
+++ b/Platform/MinPlatformPkg/MinPlatformPkg.dsc
@@ -114,6 +114,12 @@
   TestPointCheckLib|MinPlatformPkg/Test/Library/TestPointCheckLib/SmmTestPointCheckLib.inf
   TestPointLib|MinPlatformPkg/Test/Library/TestPointLib/SmmTestPointLib.inf
 
+[LibraryClasses.common.MM_STANDALONE]
+  MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
+  StandaloneMmDriverEntryPoint|MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
+  ReportStatusCodeLib|MdeModulePkg/Library/SmmReportStatusCodeLib/StandaloneMmReportStatusCodeLib.inf
+  MemoryAllocationLib|StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
+
 ###################################################################################################
 #
 # Components Section - list of the modules and components that will be processed by compilation

--- a/Silicon/Intel/IntelSiliconPkg/IntelSiliconPkg.ci.yaml
+++ b/Silicon/Intel/IntelSiliconPkg/IntelSiliconPkg.ci.yaml
@@ -1,0 +1,66 @@
+## @file
+# Core CI configuration for IntelSiliconPkg
+#
+# MU_CHANGE: Whole file
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+{
+    "CompilerPlugin": {
+        "DscPath": "IntelSiliconPkg.dsc"
+    },
+    "HostUnitTestCompilerPlugin": {
+        "DscPath": "Test/IntelSiliconPkgHostTest.dsc"
+    },
+    "HostUnitTestDscCompleteCheck": {
+        "DscPath": "Test/IntelSiliconPkgHostTest.dsc",
+        "IgnoreInf": []
+    },
+    "CharEncodingCheck": {
+        "IgnoreFiles": []
+    },
+    "DependencyCheck": {
+        "AcceptableDependencies": [
+            "MdePkg/MdePkg.dec",
+            "MdeModulePkg/MdeModulePkg.dec",
+            "IntelSiliconPkg/IntelSiliconPkg.dec",
+            "UefiCpuPkg/UefiCpuPkg.dec",
+        ],
+        "AcceptableDependencies-HOST_APPLICATION":[ # for host based unit tests
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+        ],
+        "IgnoreInf": [
+            "IntelSiliconPkg/Library/BaseConfigBlockLib/BaseConfigBlockLib.inf"
+        ]
+    },
+    "DscCompleteCheck": {
+        "DscPath": "IntelSiliconPkg.dsc",
+        "IgnoreInf": [
+            "IntelSiliconPkg/Feature/Capsule/MicrocodeCapsuleTxt/Microcode/Microcode.inf",
+            "IntelSiliconPkg/Library/BaseConfigBlockLib/BaseConfigBlockLib.inf"
+        ]
+    },
+    "GuidCheck": {
+        "IgnoreGuidName": [],
+        "IgnoreGuidValue": ["00000000-0000-0000-0000-000000000000"],
+        "IgnoreFoldersAndFiles": []
+    },
+    "LibraryClassCheck": {
+        "IgnoreHeaderFile": []
+    },
+    "MarkdownLintCheck": {
+        "AuditOnly": False,          # If True, log all errors and then mark as skipped
+        "IgnoreFiles": [
+            "Feature/Capsule",
+        ]            # package root relative file, folder, or glob pattern to ignore
+    },
+
+    "SpellCheck": {
+        "AuditOnly": True,           # Fails test but run in AuditOnly mode to collect log
+        "IgnoreFiles": [],           # use gitignore syntax to ignore errors in matching files
+        "ExtendWords": [],           # words to extend to the dictionary for this package
+        "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
+        "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
+    }
+}

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,0 +1,21 @@
+## @file
+# EDK II Python PIP requirements file
+#
+# This file provides the list of python components to install using PIP.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# https://pypi.org/project/pip/
+# https://pip.pypa.io/en/stable/user_guide/#requirements-files
+# https://pip.pypa.io/en/stable/reference/requirements-file-format
+# https://www.python.org/dev/peps/pep-0440/#version-specifiers
+##
+
+edk2-pytool-library~=0.23.13
+edk2-pytool-extensions~=0.31.0
+antlr4-python3-runtime==4.13.2
+lcov-cobertura==2.1.1
+regex==2026.5.9
+pylibfdt==1.7.2.post1
+pefile


### PR DESCRIPTION
Adding the capability to run stuart_ci_builds to the edk2 platforms repo.

This PR is targeting the Platform/Intel/BoardModulePkg, Platform/MinPlatformPkg and Silicon/Intel/IntelSiliconPkg as targets for stuart_ci.

More targets can be added as needed. 