### PR TITLE
Apply VariableStorage Protocl and VariableStorageRouterLib

### DIFF
--- a/Features/Intel/PlatformPayloadFeaturePkg/Include/PlatformPayloadFeature.dsc
+++ b/Features/Intel/PlatformPayloadFeaturePkg/Include/PlatformPayloadFeature.dsc
@@ -87,7 +87,7 @@
         NULL|PlatformPayloadFeaturePkg/Library/PcdInitLib/PcdInitLib.inf
     }
 
-    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf {
+    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbTraditionalMm.inf {
       <LibraryClasses>
         PlatformHookLib|UefiPayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
         NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
@@ -95,6 +95,11 @@
         NULL|MdeModulePkg/Library/VarCheckPcdLib/VarCheckPcdLib.inf
         NULL|MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.inf
         NULL|PlatformPayloadFeaturePkg/Library/PcdInitLib/PcdInitLib.inf
+    }
+
+    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf {
+      <LibraryClasses>
+        NULL|MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseTraditionalMmLib.inf
     }
 
     MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteSmm.inf {

--- a/Features/Intel/PlatformPayloadFeaturePkg/Include/PostMemory.fdf
+++ b/Features/Intel/PlatformPayloadFeaturePkg/Include/PostMemory.fdf
@@ -14,6 +14,7 @@
   INF PlatformPayloadFeaturePkg/PchSmiDispatchSmm/PchSmiDispatchSmm.inf
   INF PlatformPayloadFeaturePkg/Fvb/FvbSmm.inf
   INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteSmm.inf
+  INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbTraditionalMm.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
 

--- a/Platform/AMD/GenoaBoard/Include/Dsc/ProjectCommon.inc.dsc
+++ b/Platform/AMD/GenoaBoard/Include/Dsc/ProjectCommon.inc.dsc
@@ -349,9 +349,13 @@
       <LibraryClasses>
         NULL|AmdPlatformPkg/Library/BaseAlwaysFalseDepexLib/BaseAlwaysFalseDepexLib.inf
     }
-    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf {
+    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbTraditionalMm.inf
       <LibraryClasses>
         NULL|AmdPlatformPkg/Library/BaseAlwaysFalseDepexLib/BaseAlwaysFalseDepexLib.inf
+    }
+    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf {
+      <LibraryClasses>
+        NULL|MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseTraditionalMmLib.inf
     }
     MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf {
       <PcdsFixedAtBuild>

--- a/Platform/AMD/TurinBoard/Include/Dsc/ProjectCommon.inc.dsc
+++ b/Platform/AMD/TurinBoard/Include/Dsc/ProjectCommon.inc.dsc
@@ -362,9 +362,13 @@
       <LibraryClasses>
         NULL|AmdPlatformPkg/Library/BaseAlwaysFalseDepexLib/BaseAlwaysFalseDepexLib.inf
     }
-    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf {
+    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbTraditionalMm.inf {
       <LibraryClasses>
         NULL|AmdPlatformPkg/Library/BaseAlwaysFalseDepexLib/BaseAlwaysFalseDepexLib.inf
+    }
+    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf {
+      <LibraryClasses>
+        NULL|MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseTraditionalMmLib.inf
     }
     MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf {
       <PcdsFixedAtBuild>

--- a/Platform/ARM/JunoPkg/PlatformStandaloneMm.fdf
+++ b/Platform/ARM/JunoPkg/PlatformStandaloneMm.fdf
@@ -73,6 +73,7 @@ FvNameGuid         = 87940482-fc81-41c3-87e6-399cf85ac8a0
 
 !if $(ENABLE_UEFI_SECURE_VARIABLE) == TRUE
   INF Platform/ARM/Drivers/NorFlashDxe/NorFlashStandaloneMm.inf
+  INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf
   INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
 !endif

--- a/Platform/ARM/SgiPkg/PlatformStandaloneMm.fdf
+++ b/Platform/ARM/SgiPkg/PlatformStandaloneMm.fdf
@@ -51,6 +51,7 @@ READ_LOCK_STATUS   = TRUE
   INF StandaloneMmPkg/Core/StandaloneMmCore.inf
 !if $(SECURE_STORAGE_ENABLE) == TRUE
   INF Platform/ARM/Drivers/NorFlashDxe/NorFlashStandaloneMm.inf
+  INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf
   INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
 !endif

--- a/Platform/ARM/SgiPkg/SgiPlatformMm.dsc.inc
+++ b/Platform/ARM/SgiPkg/SgiPlatformMm.dsc.inc
@@ -78,6 +78,7 @@
   TimerLib|MdePkg/Library/BaseTimerLibNullTemplate/BaseTimerLibNullTemplate.inf
   VarCheckLib|MdeModulePkg/Library/VarCheckLib/VarCheckLib.inf
   VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
+  VariableStorageRouterLib|MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseStandaloneMmLib.inf
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
 !endif
 
@@ -133,8 +134,7 @@
   ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
 !if $(SECURE_STORAGE_ENABLE) == TRUE
   Platform/ARM/Drivers/NorFlashDxe/NorFlashStandaloneMm.inf
-  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
-  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf {
+  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf {
     <LibraryClasses>
       DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
@@ -143,6 +143,8 @@
       VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.inf
       VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
   }
+  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
+  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
 !endif
 
 ###################################################################################################

--- a/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc.inc
+++ b/Platform/ARM/VExpressPkg/PlatformStandaloneMm.dsc.inc
@@ -80,6 +80,7 @@
   VarCheckLib|MdeModulePkg/Library/VarCheckLib/VarCheckLib.inf
   VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   AuthVariableLib|SecurityPkg/Library/AuthVariableLib/AuthVariableLib.inf
+  VariableStorageRouterLib|MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseStandaloneMmLib.inf
 !endif
 
   ArmLib|MdePkg/Library/ArmLib/ArmBaseLib.inf
@@ -151,7 +152,7 @@
 !endif
 
 !if $(ENABLE_UEFI_SECURE_VARIABLE) == TRUE
-  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf {
+  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf {
     <LibraryClasses>
       DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLibBase.inf
       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
@@ -160,6 +161,7 @@
       VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.inf
       VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
   }
+  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
   MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
 !endif
 

--- a/Platform/ARM/VExpressPkg/PlatformStandaloneMm.fdf
+++ b/Platform/ARM/VExpressPkg/PlatformStandaloneMm.fdf
@@ -73,6 +73,7 @@ FvNameGuid         = 87940482-fc81-41c3-87e6-399cf85ac8a0
 
 !if $(ENABLE_UEFI_SECURE_VARIABLE) == TRUE
   INF Platform/ARM/Drivers/NorFlashDxe/NorFlashStandaloneMm.inf
+  INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf
   INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
 !endif

--- a/Platform/MinPlatformPkg/Include/Dsc/CoreDxeInclude.dsc
+++ b/Platform/MinPlatformPkg/Include/Dsc/CoreDxeInclude.dsc
@@ -42,19 +42,27 @@
   #
   !if gMinPlatformPkgTokenSpaceGuid.PcdStandaloneMmEnable == TRUE
     MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
-    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf {
+    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf {
       <LibraryClasses>
         NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
         NULL|MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLibStandaloneMm.inf
     }
+    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf {
+      <LibraryClasses>
+        NULL|MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseStandaloneMmLib.inf
+    }
 
   !else
     MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteSmm.inf
-    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf {
+    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbTraditionalMm.inf {
       <LibraryClasses>
         NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
         NULL|MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLib.inf
         NULL|MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.inf
+    }
+    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf {
+      <LibraryClasses>
+        NULL|MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseTraditionalMmLib.inf
     }
   !endif
 

--- a/Platform/MinPlatformPkg/Include/Fdf/CoreOsBootInclude.fdf
+++ b/Platform/MinPlatformPkg/Include/Fdf/CoreOsBootInclude.fdf
@@ -10,9 +10,11 @@
 !if gMinPlatformPkgTokenSpaceGuid.PcdBootToShellOnly == FALSE
   INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
   !if gMinPlatformPkgTokenSpaceGuid.PcdStandaloneMmEnable == TRUE
+    INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf
     INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
     INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
   !else
+    INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbTraditionalMm.inf
     INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteSmm.inf
     INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
   !endif

--- a/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
+++ b/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
@@ -52,6 +52,7 @@
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.inf
+  VariableStorageRouterLib|MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseStandaloneMmLib.inf
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
   PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
   MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
@@ -152,7 +153,7 @@
     <LibraryClasses>
       NULL|Drivers/OpTee/OpteeRpmbPkg/FixupPcd.inf
   }
-  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf {
+  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf {
     <LibraryClasses>
       AuthVariableLib|SecurityPkg/Library/AuthVariableLib/AuthVariableLib.inf
       BaseCryptLib|CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.inf
@@ -161,6 +162,7 @@
       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
       NULL|Drivers/OpTee/OpteeRpmbPkg/FixupPcd.inf
   }
+  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
 
 ###################################################################################################
 #

--- a/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.fdf
+++ b/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.fdf
@@ -66,6 +66,7 @@ READ_LOCK_STATUS   = TRUE
 
   INF StandaloneMmPkg/Core/StandaloneMmCore.inf
   INF Drivers/OpTee/OpteeRpmbPkg/OpTeeRpmbFv.inf
+  INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf
   INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
   INF ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf


### PR DESCRIPTION
Deploying VariableService in StandaloneMm provides stronger protection for
UEFI variables by isolating variable processing from the normal execution
environment.

Typical use cases include:

    Protection of Secure Boot variables:
    Secure Boot variables such as PK, KEK, db, dbx, SecureBoot, and
    SetupMode must not be modified by the operating system or untrusted DXE drivers.

    Integration with secure storage:
    Some platforms provide secure storage mechanisms, such as eMMC RPMB
    (Replay Protected Memory Block) or other platform-specific secure
    storage solutions. These backends provide protection against
    unauthorized modification while preserving the integrity of
    security-critical variables.

Although VariableService can already run in StandaloneMm, its persistence
layer remains tightly coupled to the Firmware Volume Block (FVB)
abstraction. The current implementation assumes an FVB/FTW-based storage
model, with variable persistence and fault-tolerant writes implemented
around that design.

This assumption does not hold on all platforms. Some platforms store
firmware variables through a dedicated storage management controller that
is not directly accessible from the application processor. Communication
with such storage is transactional rather than block based, making the
existing FVB abstraction unsuitable.

In these environments, StandaloneMm should act as a proxy that forwards
variable operations to the underlying storage implementation instead of
managing persistence through FVB.

This patchset proposes introducing a VariableStorage Protocol together with
VariableStorageRouterLib for StandaloneMm. This separates VariableService
from the underlying storage implementation while preserving the existing
VariableService semantics.

Existing platforms can continue using the current FVB-based storage model
without modification, while new platforms may provide alternative storage
implementations through VariableStorageRouterLib and the VariableStorage Protocol.

For a detail, Please see the RFC doc [0] and edk2's PR [1].

Link: [0] https://github.com/tianocore/tianocore-wiki.github.io/pull/44
Link: [1] https://github.com/tianocore/edk2/pull/12923