### PR TITLE
Platform/ARM/VExpressPkg: Enabling Single-Reboot Capsule Firmware Updates on Arm Platforms

### DIFF
--- a/Platform/ARM/ARM.dec
+++ b/Platform/ARM/ARM.dec
@@ -42,6 +42,15 @@
   #
   gPlatformArmTokenSpaceGuid.PcdFwuDirectWrite|FALSE|BOOLEAN|0x0000010
 
+  #
+  # When this option is enabled, FWU_COMMIT would perform FMP image
+  # authtentication.
+  # To use this option, gPlatformArmTokenSpaceGuid.PcdFwuDirectWrite 
+  # must be enabled and FmpDevice Instance must enable
+  # gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceDeferImageAuthToSetImage.
+  #
+  gPlatformArmTokenSpaceGuid.PcdFwuFmpImageAuth|FALSE|BOOLEAN|0x0000011
+
 [PcdsFixedAtBuild.common]
   gPlatformArmTokenSpaceGuid.PcdNorFlashRegBaseAddress|0x0|UINT32|0x00000002
 

--- a/Platform/ARM/ARM.dec
+++ b/Platform/ARM/ARM.dec
@@ -31,6 +31,17 @@
 [PcdsFeatureFlag.common]
   gPlatformArmTokenSpaceGuid.PcdNorFlashCheckBlockLocked|FALSE|BOOLEAN|0x0000001
 
+  # Firmware Update features
+
+  #
+  # When this option is enabled, FWU_COMMAND_WRITE_STREAM doesn't write
+  # to buffer but write into firwmare storage directly.
+  # Otherwise, buffered writes will be flushed at PSA_MM_FWU_COMMAND_COMMIT.
+  # This is useful if firmware update agent needs to authenticate the
+  # delivered image.
+  #
+  gPlatformArmTokenSpaceGuid.PcdFwuDirectWrite|FALSE|BOOLEAN|0x0000010
+
 [PcdsFixedAtBuild.common]
   gPlatformArmTokenSpaceGuid.PcdNorFlashRegBaseAddress|0x0|UINT32|0x00000002
 

--- a/Platform/ARM/Drivers/FwuSmm/FwuSmm.c
+++ b/Platform/ARM/Drivers/FwuSmm/FwuSmm.c
@@ -123,18 +123,25 @@ typedef struct {
 
   /// See the IFD_F_STATUS_*
   UINT64            Status;
+
+  /// For buffered write
+  UINT8             *Buffer;
+
+  /// Current Pos for Commit
+  UINTN             CommitPos;
 } IMAGE_FILE_DESCRIPTOR;
 
 STATIC EFI_MMRAM_DESCRIPTOR        *mNsCommBufferRange;
-STATIC EFI_MM_SYSTEM_TABLE         *mMmst           = NULL;
-STATIC UINT32                      mStagingFlags    = 0;
-STATIC IMAGE_FILE_DESCRIPTOR       *mFdTable        = NULL;
-STATIC UINTN                       mFdTableSize     = 0;
-STATIC PSA_MM_FWU_IMAGE_DIRECTORY  *mImageDirectory = NULL;
-STATIC FWS_DEVICE_INSTANCE         *mFwsDevice      = NULL;
-STATIC FW_STORE_STATE              mFwState         = FW_STORE_REGULAR;
-STATIC UINT32                      mFwuFlags        = 0;
-STATIC UINT32                      mFwuVendorFlags  = 0;
+STATIC EFI_MM_SYSTEM_TABLE         *mMmst             = NULL;
+STATIC UINT32                      mStagingFlags      = 0;
+STATIC IMAGE_FILE_DESCRIPTOR       *mFdTable          = NULL;
+STATIC UINTN                       mFdTableSize       = 0;
+STATIC PSA_MM_FWU_IMAGE_DIRECTORY  *mImageDirectory   = NULL;
+STATIC FWS_DEVICE_INSTANCE         *mFwsDevice        = NULL;
+STATIC FW_STORE_STATE              mFwState           = FW_STORE_REGULAR;
+STATIC UINT32                      mFwuFlags          = 0;
+STATIC UINT32                      mFwuVendorFlags    = 0;
+STATIC UINTN                       mFwuCommitUnitSize = 0;
 
 // Initialise the Service status to error init by default.
 STATIC UINT32  mServiceStatus = SERVICE_STATUS_ERR_INIT;
@@ -265,9 +272,16 @@ ClearStaging (
         }
 
         ASSERT (Status == EFI_SUCCESS);
+
+        Ifd->ImageFile = NULL;
         Ifd->Pos       = 0;
         Ifd->OpType    = FwuOpStreamRead;
-        Ifd->ImageFile = NULL;
+        Ifd->CommitPos = 0;
+
+        if (Ifd->Buffer != NULL) {
+          FreePool (Ifd->Buffer);
+          Ifd->Buffer = NULL;
+        }
       } else if (Mode == CLEAR_ERROR) {
         /**
          * CLEAR_ERROR Mode could be called when an error occurred during the begining staging.
@@ -471,6 +485,8 @@ InitImageFileDescTable (
   Ifd->Pos               = 0;
   Ifd->OpType            = FwuOpStreamRead;
   Ifd->Status            = 0;
+  Ifd->CommitPos         = 0;
+  Ifd->Buffer            = NULL;
 
   for (Idx = 1; Idx < mFdTableSize; Idx++) {
     Ifd     = &mFdTable[Idx];
@@ -481,6 +497,8 @@ InitImageFileDescTable (
     Ifd->Pos               = 0;
     Ifd->OpType            = FwuOpStreamRead;
     Ifd->Status            = 0;
+    Ifd->CommitPos         = 0;
+    Ifd->Buffer            = NULL;
   }
 
   return EFI_SUCCESS;
@@ -781,6 +799,7 @@ FwuSmmOpen (
   IMAGE_FILE_DESCRIPTOR      *Ifd = NULL;
   CONST PSA_MM_FWU_OPEN_REQ  *ReqData;
   PSA_MM_FWU_OPEN_RESP       *RespData;
+  UINTN                      BufferSize;
 
   ReqData  = (CONST PSA_MM_FWU_OPEN_REQ *)GET_FWU_DATA_BUFFER (Message);
   RespData = (PSA_MM_FWU_OPEN_RESP *)GET_FWU_DATA_BUFFER (Message);
@@ -823,6 +842,17 @@ FwuSmmOpen (
                );
     if (EFI_ERROR (Status)) {
       return PSA_MM_FWU_NOT_AVAILABLE;
+    }
+
+    if (!FeaturePcdGet (PcdFwuDirectWrite)) {
+      BufferSize  = Ifd->ImageFile->MaxSize;
+      Ifd->Buffer = AllocateRuntimeZeroPool (BufferSize);
+      if (Ifd->Buffer == NULL) {
+        FwsRelease (Ifd->ImageFile, 0, NULL, NULL);
+        Ifd->ImageFile = NULL;
+
+        return PSA_MM_FWU_NOT_AVAILABLE;
+      }
     }
   } else {
     Ifd->ImageFile = AllocateRuntimePool (sizeof (FWS_IMAGE_FILE));
@@ -907,12 +937,16 @@ FwuSmmWriteStream (
     return PSA_MM_FWU_OUT_OF_BOUNDS;
   }
 
-  Status = FwsWrite (Ifd->ImageFile, WriteBuffer, &WriteSize, Ifd->Pos);
-  if (EFI_ERROR (Status)) {
-    return PSA_MM_FWU_NO_PERMISSION;
+  if (FeaturePcdGet (PcdFwuDirectWrite)) {
+    Status = FwsWrite (Ifd->ImageFile, WriteBuffer, &WriteSize, Ifd->Pos);
+    if (EFI_ERROR (Status)) {
+      return PSA_MM_FWU_NO_PERMISSION;
+    }
+  } else {
+    CopyMem (Ifd->Buffer + Ifd->Pos, WriteBuffer, WriteSize);
   }
 
-  Ifd->Pos += ReqData->DataLen;
+  Ifd->Pos += WriteSize;
 
   return PSA_MM_FWU_SUCCESS;
 }
@@ -1034,6 +1068,7 @@ FwuSmmCommit (
   CONST PSA_MM_FWU_COMMIT_REQ  *ReqData;
   PSA_MM_FWU_COMMIT_RESP       *RespData;
   BOOLEAN                      IsCorrectBoot;
+  UINTN                        WriteSize;
 
   ReqData  = (CONST PSA_MM_FWU_COMMIT_REQ *)GET_FWU_DATA_BUFFER (Message);
   RespData = (PSA_MM_FWU_COMMIT_RESP *)GET_FWU_DATA_BUFFER (Message);
@@ -1048,6 +1083,25 @@ FwuSmmCommit (
     FwuStatus = PSA_MM_FWU_SUCCESS;
 
     goto ErrorHandler;
+  }
+
+  if (!FeaturePcdGet (PcdFwuDirectWrite) && (Ifd->OpType == FwuOpStreamWrite) &&
+      (Ifd->Pos != Ifd->CommitPos))
+  {
+    WriteSize = MIN (mFwuCommitUnitSize, (Ifd->Pos - Ifd->CommitPos));
+    Status    = FwsWrite (Ifd->ImageFile, Ifd->Buffer + Ifd->CommitPos, &WriteSize, Ifd->CommitPos);
+    if (EFI_ERROR (Status)) {
+      FwuStatus = PSA_MM_FWU_AUTH_FAIL;
+      goto ErrorHandler;
+    }
+
+    Ifd->CommitPos += WriteSize;
+
+    if (Ifd->Pos != Ifd->CommitPos) {
+      RespData->Progress  = Ifd->CommitPos;
+      RespData->TotalWork = Ifd->Pos;
+      return PSA_MM_FWU_RESUME;
+    }
   }
 
   FwsCheckCorrectBoot (Ifd->ImageFile->FwsDevice, &IsCorrectBoot);
@@ -1115,9 +1169,15 @@ FwuSmmCommit (
   FwuStatus = PSA_MM_FWU_SUCCESS;
 
 ErrorHandler:
+  if (Ifd->Buffer != NULL) {
+    FreePool (Ifd->Buffer);
+    Ifd->Buffer = NULL;
+  }
+
   Ifd->ImageFile = NULL;
   Ifd->Pos       = 0;
   Ifd->OpType    = FwuOpStreamRead;
+  Ifd->CommitPos = 0;
 
   return FwuStatus;
 }
@@ -1483,6 +1543,16 @@ FwuSmmMain (
   }
 
   DEBUG ((DEBUG_BLKIO, "Firmware Update Driver: Current FwState: %d\n", mFwState));
+
+  /*
+   * Commit unit size used for buffered writes.
+   * The buffered data up to this size will be committed
+   * in a single commit request.
+   * Currently, this is limited to the maximum write payload size.
+   */
+  mFwuCommitUnitSize = mNsCommBufferRange->PhysicalSize -
+                       sizeof (EFI_MM_COMMUNICATE_HEADER) -
+                       GetRequiredBufferSize (PSA_MM_FWU_COMMAND_WRITE_STREAM);
 
   mServiceStatus = SERVICE_STATUS_OPERATIVE;
 

--- a/Platform/ARM/Drivers/FwuSmm/FwuSmm.c
+++ b/Platform/ARM/Drivers/FwuSmm/FwuSmm.c
@@ -58,13 +58,17 @@
 
 #include <Library/ArmMmHandlerContext.h>
 #include <Library/BaseLib.h>
-#include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/FmpAuthenticationLib.h>
+#include <Library/FmpDependencyLib.h>
+#include <Library/FmpPayloadHeaderLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/HobLib.h>
 #include <Library/MmServicesTableLib.h>
 
 #include <Protocol/BlockIo.h>
+#include <Protocol/FirmwareManagement.h>
 #include <Protocol/MmCommunication2.h>
 
 #include <Library/FwsPlatformLib.h>
@@ -79,6 +83,8 @@
 
 #define IFD_IS_OPENED(Ifd)          ((((Ifd)->ImageFile != NULL)))
 #define IFD_IS_STATUS_STAGING(Ifd)  ((BOOLEAN) ((((Ifd)->Status) & IFD_F_STATUS_STAGING) != 0))
+
+#define FMP_MAX_HEADER_SIZE  (SIZE_1MB)
 
 /**
  * See the PSA specification 3.2.1 Firmware Store state machine.
@@ -129,6 +135,9 @@ typedef struct {
 
   /// Current Pos for Commit
   UINTN             CommitPos;
+
+  /// Trimmed Size from buffer (e.x) Header for authtentication.
+  UINTN             TrimmedSize;
 } IMAGE_FILE_DESCRIPTOR;
 
 STATIC EFI_MMRAM_DESCRIPTOR        *mNsCommBufferRange;
@@ -273,10 +282,11 @@ ClearStaging (
 
         ASSERT (Status == EFI_SUCCESS);
 
-        Ifd->ImageFile = NULL;
-        Ifd->Pos       = 0;
-        Ifd->OpType    = FwuOpStreamRead;
-        Ifd->CommitPos = 0;
+        Ifd->ImageFile   = NULL;
+        Ifd->Pos         = 0;
+        Ifd->OpType      = FwuOpStreamRead;
+        Ifd->CommitPos   = 0;
+        Ifd->TrimmedSize = 0;
 
         if (Ifd->Buffer != NULL) {
           FreePool (Ifd->Buffer);
@@ -487,6 +497,7 @@ InitImageFileDescTable (
   Ifd->Status            = 0;
   Ifd->CommitPos         = 0;
   Ifd->Buffer            = NULL;
+  Ifd->TrimmedSize       = 0;
 
   for (Idx = 1; Idx < mFdTableSize; Idx++) {
     Ifd     = &mFdTable[Idx];
@@ -499,9 +510,138 @@ InitImageFileDescTable (
     Ifd->Status            = 0;
     Ifd->CommitPos         = 0;
     Ifd->Buffer            = NULL;
+    Ifd->TrimmedSize       = 0;
   }
 
   return EFI_SUCCESS;
+}
+
+/**
+ * Authenticate the Image which includes the FmpHeaders before
+ * writing any data from the image into firmware storage.
+ *
+ * @param[in] Ifd               Image file descriptor
+ *
+ * @retval PSA_MM_FWU_SUCCESS
+ * @retval PSA_MM_FWU_AUTH_FAIL
+ */
+STATIC
+INT32
+EFIAPI
+ImageFileAuthtenticate (
+  IN IMAGE_FILE_DESCRIPTOR  *Ifd
+  )
+{
+  RETURN_STATUS  Status;
+  VOID           *PublicKeyData;
+  UINTN          PublicKeyDataLength;
+  UINT8          *PublicKeyDataXdr;
+  UINT8          *PublicKeyDataXdrEnd;
+
+  /*
+   * If PcdFwuFmpImageAuth is FALSE, the authentication is already done
+   * in the normal world.
+   */
+  if (!FeaturePcdGet (PcdFwuFmpImageAuth)) {
+    return PSA_MM_FWU_SUCCESS;
+  }
+
+  PublicKeyDataXdr    = PcdGetPtr (PcdFmpDevicePkcs7CertBufferXdr);
+  PublicKeyDataXdrEnd = PublicKeyDataXdr + PcdGetSize (PcdFmpDevicePkcs7CertBufferXdr);
+
+  if ((PublicKeyDataXdr == NULL) || (PublicKeyDataXdr == PublicKeyDataXdrEnd)) {
+    return PSA_MM_FWU_AUTH_FAIL;
+  }
+
+  while (PublicKeyDataXdr < PublicKeyDataXdrEnd) {
+    if ((PublicKeyDataXdr + sizeof (UINT32)) > PublicKeyDataXdrEnd) {
+      DEBUG ((DEBUG_ERROR, "FwuSmm(%g): Certificate size extends beyond end of Data.\n", &Ifd->ImageTypeGuid));
+      return PSA_MM_FWU_AUTH_FAIL;
+    }
+
+    PublicKeyDataLength = SwapBytes32 (*(UINT32 *)(PublicKeyDataXdr));
+    PublicKeyDataXdr   += sizeof (UINT32);
+
+    if (PublicKeyDataXdr + PublicKeyDataLength > PublicKeyDataXdrEnd) {
+      DEBUG ((DEBUG_ERROR, "FwuSmm(%g): Certificate size extends beyond end of Data.\n", &Ifd->ImageTypeGuid));
+      return PSA_MM_FWU_AUTH_FAIL;
+    }
+
+    PublicKeyData = PublicKeyDataXdr;
+    Status        = AuthenticateFmpImage (
+                      (EFI_FIRMWARE_IMAGE_AUTHENTICATION *)Ifd->Buffer,
+                      Ifd->Pos,
+                      PublicKeyData,
+                      PublicKeyDataLength
+                      );
+    if (RETURN_ERROR (Status) && (Status != RETURN_SECURITY_VIOLATION)) {
+      DEBUG ((DEBUG_ERROR, "FwuSmm(%g): Invalid Image Header for auth: %r\n", &Ifd->ImageTypeGuid, Status));
+      return PSA_MM_FWU_AUTH_FAIL;
+    }
+
+    PublicKeyDataXdr += ALIGN_VALUE (PublicKeyDataLength, 4);
+  }
+
+  if (Status != RETURN_SUCCESS) {
+    DEBUG ((DEBUG_ERROR, "FwuSmm(%g): Failed to verify the Image.\n", &Ifd->ImageTypeGuid));
+    return PSA_MM_FWU_AUTH_FAIL;
+  }
+
+  return PSA_MM_FWU_SUCCESS;
+}
+
+/**
+ * Trim Headers from the Image file.
+ *
+ * @param[in] Ifd               Image file descriptor
+ *
+ */
+STATIC
+VOID
+EFIAPI
+ImageFileTrimHeaders (
+  IN IMAGE_FILE_DESCRIPTOR  *Ifd
+  )
+{
+  EFI_STATUS                         Status;
+  EFI_FIRMWARE_IMAGE_AUTHENTICATION  *Image;
+  UINTN                              ImageSize;
+  UINT32                             DependenciesSize;
+  VOID                               *FmpPayload;
+  UINTN                              FmpPayloadSize;
+  UINT32                             FmpHeaderSize;
+  UINT32                             AllHeaderSize;
+
+  if (!FeaturePcdGet (PcdFwuFmpImageAuth)) {
+    return;
+  }
+
+  Image            = (EFI_FIRMWARE_IMAGE_AUTHENTICATION *)Ifd->Buffer;
+  ImageSize        = Ifd->Pos;
+  DependenciesSize = 0;
+  FmpHeaderSize    = 0;
+
+  GetImageDependency (Image, ImageSize, &DependenciesSize, NULL);
+
+  FmpPayload =  (VOID *)((UINT8 *)Image + sizeof (Image->MonotonicCount) +
+                         Image->AuthInfo.Hdr.dwLength  + DependenciesSize);
+  FmpPayloadSize = ImageSize - (sizeof (Image->MonotonicCount) +
+                                Image->AuthInfo.Hdr.dwLength + DependenciesSize);
+  Status = GetFmpPayloadHeaderSize (FmpPayload, FmpPayloadSize, &FmpHeaderSize);
+
+  /*
+   * FmpHeader verification is already done in normal world.
+   * Therefore, it's enough to ASSERT in here.
+   */
+  ASSERT_EFI_ERROR (Status);
+
+  AllHeaderSize = sizeof (Image->MonotonicCount) +
+                  FmpHeaderSize + DependenciesSize +
+                  Image->AuthInfo.Hdr.dwLength;
+
+  Ifd->Buffer     += AllHeaderSize;
+  Ifd->Pos        -= AllHeaderSize;
+  Ifd->TrimmedSize = AllHeaderSize;
 }
 
 /**
@@ -845,7 +985,11 @@ FwuSmmOpen (
     }
 
     if (!FeaturePcdGet (PcdFwuDirectWrite)) {
-      BufferSize  = Ifd->ImageFile->MaxSize;
+      BufferSize = Ifd->ImageFile->MaxSize;
+      if (FeaturePcdGet (PcdFwuFmpImageAuth)) {
+        BufferSize += FMP_MAX_HEADER_SIZE;
+      }
+
       Ifd->Buffer = AllocateRuntimeZeroPool (BufferSize);
       if (Ifd->Buffer == NULL) {
         FwsRelease (Ifd->ImageFile, 0, NULL, NULL);
@@ -1088,6 +1232,15 @@ FwuSmmCommit (
   if (!FeaturePcdGet (PcdFwuDirectWrite) && (Ifd->OpType == FwuOpStreamWrite) &&
       (Ifd->Pos != Ifd->CommitPos))
   {
+    if (Ifd->CommitPos == 0) {
+      FwuStatus = ImageFileAuthtenticate (Ifd);
+      if (FwuStatus != PSA_MM_FWU_SUCCESS) {
+        goto ErrorHandler;
+      }
+
+      ImageFileTrimHeaders (Ifd);
+    }
+
     WriteSize = MIN (mFwuCommitUnitSize, (Ifd->Pos - Ifd->CommitPos));
     Status    = FwsWrite (Ifd->ImageFile, Ifd->Buffer + Ifd->CommitPos, &WriteSize, Ifd->CommitPos);
     if (EFI_ERROR (Status)) {
@@ -1170,14 +1323,15 @@ FwuSmmCommit (
 
 ErrorHandler:
   if (Ifd->Buffer != NULL) {
-    FreePool (Ifd->Buffer);
+    FreePool (Ifd->Buffer - Ifd->TrimmedSize);
     Ifd->Buffer = NULL;
   }
 
-  Ifd->ImageFile = NULL;
-  Ifd->Pos       = 0;
-  Ifd->OpType    = FwuOpStreamRead;
-  Ifd->CommitPos = 0;
+  Ifd->ImageFile   = NULL;
+  Ifd->Pos         = 0;
+  Ifd->OpType      = FwuOpStreamRead;
+  Ifd->CommitPos   = 0;
+  Ifd->TrimmedSize = 0;
 
   return FwuStatus;
 }
@@ -1468,6 +1622,11 @@ FwuSmmMain (
   EFI_BLOCK_IO_PROTOCOL  *NorFlashBlockIo = NULL;
   UINT16                 Idx;
   BOOLEAN                IsTrialState;
+
+  if (FeaturePcdGet (PcdFwuFmpImageAuth) && FeaturePcdGet (PcdFwuDirectWrite)) {
+    DEBUG ((DEBUG_ERROR, "PcdFwuDirectWrite should be disabled for PcdFwuFmpImageAuth.\n"));
+    return EFI_UNSUPPORTED;
+  }
 
   Status = gMmst->MmLocateProtocol (
                     &gEfiBlockIoProtocolGuid,

--- a/Platform/ARM/Drivers/FwuSmm/FwuSmm.inf
+++ b/Platform/ARM/Drivers/FwuSmm/FwuSmm.inf
@@ -49,6 +49,9 @@
   gPlatformArmTokenSpaceGuid.PcdFwuNumberOfBanks
   gPlatformArmTokenSpaceGuid.PcdFwuImagesPerBank
 
+[FeaturePcd]
+  gPlatformArmTokenSpaceGuid.PcdFwuDirectWrite
+
 [Guids]
   gPsaFwuUpdateAgentGuid
   gPsaFwuImageDirectoryGuid

--- a/Platform/ARM/Drivers/FwuSmm/FwuSmm.inf
+++ b/Platform/ARM/Drivers/FwuSmm/FwuSmm.inf
@@ -27,8 +27,10 @@
 
 [Packages]
   ArmPkg/ArmPkg.dec
+  FmpDevicePkg/FmpDevicePkg.dec
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
+  SecurityPkg/SecurityPkg.dec
   StandaloneMmPkg/StandaloneMmPkg.dec
   Platform/ARM/ARM.dec
   Platform/ARM/VExpressPkg/ArmVExpressPkg.dec
@@ -37,20 +39,25 @@
   ArmLib
   BaseMemoryLib
   DebugLib
+  FmpAuthenticationLib
+  FmpDependencyLib
+  FmpPayloadHeaderLib
+  FwsPlatformLib
+  HobLib
   MemoryAllocationLib
   StandaloneMmDriverEntryPoint
-  HobLib
-  FwsPlatformLib
 
 [Protocols]
   gEfiBlockIoProtocolGuid
 
 [FixedPcd]
+  gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr
   gPlatformArmTokenSpaceGuid.PcdFwuNumberOfBanks
   gPlatformArmTokenSpaceGuid.PcdFwuImagesPerBank
 
 [FeaturePcd]
   gPlatformArmTokenSpaceGuid.PcdFwuDirectWrite
+  gPlatformArmTokenSpaceGuid.PcdFwuFmpImageAuth
 
 [Guids]
   gPsaFwuUpdateAgentGuid

--- a/Platform/ARM/Features/Fwu/FmpSystemFipImage.dsc.inc
+++ b/Platform/ARM/Features/Fwu/FmpSystemFipImage.dsc.inc
@@ -98,7 +98,13 @@
       # For more detail, Please see "Quick Start" Section of
       # Platform/ARM/Features/Fwu/Readme.md
       #
+
+!ifdef FMP_SYSTEM_FIP_CERT_PCD_FILE
       !include $(FMP_SYSTEM_FIP_CERT_PCD_FILE)
+!endif
+
+    <PcdsFeatureFlag>
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceDeferImageAuthToSetImage|FALSE
 
     <LibraryClasses>
       #

--- a/Platform/ARM/Features/Fwu/FmpSystemFipImageRuntime.dsc.inc
+++ b/Platform/ARM/Features/Fwu/FmpSystemFipImageRuntime.dsc.inc
@@ -1,0 +1,126 @@
+#/** @file
+# FmpDxe driver for AArch64 firmware update.
+#
+#  Copyright (c) 2024, Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+#**/
+[Defines]
+  # System fip firmware image type guid.
+  # This will be the filename of FmpDevicePkg and used to find firmware image
+  DEFINE FMP_SYSTEM_FIP_IMAGE_GUID = 49757D90-6C22-11EE-A556-1757EBA0420C
+
+[PcdsPatchableInModule.common]
+  #
+  # Firmware Update
+  #
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSystemFmpCapsuleImageTypeIdGuid|{GUID("$(FMP_SYSTEM_FIP_IMAGE_GUID)")}|VOID*|0x10
+
+[Components.common]
+  MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
+  MdeModulePkg/Application/CapsuleApp/CapsuleApp.inf {
+    <LibraryClasses>
+      PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+      BmpSupportLib|MdeModulePkg/Library/BaseBmpSupportLib/BaseBmpSupportLib.inf
+  }
+
+  FmpDevicePkg/FmpDxe/FmpDxeRuntime.inf {
+    <Defines>
+      #
+      # ESRT and FMP GUID for system firmware capsule update
+      #
+      FILE_GUID = $(FMP_SYSTEM_FIP_IMAGE_GUID)
+
+    <PcdsFixedAtBuild>
+      #
+      # Unicode name string that is used to populate FMP Image Descriptor for this capsule update module
+      #
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceImageIdName|L"System Fip Firmware Image"
+
+      #
+      # ESRT and FMP Lowest Support Version for this capsule update module
+      # 000.000.000.000
+      #
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceBuildTimeLowestSupportedVersion|0x00000000
+
+      gArmTokenSpaceGuid.PcdSystemFirmwareFmpLowestSupportedVersion|0x00000000
+      gArmTokenSpaceGuid.PcdSystemFirmwareFmpVersion|0x00000000
+      gArmTokenSpaceGuid.PcdSystemFirmwareFmpVersionString|"000.000.000.000"
+
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceProgressWatchdogTimeInSeconds|4
+
+      #
+      # Lock all updatable firmware devices at Exit boot Services.
+      # This allows to update firmware via CapsuleApp.
+      #
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceLockEventGuid|{GUID(gEfiEventExitBootServicesGuid)}
+
+      #
+      # Capsule Update Progress Bar Color.  Set to Purple (RGB) (255, 0, 255)
+      #
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceProgressColor|0x00FF00FF
+
+      #
+      # Certificates are used to authenticate capsule update image.
+      # Root certificate should be converted to Pcd format using BinToPcd.py
+      #
+      #
+      # Certificate used for FmpDevicePkg.
+      #
+      # Without generating Pcd certificate file, we couldn't build properly
+      # with build option, ENABLE_FIRMWARE_UPDATE == TRUE.
+      #
+      # If you have your own certificate chain,
+      # Please generate the Pcd file with your Root certificate:
+      #     openssl x509 -in {ROOT_CERT_FILE} -out Root.cer -outform DER
+      #     BinToPcd.py -i Root.cer gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr \
+      #                 -x -o {CERT_PCD_FILE_PATH}
+      # And Build with:
+      #    -D FMP_SYSTEM_FIP_CERT_PCD_FILE={CERT_PCD_FILE_PATH}
+      #
+      # For test and development, you can generate all test certificates chain
+      # and required Pcd file with:
+      #     python3 Features/Fwu/GenTestCert.py
+      #
+      # NOTE: This tool should run after edk2 build setup.
+      #
+      # The tool generates all test certificates chain in 'TestCert' directory
+      # and generate below then Pcd file in.
+      #
+      #    Platform/ARM/VExpressPkg/Root.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
+      #
+      #
+      # And Build with:
+      #    -D FMP_SYSTEM_FIP_CERT_PCD_FILE=Platform/ARM/VExpressPkg/Root.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
+      #
+      # For more detail, Please see "Quick Start" Section of
+      # Platform/ARM/Features/Fwu/Readme.md
+      #
+
+!ifdef FMP_SYSTEM_FIP_CERT_PCD_FILE
+      !include $(FMP_SYSTEM_FIP_CERT_PCD_FILE)
+!endif
+
+    <PcdsFeatureFlag>
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceDeferImageAuthToSetImage|TRUE
+
+    <LibraryClasses>
+      #
+      # Generic libraries that are used "as is" by all FMP modules
+      #
+      FmpPayloadHeaderLib|FmpDevicePkg/Library/FmpPayloadHeaderLibV1/FmpPayloadHeaderLibV1.inf
+      FmpAuthenticationLib|SecurityPkg/Library/FmpAuthenticationLibPkcs7/FmpAuthenticationLibPkcs7.inf
+      FmpDependencyLib|FmpDevicePkg/Library/FmpDependencyLib/FmpDependencyLib.inf
+      FmpDependencyCheckLib|FmpDevicePkg/Library/FmpDependencyCheckLibNull/FmpDependencyCheckLibNull.inf
+      FmpDependencyDeviceLib|FmpDevicePkg/Library/FmpDependencyDeviceLibNull/FmpDependencyDeviceLibNull.inf
+      #
+      # Platform specific capsule policy library
+      #
+      CapsuleUpdatePolicyLib|Platform/ARM/Library/CapsuleUpdateRuntimePolicyLib/CapsuleUpdateRuntimePolicyLib.inf
+      #
+      # Device specific library that processes a capsule and updates the FW storage device
+      #
+      FmpDeviceLib|ArmPkg/Library/FmpDevicePsaFwuLib/FmpDevicePsaFwuLib.inf
+  }

--- a/Platform/ARM/Features/Fwu/FmpSystemFipImageRuntime.fdf.inc
+++ b/Platform/ARM/Features/Fwu/FmpSystemFipImageRuntime.fdf.inc
@@ -1,0 +1,14 @@
+#/** @file
+# FmpDxe driver for AArch64 firmware update.
+#
+#  Copyright (c) 2025, Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+#**/
+
+  INF MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
+  INF MdeModulePkg/Application/CapsuleApp/CapsuleApp.inf
+  INF FILE_GUID = $(FMP_SYSTEM_FIP_IMAGE_GUID) FmpDevicePkg/FmpDxe/FmpDxeRuntime.inf
+

--- a/Platform/ARM/Library/FwsGptSystemFipLib/FwsGptSystemFipLib.c
+++ b/Platform/ARM/Library/FwsGptSystemFipLib/FwsGptSystemFipLib.c
@@ -883,7 +883,6 @@ FwsRelease (
   )
 {
   FWS_IMAGE_FILE_DATA  *FileData;
-  FWS_DEVICE_DATA      *FwsDeviceData;
 
   if ((ImageFile == NULL) ||
       (ImageFile->FwsDevice == NULL) ||
@@ -893,7 +892,6 @@ FwsRelease (
   }
 
   FileData      = ImageFile->Private;
-  FwsDeviceData = ImageFile->FwsDevice->Private;
 
   /**
    * Currently, UpdateCapsule is blocking call in UEFI.
@@ -907,7 +905,7 @@ FwsRelease (
     *Progress = 100;
   }
 
-  InternalFwsRelease ((FWS_IMAGE_FILE_DATA *)ImageFile->Private);
+  InternalFwsRelease (FileData);
   ImageFile->FwsDevice->ImageFileCount--;
   ImageFile->FwsDevice = NULL;
   ImageFile->Private   = NULL;

--- a/Platform/ARM/Library/FwsGptSystemFipLib/FwsMetadataV2Ops.c
+++ b/Platform/ARM/Library/FwsGptSystemFipLib/FwsMetadataV2Ops.c
@@ -538,12 +538,10 @@ FwsMetadataV2CheckTrialRunState (
   )
 {
   PSA_MM_FWU_METADATA_V2       *Metadata;
-  PSA_MM_FWU_FW_STORE_DESC_V2  *FwFwsDesc;
   UINT8                        BankIdx;
 
   Metadata  = (PSA_MM_FWU_METADATA_V2 *)FwsMetadata->Metadata;
   BankIdx   = Metadata->Header.ActiveIndex;
-  FwFwsDesc = GET_FWU_FW_STORE_DESC_V2 (Metadata);
 
   if (Metadata->BankState[BankIdx] == FWU_BANK_STATE_VALID) {
     *TrialRunState = TRUE;

--- a/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
@@ -160,7 +160,11 @@
   #
 !if $(ENABLE_STMM) == TRUE
   ## MM Communicate
+!if $(ENABLE_FIRMWARE_UPDATE) == TRUE
+  gArmTokenSpaceGuid.PcdMmBufferBase|0xFBF00000
+!else
   gArmTokenSpaceGuid.PcdMmBufferBase|0xFEF00000
+!endif
   gArmTokenSpaceGuid.PcdMmBufferSize|0x10000
 !endif
 
@@ -278,8 +282,16 @@
   # Normal pseudo crbs which locality from 0 to 3 are allocated
   # at the start of System Memory.
   #
+!if $(ENABLE_FIRMWARE_UPDATE) == TRUE
+  #
+  # When ENABLE_FIRMWARE_UPDATE, TZC DRAM size is 64MB.
+  #
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0xfbf10000
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmMaxAddress|0xfbf13fff
+!else
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0xfef10000
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmMaxAddress|0xfef13fff
+!endif
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmCrbRegionSize|0x4000
   gArmVExpressTokenSpaceGuid.PcdTpmUseSipSmc|FALSE
   gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdGenTpm2DeviceTable|TRUE

--- a/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc
@@ -57,7 +57,7 @@
 !include DynamicTablesPkg/DynamicTables.dsc.inc
 
 !if $(ENABLE_FIRMWARE_UPDATE) == TRUE
-!include Platform/ARM/Features/Fwu/FmpSystemFipImage.dsc.inc
+!include Platform/ARM/Features/Fwu/FmpSystemFipImageRuntime.dsc.inc
 !endif
 
 [LibraryClasses.common]
@@ -132,6 +132,10 @@
 !if $(ENABLE_UEFI_SECURE_VARIABLE) == TRUE
   ## Disable Runtime Variable Cache.
   gEfiMdeModulePkgTokenSpaceGuid.PcdEnableVariableRuntimeCache|FALSE
+!endif
+
+!if $(ENABLE_FIRMWARE_UPDATE) == TRUE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportProcessCapsuleAtRuntime|TRUE
 !endif
 
 [PcdsFixedAtBuild.common]

--- a/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.fdf
+++ b/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.fdf
@@ -227,7 +227,7 @@ FvNameGuid         = 87940482-fc81-41c3-87e6-399cf85ac8a0
   # Firmware update
   #
 !if $(ENABLE_FIRMWARE_UPDATE) == TRUE
-  !include Platform/ARM/Features/Fwu/FmpSystemFipImage.fdf.inc
+  !include Platform/ARM/Features/Fwu/FmpSystemFipImageRuntime.fdf.inc
 !endif
 
 !if $(ENABLE_TPM) == TRUE

--- a/Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
+++ b/Platform/ARM/VExpressPkg/ArmVExpress.dsc.inc
@@ -296,7 +296,7 @@
 !endif
   ReportStatusCodeLib|MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/RuntimeDxeReportStatusCodeLib.inf
   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLibRuntimeDxe.inf
-!if $(SECURE_BOOT_ENABLE) == TRUE
+!if $(SECURE_BOOT_ENABLE) == TRUE || $(ENABLE_FIRMWARE_UPDATE) == TRUE
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
 !endif
 !if $(TARGET) != RELEASE

--- a/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
+++ b/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
@@ -107,8 +107,16 @@
   # at the start of System Memory.
   # These regions are reserved by TF-A.
   #
+!if $(ENABLE_FIRMWARE_UPDATE) == TRUE
+  #
+  # When ENABLE_FIRMWARE_UPDATE, TZC DRAM size is 64MB.
+  #
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0xfbf10000
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmMaxAddress|0xfbf13fff
+!else
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0xfef10000
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmMaxAddress|0xfef13fff
+!endif
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmCrbRegionSize|0x4000
 
   #

--- a/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
+++ b/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
@@ -190,6 +190,18 @@
       gPlatformArmTokenSpaceGuid.PcdSystemFirmwareFmpLowestSupportedVersion|0x00000000
       gPlatformArmTokenSpaceGuid.PcdSystemFirmwareFmpVersion|0x00000000
       gPlatformArmTokenSpaceGuid.PcdSystemFirmwareFmpVersionString|"000.000.000.000"
+
+!ifdef FMP_SYSTEM_FIP_CERT_PCD_FILE
+      !include $(FMP_SYSTEM_FIP_CERT_PCD_FILE)
+!endif
+
+    <PcdsFeatureFlag>
+      gPlatformArmTokenSpaceGuid.PcdFwuFmpImageAuth|FALSE
+
+    <LibraryClasses>
+      FmpAuthenticationLib|SecurityPkg/Library/FmpAuthenticationLibPkcs7/FmpAuthenticationLibPkcs7.inf
+      FmpDependencyLib|FmpDevicePkg/Library/FmpDependencyLib/FmpDependencyLib.inf
+      FmpPayloadHeaderLib|FmpDevicePkg/Library/FmpPayloadHeaderLibV1/FmpPayloadHeaderLibV1.inf
   }
 !endif
 

--- a/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
+++ b/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc
@@ -196,7 +196,7 @@
 !endif
 
     <PcdsFeatureFlag>
-      gPlatformArmTokenSpaceGuid.PcdFwuFmpImageAuth|FALSE
+      gPlatformArmTokenSpaceGuid.PcdFwuFmpImageAuth|TRUE
 
     <LibraryClasses>
       FmpAuthenticationLib|SecurityPkg/Library/FmpAuthenticationLibPkcs7/FmpAuthenticationLibPkcs7.inf

--- a/Platform/ARM/VExpressPkg/PlatformStandaloneMm.fdf
+++ b/Platform/ARM/VExpressPkg/PlatformStandaloneMm.fdf
@@ -20,7 +20,11 @@
 
 [FD.BL32_AP_MM]
 # See macro definition BL32_BASE in TF-A code at include/plat/arm/common/arm_def.h
+!if $(ENABLE_FIRMWARE_UPDATE)
+BaseAddress   = 0xfc200000|gArmTokenSpaceGuid.PcdFdBaseAddress
+!else
 BaseAddress   = 0xff200000|gArmTokenSpaceGuid.PcdFdBaseAddress
+!endif
 
 # Maximum size of BL32 Image in TF-A (see include/plat/arm/common/arm_spm.def.h)
 Size          = 0x00300000|gArmTokenSpaceGuid.PcdFdSize


### PR DESCRIPTION
Capsule-based firmware update support on Arm platforms is currently limited to
the Capsule-On-Disk delivery mechanism defined in the UEFI specification section [8.5.5. Delivery of Capsules via file on Mass Storage Device](https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#delivery-of-capsules-via-file-on-mass-storage-device). While this mechanism is functional, it typically requires multiple reboots to
complete a firmware update.

The UEFI specification also defines the UpdateCapsule() runtime service in section [8.5.3.1. UpdateCapsule()](https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#updatecapsule).
This interface allows an operating system to pass capsule images directly to
firmware at runtime. Capsule processing behaviour is controlled, in part, by
the CAPSULE_FLAGS_PERSIST_ACROSS_RESET flag in the EFI_CAPSULE_HEADER.

When CAPSULE_FLAGS_PERSIST_ACROSS_RESET is set, the firmware update flow requires two reboots:

    The operating system submits the capsule to firmware, and
    the firmware requests a reboot.
    On the next boot, firmware reconstructs and processes the capsule,
    performs the flash update, and then triggers another reboot.
    The platform finally boots using the updated firmware image.

In contrast, when CAPSULE_FLAGS_PERSIST_ACROSS_RESET is not set, capsule processing
may begin immediately at runtime. In this model, the firmware image can be written to
flash before reset, allowing the platform to reboot directly into the updated firmware image.
This enables a single-reboot update flow, reducing update latency and platform downtime.

However, current Arm platform implementations generally lack a standardized architecture for
supporting this single-reboot runtime firmware update flow.

The [Arm Platform Security Firmware Update for the A-profile Arm Architecture, version 1.0 A-EAC1, DEN0118](https://developer.arm.com/documentation/den0118/latest) specification defines a standard firmware update architecture for
Arm A-profile systems that enables coordinated runtime firmware update handling between
the non-secure software stack and platform security firmware.

This PR proposes leveraging the Arm Platform Security Firmware Update architecture to
enable single-reboot firmware updates on Arm platforms through the UpdateCapsule() runtime interface.

Enabling this capability provides several benefits and unlocks important use cases, including:

    Reduced firmware update downtime by eliminating the second reboot.
    Faster firmware deployment in cloud and datacenter environments.
    Improved platform availability.
    Better alignment with modern firmware update frameworks that implement
    the Arm Platform Security Firmware Update architecture.

For a more detail, Please check the RFC[0] proposal.

Link: [0] https://github.com/tianocore/tianocore-wiki.github.io/commit/ed14b7cefecd64b2cf786f7799db1e26f0b5609e
Link: [1] https://review.trustedfirmware.org/q/topic:%22fvp_enable_single_boot_capsule_update%22
Link: [2] https://github.com/tianocore/edk2/pull/12900