### PR TITLE
Silicon/Intel/Tools/FitGen: Set Rsvd Field to 0 For Optional Modules

### DIFF
--- a/Silicon/Intel/Tools/FitGen/FitGen.c
+++ b/Silicon/Intel/Tools/FitGen/FitGen.c
@@ -3257,6 +3257,8 @@ FillFitTable (
     FitEntry[FitIndex].Type     = (UINT8)gFitTableContext.OptionalModule[Index].Type;
     if (FitEntry[FitIndex].Type == FIT_TABLE_TYPE_CSE_SECURE_BOOT) {
       FitEntry[FitIndex].Rsvd   = (UINT8)gFitTableContext.OptionalModule[Index].SubType;
+    } else {
+      FitEntry[FitIndex].Rsvd   = 0;
     }
     FitEntry[FitIndex].C_V      = 0;
     FitEntry[FitIndex].Checksum = 0;


### PR DESCRIPTION
fixes #1035. Reserved field in FIT entry for optional modules should be set to 0, except for CSE Secure Boot module, which uses the reserved field to store the subtype.