### PR TITLE
AMD EDKII Platform Code v1.0.0.B for 5th Generation EPYC Processors

### DIFF
--- a/Platform/AMD/GenoaBoard/Universal/BoardAcpiDxe/Dsdt/Dsdt.asl
+++ b/Platform/AMD/GenoaBoard/Universal/BoardAcpiDxe/Dsdt/Dsdt.asl
@@ -103,7 +103,7 @@ DefinitionBlock (
           // Check bit 1
           // CXL VH Register Access Supported
           //
-          If (LNotEqual (And (SUPC, 0x02), 0x01))
+          If (LNotEqual (And (SUPC, 0x02), 0x02))
           {
             And (CTRC, 0xFE, CTRC)
           }

--- a/Platform/AMD/ServerBoard.md
+++ b/Platform/AMD/ServerBoard.md
@@ -26,6 +26,7 @@
 | 1.0.0.8          | Commit ID 17893ae84e968214ee6db15bf7502531d9034260 |                                    |
 | 1.0.0.9          | Commit ID 0991a0b643509d900e5d023a0116789827a696e5 |                                    |
 | 1.0.0.A          | Commit ID 0991a0b643509d900e5d023a0116789827a696e5 | No edk2-platforms changes required |
+| 1.0.0.B          | Commit ID 3c044a6c40478c11491242c87dc6409213cffd7e | CXL VH Register Access bitmask fix |
 
 #### Server boards edk2 build
 AMD server SoC platform firmware reference code can be built using edk2 native build system. As of now the AGESA source code is released to customer in a different way, the AGESA source files under edk2-platforms/Platform/AMD are published to make sure the platform firmware reference code can be built without errors. Those AGESA modules are considered as the NULL instance of AGESA. Customers can request the release version of

--- a/Platform/AMD/TurinBoard/Universal/BoardAcpiDxe/Dsdt/Dsdt.asl
+++ b/Platform/AMD/TurinBoard/Universal/BoardAcpiDxe/Dsdt/Dsdt.asl
@@ -145,7 +145,7 @@ DefinitionBlock (
           // Check bit 1
           // CXL VH Register Access Supported
           //
-          If (LNotEqual (And (SUPC, 0x02), 0x01))
+          If (LNotEqual (And (SUPC, 0x02), 0x02))
           {
             And (CTRC, 0xFE, CTRC)
           }


### PR DESCRIPTION
Update of AMD EDKII Platform Code for 5th Generation EPYC Processors (formerly Turin). This sample platform code was tested to work with the Turin 1.0.0.B AGESA PI package, which is available from AMD under license and NDA. Fix CXL VH Register Access bitmask check in DSDT (GenoaBoard and TurinBoard). Updated ServerBoard.md with AGESA PI version compatibility table.