### PR TITLE
IOMMU: Rework VTd DXE dispatch and pin IoMmuLibNull for NonCoherentIoMmuDxe

### DIFF
--- a/Platform/RaspberryPi/RPi4/RPi4.dsc
+++ b/Platform/RaspberryPi/RPi4/RPi4.dsc
@@ -754,6 +754,13 @@
   MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
   MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
   EmbeddedPkg/Drivers/NonCoherentIoMmuDxe/NonCoherentIoMmuDxe.inf {
+    <LibraryClasses>
+      #
+      # NonCoherentIoMmuDxe is itself the IOMMU producer, so it must not
+      # consume the IOMMU protocol via IoMmuLib (would create a circular
+      # dependency through DmaLib). Use the null instance for this driver only.
+      #
+      IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
     <PcdsFixedAtBuild>
       gEmbeddedTokenSpaceGuid.PcdDmaDeviceOffset|0x00000000
       gEmbeddedTokenSpaceGuid.PcdDmaDeviceLimit|0xbfffffff

--- a/Silicon/Broadcom/Bcm283x/Drivers/InterruptDxe/InterruptDxe.inf
+++ b/Silicon/Broadcom/Bcm283x/Drivers/InterruptDxe/InterruptDxe.inf
@@ -21,6 +21,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
   Silicon/Broadcom/Bcm283x/Bcm283x.dec
 
 [LibraryClasses]

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/BmDma.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/BmDma.c
@@ -157,6 +157,10 @@ IoMmuMap (
   BOOLEAN                                           NeedRemap;
   EFI_TPL                                           OriginalTpl;
 
+  if (!mVtdInitialized) {
+    return EFI_NOT_READY;
+  }
+
   if (NumberOfBytes == NULL || DeviceAddress == NULL ||
       Mapping == NULL) {
     DEBUG ((DEBUG_ERROR, "IoMmuMap: %r\n", EFI_INVALID_PARAMETER));
@@ -419,6 +423,10 @@ IoMmuAllocateBuffer (
 {
   EFI_STATUS                Status;
   EFI_PHYSICAL_ADDRESS      PhysicalAddress;
+
+  if (!mVtdInitialized) {
+    return EFI_NOT_READY;
+  }
 
   DEBUG ((DEBUG_VERBOSE, "IoMmuAllocateBuffer: ==> 0x%08x\n", Pages));
 

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/DmaProtection.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/DmaProtection.c
@@ -10,6 +10,8 @@
 UINT64                                  mBelow4GMemoryLimit;
 UINT64                                  mAbove4GMemoryLimit;
 
+BOOLEAN                                 mVtdInitialized = FALSE;
+
 EDKII_PLATFORM_VTD_POLICY_PROTOCOL      *mPlatformVTdPolicy;
 
 VTD_ACCESS_REQUEST                      *mAccessRequest = NULL;
@@ -459,8 +461,12 @@ InitializePlatformVTdPolicy (
 
 /**
   Setup VTd engine.
+
+  @retval EFI_SUCCESS      Setup completed and DMAR translation is enabled.
+  @retval EFI_NOT_READY    PCI enumeration is not yet complete; retry later.
+  @retval Other            Setup failed.
 **/
-VOID
+EFI_STATUS
 SetupVtd (
   VOID
   )
@@ -472,6 +478,10 @@ SetupVtd (
   UINT64               Above4GMemoryLimit;
   VTD_ROOT_TABLE_INFO  RootTableInfo;
 
+  if (mVtdInitialized) {
+    return EFI_SUCCESS;
+  }
+
   //
   // PCI Enumeration must be done
   //
@@ -480,7 +490,9 @@ SetupVtd (
                   NULL,
                   &PciEnumerationComplete
                   );
-  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    return EFI_NOT_READY;
+  }
 
   ReturnUefiMemoryMap (&Below4GMemoryLimit, &Above4GMemoryLimit);
   Below4GMemoryLimit = ALIGN_VALUE_UP(Below4GMemoryLimit, SIZE_256MB);
@@ -497,7 +509,7 @@ SetupVtd (
   DEBUG ((DEBUG_INFO, "ParseDmarAcpiTable\n"));
   Status = ParseDmarAcpiTableDrhd ();
   if (EFI_ERROR (Status)) {
-    return;
+    return Status;
   }
 
   DumpVtdIfError ();
@@ -511,7 +523,7 @@ SetupVtd (
   DEBUG ((DEBUG_INFO, "SetupTranslationTable\n"));
   Status = SetupTranslationTable ();
   if (EFI_ERROR (Status)) {
-    return;
+    return Status;
   }
 
   InitializePlatformVTdPolicy ();
@@ -554,10 +566,13 @@ SetupVtd (
   DEBUG ((DEBUG_INFO, "EnableDmar\n"));
   Status = EnableDmar ();
   if (EFI_ERROR (Status)) {
-    return;
+    return Status;
   }
   DEBUG ((DEBUG_INFO, "DumpVtdRegs\n"));
   DumpVtdRegsAll ();
+
+  mVtdInitialized = TRUE;
+  return EFI_SUCCESS;
 }
 
 /**
@@ -579,14 +594,14 @@ AcpiNotificationFunc (
   EFI_STATUS          Status;
 
   Status = GetDmarAcpiTable ();
-  if (EFI_ERROR (Status)) {
-    if (Status == EFI_ALREADY_STARTED) {
-      gBS->CloseEvent (Event);
-    }
+  if (EFI_ERROR (Status) && (Status != EFI_ALREADY_STARTED)) {
     return;
   }
-  SetupVtd ();
-  gBS->CloseEvent (Event);
+
+  Status = SetupVtd ();
+  if (!EFI_ERROR (Status)) {
+    gBS->CloseEvent (Event);
+  }
 }
 
 /**
@@ -655,6 +670,8 @@ InitializeDmaProtection (
   EFI_EVENT   LegacyBootEvent;
   EFI_EVENT   EventAcpi10;
   EFI_EVENT   EventAcpi20;
+  EFI_EVENT   EventPciEnumComplete;
+  VOID        *PciEnumCompleteRegistration;
 
   Status = gBS->CreateEventEx (
                   EVT_NOTIFY_SIGNAL,
@@ -673,6 +690,25 @@ InitializeDmaProtection (
                   NULL,
                   &gEfiAcpi20TableGuid,
                   &EventAcpi20
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Also retry SetupVtd when gEfiPciEnumerationCompleteProtocolGuid appears,
+  // to cover the case where DMAR is installed before PCI enumeration completes.
+  //
+  Status = gBS->CreateEvent (
+                  EVT_NOTIFY_SIGNAL,
+                  VTD_TPL_LEVEL,
+                  AcpiNotificationFunc,
+                  NULL,
+                  &EventPciEnumComplete
+                  );
+  ASSERT_EFI_ERROR (Status);
+  Status = gBS->RegisterProtocolNotify (
+                  &gEfiPciEnumerationCompleteProtocolGuid,
+                  EventPciEnumComplete,
+                  &PciEnumCompleteRegistration
                   );
   ASSERT_EFI_ERROR (Status);
 

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/DmaProtection.h
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/DmaProtection.h
@@ -127,6 +127,8 @@ extern VTD_UNIT_INFORMATION             *mVtdUnitInformation;
 extern UINT64                           mBelow4GMemoryLimit;
 extern UINT64                           mAbove4GMemoryLimit;
 
+extern BOOLEAN                          mVtdInitialized;
+
 extern EDKII_PLATFORM_VTD_POLICY_PROTOCOL   *mPlatformVTdPolicy;
 
 /**

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/IntelVTdCoreDxe.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/IntelVTdCoreDxe.c
@@ -244,32 +244,18 @@ VTdSetAttribute (
   DEBUG ((DEBUG_VERBOSE, "PCI(S%x.B%x.D%x.F%x) ", Segment, SourceId.Bits.Bus, SourceId.Bits.Device, SourceId.Bits.Function));
   DEBUG ((DEBUG_VERBOSE, "(0x%lx~0x%lx) - %lx\n", DeviceAddress, Length, IoMmuAccess));
 
-  if (mAcpiDmarTable == NULL) {
-    //
-    // Record the entry to driver global variable.
-    // As such once VTd is activated, the setting can be adopted.
-    //
-    if ((PcdGet8 (PcdVTdPolicyPropertyMask) & BIT2) != 0) {
-      //
-      // Force no IOMMU access attribute request recording before DMAR table is installed.
-      //
-      return EFI_NOT_READY;
-    }
-    Status = RequestAccessAttribute (Segment, SourceId, DeviceAddress, Length, IoMmuAccess);
-  } else {
-    PERF_CODE (
-      AsciiSPrint (PerfToken, sizeof(PerfToken), "S%04xB%02xD%02xF%01x", Segment, SourceId.Bits.Bus, SourceId.Bits.Device, SourceId.Bits.Function);
-      Identifier = (Segment << 16) | SourceId.Uint16;
-      PERF_START_EX (gImageHandle, PerfToken, "IntelVTD", 0, Identifier);
-    );
+  PERF_CODE (
+    AsciiSPrint (PerfToken, sizeof(PerfToken), "S%04xB%02xD%02xF%01x", Segment, SourceId.Bits.Bus, SourceId.Bits.Device, SourceId.Bits.Function);
+    Identifier = (Segment << 16) | SourceId.Uint16;
+    PERF_START_EX (gImageHandle, PerfToken, "IntelVTD", 0, Identifier);
+  );
 
-    Status = SetAccessAttribute (Segment, SourceId, DeviceAddress, Length, IoMmuAccess);
+  Status = SetAccessAttribute (Segment, SourceId, DeviceAddress, Length, IoMmuAccess);
 
-    PERF_CODE (
-      Identifier = (Segment << 16) | SourceId.Uint16;
-      PERF_END_EX (gImageHandle, PerfToken, "IntelVTD", 0, Identifier);
-    );
-  }
+  PERF_CODE (
+    Identifier = (Segment << 16) | SourceId.Uint16;
+    PERF_END_EX (gImageHandle, PerfToken, "IntelVTD", 0, Identifier);
+  );
 
   if (!EFI_ERROR(Status)) {
     SyncDeviceHandleToMapInfo (
@@ -340,6 +326,10 @@ IoMmuSetAttribute (
   EFI_PHYSICAL_ADDRESS  DeviceAddress;
   UINTN                 NumberOfPages;
   EFI_TPL               OriginalTpl;
+
+  if (!mVtdInitialized) {
+    return EFI_NOT_READY;
+  }
 
   OriginalTpl = gBS->RaiseTPL (VTD_TPL_LEVEL);
 

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/IntelVTdCoreDxe.inf
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdCoreDxe/IntelVTdCoreDxe.inf
@@ -86,7 +86,7 @@
   gIntelSiliconPkgTokenSpaceGuid.PcdVTdDxeLogBufferSize         ## CONSUMES
 
 [Depex]
-  gEfiPciRootBridgeIoProtocolGuid
+  TRUE
 
 [UserExtensions.TianoCore."ExtraFiles"]
   IntelVTdCoreDxeExtra.uni

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/BmDma.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/BmDma.c
@@ -157,6 +157,10 @@ IoMmuMap (
   BOOLEAN                                           NeedRemap;
   EFI_TPL                                           OriginalTpl;
 
+  if (!mVtdInitialized) {
+    return EFI_NOT_READY;
+  }
+
   if (NumberOfBytes == NULL || DeviceAddress == NULL ||
       Mapping == NULL) {
     DEBUG ((DEBUG_ERROR, "IoMmuMap: %r\n", EFI_INVALID_PARAMETER));
@@ -415,6 +419,10 @@ IoMmuAllocateBuffer (
 {
   EFI_STATUS                Status;
   EFI_PHYSICAL_ADDRESS      PhysicalAddress;
+
+  if (!mVtdInitialized) {
+    return EFI_NOT_READY;
+  }
 
   DEBUG ((DEBUG_VERBOSE, "IoMmuAllocateBuffer: ==> 0x%08x\n", Pages));
 

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/DmaProtection.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/DmaProtection.c
@@ -10,6 +10,8 @@
 UINT64                                  mBelow4GMemoryLimit;
 UINT64                                  mAbove4GMemoryLimit;
 
+BOOLEAN                                 mVtdInitialized = FALSE;
+
 EDKII_PLATFORM_VTD_POLICY_PROTOCOL      *mPlatformVTdPolicy;
 
 VTD_ACCESS_REQUEST                      *mAccessRequest = NULL;
@@ -459,8 +461,12 @@ InitializePlatformVTdPolicy (
 
 /**
   Setup VTd engine.
+
+  @retval EFI_SUCCESS      Setup completed and DMAR translation is enabled.
+  @retval EFI_NOT_READY    PCI enumeration is not yet complete; retry later.
+  @retval Other            Setup failed.
 **/
-VOID
+EFI_STATUS
 SetupVtd (
   VOID
   )
@@ -471,6 +477,10 @@ SetupVtd (
   UINT64          Below4GMemoryLimit;
   UINT64          Above4GMemoryLimit;
 
+  if (mVtdInitialized) {
+    return EFI_SUCCESS;
+  }
+
   //
   // PCI Enumeration must be done
   //
@@ -479,7 +489,9 @@ SetupVtd (
                   NULL,
                   &PciEnumerationComplete
                   );
-  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    return EFI_NOT_READY;
+  }
 
   ReturnUefiMemoryMap (&Below4GMemoryLimit, &Above4GMemoryLimit);
   Below4GMemoryLimit = ALIGN_VALUE_UP(Below4GMemoryLimit, SIZE_256MB);
@@ -494,7 +506,7 @@ SetupVtd (
   DEBUG ((DEBUG_INFO, "ParseDmarAcpiTable\n"));
   Status = ParseDmarAcpiTableDrhd ();
   if (EFI_ERROR (Status)) {
-    return;
+    return Status;
   }
 
   DumpVtdIfError ();
@@ -508,7 +520,7 @@ SetupVtd (
   DEBUG ((DEBUG_INFO, "SetupTranslationTable\n"));
   Status = SetupTranslationTable ();
   if (EFI_ERROR (Status)) {
-    return;
+    return Status;
   }
 
   InitializePlatformVTdPolicy ();
@@ -539,10 +551,13 @@ SetupVtd (
   DEBUG ((DEBUG_INFO, "EnableDmar\n"));
   Status = EnableDmar ();
   if (EFI_ERROR (Status)) {
-    return;
+    return Status;
   }
   DEBUG ((DEBUG_INFO, "DumpVtdRegs\n"));
   DumpVtdRegsAll ();
+
+  mVtdInitialized = TRUE;
+  return EFI_SUCCESS;
 }
 
 /**
@@ -564,14 +579,14 @@ AcpiNotificationFunc (
   EFI_STATUS          Status;
 
   Status = GetDmarAcpiTable ();
-  if (EFI_ERROR (Status)) {
-    if (Status == EFI_ALREADY_STARTED) {
-      gBS->CloseEvent (Event);
-    }
+  if (EFI_ERROR (Status) && (Status != EFI_ALREADY_STARTED)) {
     return;
   }
-  SetupVtd ();
-  gBS->CloseEvent (Event);
+
+  Status = SetupVtd ();
+  if (!EFI_ERROR (Status)) {
+    gBS->CloseEvent (Event);
+  }
 }
 
 /**
@@ -639,6 +654,8 @@ InitializeDmaProtection (
   EFI_EVENT   LegacyBootEvent;
   EFI_EVENT   EventAcpi10;
   EFI_EVENT   EventAcpi20;
+  EFI_EVENT   EventPciEnumComplete;
+  VOID        *PciEnumCompleteRegistration;
 
   Status = gBS->CreateEventEx (
                   EVT_NOTIFY_SIGNAL,
@@ -657,6 +674,25 @@ InitializeDmaProtection (
                   NULL,
                   &gEfiAcpi20TableGuid,
                   &EventAcpi20
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Also retry SetupVtd when gEfiPciEnumerationCompleteProtocolGuid appears,
+  // to cover the case where DMAR is installed before PCI enumeration completes.
+  //
+  Status = gBS->CreateEvent (
+                  EVT_NOTIFY_SIGNAL,
+                  VTD_TPL_LEVEL,
+                  AcpiNotificationFunc,
+                  NULL,
+                  &EventPciEnumComplete
+                  );
+  ASSERT_EFI_ERROR (Status);
+  Status = gBS->RegisterProtocolNotify (
+                  &gEfiPciEnumerationCompleteProtocolGuid,
+                  EventPciEnumComplete,
+                  &PciEnumCompleteRegistration
                   );
   ASSERT_EFI_ERROR (Status);
 

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/DmaProtection.h
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/DmaProtection.h
@@ -138,6 +138,8 @@ extern VTD_UNIT_INFORMATION             *mVtdUnitInformation;
 extern UINT64                           mBelow4GMemoryLimit;
 extern UINT64                           mAbove4GMemoryLimit;
 
+extern BOOLEAN                          mVtdInitialized;
+
 extern EDKII_PLATFORM_VTD_POLICY_PROTOCOL   *mPlatformVTdPolicy;
 
 /**

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/IntelVTdDxe.c
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/IntelVTdDxe.c
@@ -243,32 +243,18 @@ VTdSetAttribute (
   DEBUG ((DEBUG_VERBOSE, "PCI(S%x.B%x.D%x.F%x) ", Segment, SourceId.Bits.Bus, SourceId.Bits.Device, SourceId.Bits.Function));
   DEBUG ((DEBUG_VERBOSE, "(0x%lx~0x%lx) - %lx\n", DeviceAddress, Length, IoMmuAccess));
 
-  if (mAcpiDmarTable == NULL) {
-    //
-    // Record the entry to driver global variable.
-    // As such once VTd is activated, the setting can be adopted.
-    //
-    if ((PcdGet8 (PcdVTdPolicyPropertyMask) & BIT2) != 0) {
-      //
-      // Force no IOMMU access attribute request recording before DMAR table is installed.
-      //
-      return EFI_NOT_READY;
-    }
-    Status = RequestAccessAttribute (Segment, SourceId, DeviceAddress, Length, IoMmuAccess);
-  } else {
-    PERF_CODE (
-      AsciiSPrint (PerfToken, sizeof(PerfToken), "S%04xB%02xD%02xF%01x", Segment, SourceId.Bits.Bus, SourceId.Bits.Device, SourceId.Bits.Function);
-      Identifier = (Segment << 16) | SourceId.Uint16;
-      PERF_START_EX (gImageHandle, PerfToken, "IntelVTD", 0, Identifier);
-    );
+  PERF_CODE (
+    AsciiSPrint (PerfToken, sizeof(PerfToken), "S%04xB%02xD%02xF%01x", Segment, SourceId.Bits.Bus, SourceId.Bits.Device, SourceId.Bits.Function);
+    Identifier = (Segment << 16) | SourceId.Uint16;
+    PERF_START_EX (gImageHandle, PerfToken, "IntelVTD", 0, Identifier);
+  );
 
-    Status = SetAccessAttribute (Segment, SourceId, DeviceAddress, Length, IoMmuAccess);
+  Status = SetAccessAttribute (Segment, SourceId, DeviceAddress, Length, IoMmuAccess);
 
-    PERF_CODE (
-      Identifier = (Segment << 16) | SourceId.Uint16;
-      PERF_END_EX (gImageHandle, PerfToken, "IntelVTD", 0, Identifier);
-    );
-  }
+  PERF_CODE (
+    Identifier = (Segment << 16) | SourceId.Uint16;
+    PERF_END_EX (gImageHandle, PerfToken, "IntelVTD", 0, Identifier);
+  );
 
   if (!EFI_ERROR(Status)) {
     SyncDeviceHandleToMapInfo (
@@ -332,6 +318,10 @@ IoMmuSetAttribute (
   EFI_PHYSICAL_ADDRESS  DeviceAddress;
   UINTN                 NumberOfPages;
   EFI_TPL               OriginalTpl;
+
+  if (!mVtdInitialized) {
+    return EFI_NOT_READY;
+  }
 
   OriginalTpl = gBS->RaiseTPL (VTD_TPL_LEVEL);
 

--- a/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/IntelVTdDxe.inf
+++ b/Silicon/Intel/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/IntelVTdDxe.inf
@@ -78,7 +78,7 @@
   gIntelSiliconPkgTokenSpaceGuid.PcdVTdSupportAbortDmaMode  ## CONSUMES
 
 [Depex]
-  gEfiPciRootBridgeIoProtocolGuid
+  TRUE
 
 [UserExtensions.TianoCore."ExtraFiles"]
   IntelVTdDxeExtra.uni


### PR DESCRIPTION
## Description

Three related changes to how DXE-phase IOMMU producers dispatch and initialize:

1. **`Silicon/Intel/IntelSiliconPkg/Feature/VTd/{IntelVTdDxe,IntelVTdCoreDxe}`**
   Relax the DXE dispatch depex from `gEfiPciRootBridgeIoProtocolGuid` to `TRUE`
   so the `gEdkiiIoMmuProtocolGuid` producer can be installed as early as
   possible. This would cause a circular dependency with MdeModulePkg/IoMmuLib otherwise.
   Defer actual VTd hardware setup until both the DMAR ACPI table
   and PCI enumeration have been reported: gate `IoMmuMap`,
   `IoMmuAllocateBuffer`, and `IoMmuSetAttribute` with a new `mVtdInitialized`
   flag; convert `SetupVtd()` to `EFI_STATUS` and make it idempotent
   (`EFI_SUCCESS` on re-entry, `EFI_NOT_READY` before PCI enumeration
   completes); and register a protocol notify on
   `gEfiPciEnumerationCompleteProtocolGuid` in addition to the existing ACPI
   table notifies so `SetupVtd()` is retried once PCI enumeration finishes.

2. **`Platform/RaspberryPi/RPi4/RPi4.dsc`**
   Pin `IoMmuLib` to `MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf` in a
   module-scoped `<LibraryClasses>` block for
   `EmbeddedPkg/Drivers/NonCoherentIoMmuDxe`. This driver is the platform's
   IOMMU producer and links against `DmaLib` (`NonCoherentDmaLib`), which now
   consumes `IoMmuLib`; using the functional `IoMmuLib` here would create a
   circular dependency on the very protocol this driver installs. Other
   consumers on the platform continue to use whatever `IoMmuLib` mapping is
   set at the platform level. Depends on the new `IoMmuLib` class introduced
   by [tianocore/edk2#12676](https://github.com/tianocore/edk2/pull/12676).

3. Silicon/Broadcom/Bcm283x/InterruptDxe: Add UefiCpuPkg dependency because https://github.com/tianocore/edk2/pull/12697 moves the hardware interrupt protocols to UefiCpuPkg.

## Commits

* `IntelSiliconPkg/VTd: Load early and defer setup until DMAR + PCI ready`
* `Platform/RaspberryPi/RPi4: Use IoMmuLibNull for NonCoherentIoMmuDxe`
* `Silicon/Broadcom/Bcm283x/InterruptDxe: Add UefiCpuPkg dependency`

## Impacted packages / platforms

* `Silicon/Intel/IntelSiliconPkg`
* `Platform/RaspberryPi/RPi4`
* `Silicon/Broadcom/Bcm283x/InterruptDxe`