### PR TITLE
RB3Gen2, SbsaQemu: Add ArmSmcccSocIdLib to fix ProcessorSubClassDxe build failure

### DIFF
--- a/Platform/Qemu/SbsaQemu/SbsaQemu.dsc
+++ b/Platform/Qemu/SbsaQemu/SbsaQemu.dsc
@@ -104,6 +104,7 @@ DEFINE NETWORK_HTTP_BOOT_ENABLE       = FALSE
   CacheMaintenanceLib|ArmPkg/Library/ArmCacheMaintenanceLib/ArmCacheMaintenanceLib.inf
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
   ArmSmcLib|MdePkg/Library/ArmSmcLib/ArmSmcLib.inf
+  ArmSmcccSocIdLib|ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.inf
   ArmHvcLib|ArmPkg/Library/ArmHvcLib/ArmHvcLib.inf
   ArmTransferListLib|ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
   ArmGenericTimerCounterLib|ArmPkg/Library/ArmGenericTimerVirtCounterLib/ArmGenericTimerVirtCounterLib.inf

--- a/Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
+++ b/Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc
@@ -100,6 +100,7 @@ DEFINE NETWORK_HTTP_BOOT_ENABLE       = FALSE
   CacheMaintenanceLib|ArmPkg/Library/ArmCacheMaintenanceLib/ArmCacheMaintenanceLib.inf
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
   ArmSmcLib|MdePkg/Library/ArmSmcLib/ArmSmcLib.inf
+  ArmSmcccSocIdLib|ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.inf
   ArmHvcLib|ArmPkg/Library/ArmHvcLib/ArmHvcLib.inf
   ArmTransferListLib|ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
   ArmGenericTimerCounterLib|ArmPkg/Library/ArmGenericTimerVirtCounterLib/ArmGenericTimerVirtCounterLib.inf


### PR DESCRIPTION
edk2 PR: (https://github.com/tianocore/edk2/pull/12846)  introduced `ArmSmcccSocIdLib` as a new dependency of `ProcessorSubClassDxe` .The following build error is seen on platforms that include `ProcessorSubClassDxe`:

```
 error 4000: Instance of library class [ArmSmcccSocIdLib] is not found for module
 [ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassDxe.inf]
```
Added `ArmSmcccSocIdLib|ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.inf` to below platform DSC files for fixing the compilation.
- `Platform/Qualcomm/RB3Gen2/RB3Gen2.dsc`
- `Platform/Qemu/SbsaQemu/SbsaQemu.dsc`

Compilation verified successfully for:
- `RB3Gen2` — AARCH64 RELEASE, DEBUG
- `SbsaQemu` — AARCH64 RELEASE, DEBUG