### PR TITLE
Platform/RaspberryPi: Fix RPI_FW_MAC_ADDR_TAG value buffer size

### DIFF
--- a/Platform/RaspberryPi/Drivers/RpiFirmwareDxe/RpiFirmwareDxe.c
+++ b/Platform/RaspberryPi/Drivers/RpiFirmwareDxe/RpiFirmwareDxe.c
@@ -31,7 +31,6 @@
 //
 #define NUM_PAGES   1
 
-#pragma pack(1)
 typedef struct {
   UINT32    BufferSize;
   UINT32    Response;
@@ -69,7 +68,6 @@ typedef struct {
 
 typedef struct {
   UINT8                     MacAddress[6];
-  UINT32                    Padding;
 } RPI_FW_MAC_ADDR_TAG;
 
 typedef struct {
@@ -80,7 +78,7 @@ typedef struct {
 } RPI_FW_GET_MAC_ADDR_CMD;
 
 typedef struct {
-  UINT64                    Serial;
+  UINT32                    Serial[2];
 } RPI_FW_SERIAL_TAG;
 
 typedef struct {
@@ -254,7 +252,6 @@ typedef struct {
   RPI_FW_GPIO_SET_CFG_TAG      TagBody;
   UINT32                       EndTag;
 } RPI_FW_NOTIFY_GPIO_SET_CFG_CMD;
-#pragma pack()
 
 STATIC VOID  *mDmaBuffer;
 STATIC VOID  *mDmaBufferMapping;
@@ -549,7 +546,7 @@ RpiFirmwareGetSerial (
     return EFI_DEVICE_ERROR;
   }
 
-  *Serial = Cmd->TagBody.Serial;
+  CopyMem (Serial, Cmd->TagBody.Serial, sizeof (*Serial));
   ReleaseSpinLock (&mMailboxLock);
   // Some platforms return 0 or 0x0000000010000000 for serial.
   // For those, try to use the MAC address.


### PR DESCRIPTION
Fix reading mac address on RPi4.

### Background

2 years ago I submitted [a bugfix for populating serial number on RPi4](https://github.com/tianocore/edk2-platforms/pull/217). That fix turned into larger refactoring. That refactoring caused another bug: https://github.com/tianocore/edk2-platforms/issues/908.

I actually received an email from Oleg (sorry don't know his GH handle) reporting this same issue right after the changes were merged, but I didn't manage to look into it back then.

Interesting thing is that with older firmware (e.g. [`1.20241125`](https://github.com/raspberrypi/firmware/releases/tag/1.20241125)) there were no issues, so it seems that at some point the firmware started returning an error if you provide it with an unaligned block of memory (not 100% sure on this).